### PR TITLE
feat(security): implement SecretRef credential masking/redaction utility

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/zhang/Yiyi/ai/cmasterBot/node_modules

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,25 +15,33 @@ export async function loadConfig(configPath?: string): Promise<Config> {
     return resolveEnvVariables(rawConfig) as Config;
 }
 
+import { registerSecret } from './utils/secret-ref.js';
+
 /**
- * 递归解析环境变量
+ * 递归解析环境变量 (并对敏感字段进行 SecretRef 注册)
  */
-function resolveEnvVariables(obj: unknown): unknown {
+function resolveEnvVariables(obj: unknown, parentKey?: string): unknown {
     if (typeof obj === 'string') {
         // 匹配 ${VAR_NAME} 或 ${VAR_NAME:default}
-        return obj.replace(/\$\{(\w+)(?::([^}]*))?\}/g, (_, name, defaultValue) => {
+        const resolved = obj.replace(/\$\{(\w+)(?::([^}]*))?\}/g, (_, name, defaultValue) => {
             return process.env[name] ?? defaultValue ?? '';
         });
+
+        // 自动将名称中包含 key/token/password/secret 的字段注册为脱敏引用
+        if (parentKey && /key|token|password|secret/i.test(parentKey)) {
+            return registerSecret(resolved);
+        }
+        return resolved;
     }
 
     if (Array.isArray(obj)) {
-        return obj.map(resolveEnvVariables);
+        return obj.map(item => resolveEnvVariables(item));
     }
 
     if (obj && typeof obj === 'object') {
         const result: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(obj)) {
-            result[key] = resolveEnvVariables(value);
+            result[key] = resolveEnvVariables(value, key);
         }
         return result;
     }

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -4,6 +4,7 @@ import { join, dirname, basename } from 'path';
 import { glob } from 'glob';
 import matter from 'gray-matter';
 import type { Skill, SkillMetadata, SkillAction, SkillContext, SkillSource, ToolDefinition, Logger } from '../types.js';
+import { deepRedact } from '../utils/secret-ref.js';
 
 /**
  * SKILL.md 解析器
@@ -231,8 +232,9 @@ export class SkillRegistry {
 
             const found = tools.find(t => t.function.name === toolName);
             if (found) {
-                // 找到了就直接执行，执行错误自然传播（不 catch）
-                return await source.execute(toolName, params, context);
+                // 找到了就直接执行，对结果进行脱敏，执行错误自然传播（不 catch）
+                const rawResult = await source.execute(toolName, params, context);
+                return deepRedact(rawResult);
             }
         }
 

--- a/src/utils/secret-ref.ts
+++ b/src/utils/secret-ref.ts
@@ -1,0 +1,71 @@
+import { nanoid } from 'nanoid';
+
+const registry = new Map<string, string>(); // ref -> plaintext
+
+/**
+ * Registers a secret and returns a protected reference string.
+ * This reference can be passed around and later redacted from logs/outputs.
+ */
+export function registerSecret(plaintext: string): string {
+    if (!plaintext || typeof plaintext !== 'string') return plaintext;
+
+    // Attempt to find if we already registered this exact secret to avoid duplicates
+    for (const [existingRef, pt] of registry.entries()) {
+        if (pt === plaintext) return existingRef;
+    }
+
+    const ref = `[SECRET:${nanoid(8)}]`;
+    registry.set(ref, plaintext);
+    return ref;
+}
+
+/**
+ * Sweeps a given text string and replaces any known plaintexts with [REDACTED].
+ * Use this before sending text to LLMs, logs, or UI streams.
+ */
+export function redact(text: string): string {
+    if (!text || typeof text !== 'string') return text;
+    if (registry.size === 0) return text;
+
+    let scrubbed = text;
+    for (const plaintext of registry.values()) {
+        // Simple string replacement across the entire text
+        // Note: split/join is fast for sweeping all occurrences
+        scrubbed = scrubbed.split(plaintext).join('[REDACTED]');
+    }
+    return scrubbed;
+}
+
+/**
+ * Deep sweeps objects, arrays, and strings, replacing plaintexts with [REDACTED].
+ */
+export function deepRedact(obj: unknown): unknown {
+    if (!obj) return obj;
+    if (registry.size === 0) return obj;
+
+    if (typeof obj === 'string') {
+        return redact(obj);
+    }
+
+    if (Array.isArray(obj)) {
+        return obj.map(item => deepRedact(item));
+    }
+
+    // Check if it is a plain object
+    if (typeof obj === 'object') {
+        const redactedObj: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(obj)) {
+            redactedObj[key] = deepRedact(value);
+        }
+        return redactedObj;
+    }
+
+    return obj;
+}
+
+/**
+ * Clears the registry (useful for testing or reset)
+ */
+export function clearSecrets(): void {
+    registry.clear();
+}

--- a/tests/secret-ref.test.ts
+++ b/tests/secret-ref.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { registerSecret, redact, deepRedact, clearSecrets } from '../src/utils/secret-ref.js';
+
+describe('SecretRef Credential Masking', () => {
+    beforeEach(() => {
+        clearSecrets();
+    });
+
+    it('registers a secret and redacts it from string', () => {
+        const secret = 'sk-prod-1234567890abcdef';
+        const ref = registerSecret(secret);
+
+        expect(ref).toMatch(/^\[SECRET:[\w-]+\]$/);
+
+        const logMsg = `User called API with key ${secret} successfully.`;
+        const redactedMsg = redact(logMsg);
+
+        expect(redactedMsg).not.toContain(secret);
+        expect(redactedMsg).toContain('[REDACTED]');
+        expect(redactedMsg).toBe('User called API with key [REDACTED] successfully.');
+    });
+
+    it('handles multiple occurrences of the same secret', () => {
+        const secret = 'super-secret-password';
+        registerSecret(secret);
+
+        const logMsg = `Password: ${secret}. Yes, it is ${secret}!`;
+        const redactedMsg = redact(logMsg);
+
+        expect(redactedMsg).toBe('Password: [REDACTED]. Yes, it is [REDACTED]!');
+    });
+
+    it('handles multiple different secrets', () => {
+        registerSecret('key-A');
+        registerSecret('key-B');
+
+        const result = redact('Used key-A and key-B together');
+        expect(result).toBe('Used [REDACTED] and [REDACTED] together');
+    });
+
+    it('does not alter string if secret is not present', () => {
+        registerSecret('my-secret');
+        const normalString = 'Just a normal log message';
+        expect(redact(normalString)).toBe(normalString);
+    });
+
+    describe('deepRedact', () => {
+        it('deeply redacts objects and arrays', () => {
+            const apiToken = 'xoxb-123-token';
+            const dbPassword = 'db-pass-words';
+
+            registerSecret(apiToken);
+            registerSecret(dbPassword);
+
+            const rawResult = {
+                status: 'success',
+                message: `Connected using token ${apiToken}`,
+                credentials: {
+                    user: 'admin',
+                    password: dbPassword
+                },
+                history: [
+                    `Tried ${dbPassword} previously`,
+                    { fallback: apiToken }
+                ]
+            };
+
+            const redacted = deepRedact(rawResult) as any;
+
+            // Check top level string
+            expect(redacted.message).toBe('Connected using token [REDACTED]');
+            // Check nested object
+            expect(redacted.credentials.password).toBe('[REDACTED]');
+            // Check nested array of strings
+            expect(redacted.history[0]).toBe('Tried [REDACTED] previously');
+            // Check deep nested object in array
+            expect(redacted.history[1].fallback).toBe('[REDACTED]');
+
+            // Verify originals are not present
+            const jsonStr = JSON.stringify(redacted);
+            expect(jsonStr).not.toContain(apiToken);
+            expect(jsonStr).not.toContain(dbPassword);
+        });
+
+        it('handles null, undefined, and non-string primitives', () => {
+            expect(deepRedact(null)).toBe(null);
+            expect(deepRedact(undefined)).toBe(undefined);
+            expect(deepRedact(42)).toBe(42);
+            expect(deepRedact(true)).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
背景
API Key 和 Token 等机密信息可能通过 YAML/Env 加载后，明文出现在 LLM 思考过程或审核日志中。

改进方案
新增 src/utils/secret-ref.ts：提供密钥注册、引用映射及深度脱敏 (Redaction) 工具。
自动注册：修改 loadConfig，扫描所有含 key/token/secret 字样的字段并自动替换为引用。
执行拦截：在 SkillRegistry执行出口处强制调用 deepRedact，确保所有 Skill 返回内容均不含明文密钥。
验证
通过 tests/secret-ref.test.ts 验证了深度嵌套 JSON 对象中的密钥被成功替换为 [REDACTED]。
检查了审计日志，确认无 API Key 泄露。