### PR TITLE
feat(memory): implement pre-compaction flush for auto-saving context …

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/zhang/Yiyi/ai/cmasterBot/node_modules

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -364,11 +364,26 @@ export class Agent {
         );
         const messages = trimResult.messages;
 
-        // 如果发生压缩，通知前端
+        // 如果发生压缩，通知前端，并执行 Pre-Compaction Flush（持久化摘要）
         if (trimResult.droppedCount > 0) {
+            const summaryStr = trimResult.summaryText ?? `已压缩 ${trimResult.droppedCount} 条历史消息`;
+
+            if (this.longTermMemory && trimResult.summaryText) {
+                try {
+                    await this.longTermMemory.remember(
+                        `[AutoFlush] ${trimResult.summaryText}`,
+                        { tags: ['auto-flush', context.sessionId] },
+                        context.sessionId
+                    );
+                    this.logger.info(`[PreCompactionFlush] Saved summary to long-term memory for session ${context.sessionId}`);
+                } catch (err) {
+                    this.logger.warn(`[PreCompactionFlush] Failed to save summary: ${(err as Error).message}`);
+                }
+            }
+
             yield {
                 type: 'context_compressed',
-                content: trimResult.summaryText ?? `已压缩 ${trimResult.droppedCount} 条历史消息`,
+                content: summaryStr,
                 droppedCount: trimResult.droppedCount,
                 timestamp: new Date(),
             } satisfies ExecutionStep;


### PR DESCRIPTION
背景
当上下文窗口溢出触发压缩时，生成的摘要信息仅保留在内存中，跨 Session 或重启后会导致“失忆”。

改进方案
修改 Agent.run：在触发 context_compressed 事件时，同步将 summaryText 写入 LongTermMemory。
采用 [AutoFlush] 前缀标记，便于基于向量的语义检索找回历史决策。
增强了长流程任务的记忆连贯性。
验证
确认压缩触发后，长期记忆数据库中正确出现了自动生成的摘要条目。