### PR TITLE
Issue/conductor workflow

### DIFF
--- a/skills/built-in/conductor-workflow/SKILL.md
+++ b/skills/built-in/conductor-workflow/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: conductor-workflow
+version: 1.0.0
+description: 基于自然语言生成、分析和修改 Conductor OSS v3.21.20 标准工作流定义 JSON，用于企业编排引擎
+author: CMaster Bot
+---
+
+## Actions
+
+### generate_workflow
+根据自然语言描述的业务逻辑，生成符合 Conductor OSS v3.21.20 规范的 WorkflowDef JSON。支持所有标准任务类型（SIMPLE, HTTP, SWITCH, FORK_JOIN, DO_WHILE, SUB_WORKFLOW 等），复杂流程自动拆解为多个子工作流。
+
+- `description` (string, required) — 业务流程的自然语言描述
+- `name` (string, 可选) — 工作流名称，默认由 AI 根据描述自动生成
+
+### analyze_workflow
+分析已有的 Conductor 工作流 JSON 定义，输出结构解读、任务依赖关系、潜在问题和优化建议。
+
+- `workflow_json` (string, required) — 要分析的 WorkflowDef JSON 字符串
+
+### update_workflow
+根据自然语言指令修改已有的 Conductor 工作流定义，返回更新后的完整 WorkflowDef JSON。
+
+- `workflow_json` (string, required) — 现有的 WorkflowDef JSON 字符串
+- `instruction` (string, required) — 修改指令的自然语言描述

--- a/skills/built-in/conductor-workflow/conductor-schema.md
+++ b/skills/built-in/conductor-workflow/conductor-schema.md
@@ -1,0 +1,286 @@
+# Conductor OSS v3.21.20 — Workflow & Task Schema Reference
+
+## WorkflowDef (工作流定义)
+
+```json
+{
+  "name": "string (必填, snake_case)",
+  "description": "string",
+  "version": "number (默认 1)",
+  "tasks": "TaskDef[] (必填, 任务 DAG 定义)",
+  "inputParameters": ["string (输入参数名列表)"],
+  "outputParameters": { "key": "${task_ref.output.field}" },
+  "schemaVersion": 2,
+  "restartable": true,
+  "ownerEmail": "string",
+  "timeoutPolicy": "TIME_OUT_WF | ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "failureWorkflow": "string (失败补偿工作流名称)",
+  "variables": {},
+  "inputTemplate": {}
+}
+```
+
+## TaskDef (任务定义)
+
+通用字段（所有类型共有）:
+```json
+{
+  "name": "string (任务名称)",
+  "taskReferenceName": "string (必填, 工作流内唯一引用名)",
+  "type": "TaskType (必填)",
+  "description": "string",
+  "inputParameters": { "key": "value 或 ${jsonpath}" },
+  "optional": false,
+  "asyncComplete": false,
+  "startDelay": 0,
+  "retryCount": 0,
+  "timeoutSeconds": 0
+}
+```
+
+## TaskType 详细定义
+
+### SIMPLE (Worker 任务)
+外部 Worker 执行的自定义任务。
+```json
+{ "name": "task_name", "taskReferenceName": "ref", "type": "SIMPLE" }
+```
+
+### HTTP (HTTP 请求)
+```json
+{
+  "name": "http_call",
+  "taskReferenceName": "http_ref",
+  "type": "HTTP",
+  "inputParameters": {
+    "http_request": {
+      "uri": "https://api.example.com/resource",
+      "method": "GET|POST|PUT|DELETE",
+      "headers": { "Content-Type": "application/json" },
+      "body": {},
+      "connectionTimeOut": 3000,
+      "readTimeOut": 3000
+    }
+  }
+}
+```
+
+### SWITCH (条件分支)
+替代 DECISION（已废弃），基于表达式选择执行分支。
+```json
+{
+  "name": "switch_task",
+  "taskReferenceName": "switch_ref",
+  "type": "SWITCH",
+  "evaluatorType": "value-param | javascript",
+  "expression": "switchCaseValue 或 JS表达式",
+  "inputParameters": {
+    "switchCaseValue": "${workflow.input.status}"
+  },
+  "decisionCases": {
+    "approved": [{ "...TaskDef" }],
+    "rejected": [{ "...TaskDef" }]
+  },
+  "defaultCase": [{ "...TaskDef" }]
+}
+```
+
+### FORK_JOIN (并行分支)
+并行执行多个分支，必须紧跟 JOIN 任务。
+```json
+{
+  "name": "parallel",
+  "taskReferenceName": "fork_ref",
+  "type": "FORK_JOIN",
+  "forkTasks": [
+    [{ "...branch1_task1" }, { "...branch1_task2" }],
+    [{ "...branch2_task1" }]
+  ]
+}
+// 紧跟 JOIN:
+{
+  "name": "join",
+  "taskReferenceName": "join_ref",
+  "type": "JOIN",
+  "joinOn": ["branch1_task2_ref", "branch2_task1_ref"]
+}
+```
+
+### FORK_JOIN_DYNAMIC (动态并行)
+运行时决定并行分支数量。
+```json
+{
+  "name": "dynamic_fork",
+  "taskReferenceName": "dfork_ref",
+  "type": "FORK_JOIN_DYNAMIC",
+  "inputParameters": {
+    "dynamicTasks": "${prepare_ref.output.tasks}",
+    "dynamicTasksInput": "${prepare_ref.output.inputs}"
+  },
+  "dynamicForkTasksParam": "dynamicTasks",
+  "dynamicForkTasksInputParamName": "dynamicTasksInput"
+}
+```
+
+### DO_WHILE (循环)
+循环执行一组任务，直到条件为 false。
+```json
+{
+  "name": "loop",
+  "taskReferenceName": "loop_ref",
+  "type": "DO_WHILE",
+  "loopCondition": "if ($.loop_ref['iteration'] < $.loop_ref.output.maxRetries) { true; } else { false; }",
+  "loopOver": [{ "...循环体内的TaskDef" }]
+}
+```
+
+### SUB_WORKFLOW (子工作流)
+同步调用另一个工作流。
+```json
+{
+  "name": "sub_flow",
+  "taskReferenceName": "sub_ref",
+  "type": "SUB_WORKFLOW",
+  "subWorkflowParam": {
+    "name": "child_workflow_name",
+    "version": 1
+  },
+  "inputParameters": {
+    "param1": "${workflow.input.data}"
+  }
+}
+```
+
+### WAIT (等待)
+暂停执行，等待外部信号或超时。
+```json
+{
+  "name": "wait",
+  "taskReferenceName": "wait_ref",
+  "type": "WAIT",
+  "inputParameters": {
+    "duration": "1 hour"
+  }
+}
+```
+
+### HUMAN (人工审批)
+暂停等待人工介入。
+```json
+{
+  "name": "approval",
+  "taskReferenceName": "human_ref",
+  "type": "HUMAN"
+}
+```
+
+### EVENT (事件发布)
+发布事件到外部系统。
+```json
+{
+  "name": "event",
+  "taskReferenceName": "event_ref",
+  "type": "EVENT",
+  "sink": "conductor | sqs:queue_name | kafka:topic",
+  "inputParameters": {
+    "payload": "${workflow.input.data}"
+  }
+}
+```
+
+### TERMINATE (终止)
+立即终止工作流。
+```json
+{
+  "name": "terminate",
+  "taskReferenceName": "term_ref",
+  "type": "TERMINATE",
+  "inputParameters": {
+    "terminationStatus": "COMPLETED | FAILED",
+    "terminationReason": "说明",
+    "workflowOutput": {}
+  }
+}
+```
+
+### SET_VARIABLE (设置变量)
+设置工作流级别变量。
+```json
+{
+  "name": "set_var",
+  "taskReferenceName": "setvar_ref",
+  "type": "SET_VARIABLE",
+  "inputParameters": {
+    "myVar": "${some_task.output.value}"
+  }
+}
+```
+
+### JSON_JQ_TRANSFORM (JQ 转换)
+使用 JQ 语法转换 JSON。
+```json
+{
+  "name": "transform",
+  "taskReferenceName": "jq_ref",
+  "type": "JSON_JQ_TRANSFORM",
+  "inputParameters": {
+    "data": "${prev_task.output.result}",
+    "queryExpression": ".data | map(select(.active == true))"
+  }
+}
+```
+
+### INLINE (内联脚本)
+执行轻量级 JavaScript。
+```json
+{
+  "name": "inline_eval",
+  "taskReferenceName": "inline_ref",
+  "type": "INLINE",
+  "inputParameters": {
+    "value": "${workflow.input.amount}",
+    "evaluatorType": "graaljs",
+    "expression": "function e() { return $.value > 100 ? 'high' : 'low'; } e();"
+  }
+}
+```
+
+### KAFKA_PUBLISH (Kafka 发布)
+```json
+{
+  "name": "kafka_pub",
+  "taskReferenceName": "kafka_ref",
+  "type": "KAFKA_PUBLISH",
+  "inputParameters": {
+    "kafka_request": {
+      "topic": "my-topic",
+      "value": "${workflow.input.message}",
+      "bootStrapServers": "localhost:9092",
+      "headers": {},
+      "key": "msg-key",
+      "keySerializer": "org.apache.kafka.common.serialization.StringSerializer"
+    }
+  }
+}
+```
+
+## JSONPath 变量引用语法
+
+| 语法 | 说明 |
+|------|------|
+| `${workflow.input.fieldName}` | 工作流输入参数 |
+| `${taskRefName.output.fieldName}` | 引用指定任务的输出 |
+| `${taskRefName.input.fieldName}` | 引用指定任务的输入 |
+| `${workflow.variables.varName}` | 工作流变量 |
+
+## 最佳实践
+
+1. **命名规范**: 工作流名 snake_case，taskReferenceName 在工作流内必须唯一
+2. **错误处理**: 使用 `optional: true` 容忍非关键任务失败；设置 `failureWorkflow` 自动触发补偿
+3. **超时**: 为关键任务设置 `timeoutSeconds`；工作流级别设置 `timeoutPolicy`
+4. **重试**: 通过 `retryCount` 配置自动重试次数
+5. **复杂流程拆解**: 超过 15 个任务的流程应拆为多个 SUB_WORKFLOW
+6. **FORK_JOIN 规则**: 每个 FORK_JOIN 必须紧跟一个 JOIN，joinOn 列出每个分支的最后一个任务 ref
+7. **SWITCH vs DECISION**: 始终使用 SWITCH（DECISION 已废弃）
+8. **幂等性**: Worker 任务应设计为幂等，以支持安全重试

--- a/skills/built-in/conductor-workflow/index.ts
+++ b/skills/built-in/conductor-workflow/index.ts
@@ -1,0 +1,309 @@
+import type { SkillAction, SkillContext } from '../../../src/types.js';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+// Load schema reference for system prompt
+let schemaReference = '';
+try {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    schemaReference = readFileSync(join(__dirname, 'conductor-schema.md'), 'utf-8');
+} catch {
+    schemaReference = '(Schema reference file not found)';
+}
+
+const SYSTEM_PROMPT = `你是 Conductor OSS 工作流编排专家。你的职责是基于用户的自然语言描述，生成、分析或修改符合 Conductor OSS v3.21.20 标准的 WorkflowDef JSON。
+
+## 核心约束
+1. **严格遵守 Conductor OSS v3.21.20 Schema**，输出必须可被 Conductor 服务端直接导入
+2. 使用标准任务类型: SIMPLE, HTTP, SWITCH, FORK_JOIN, JOIN, DO_WHILE, SUB_WORKFLOW, EVENT, WAIT, HUMAN, TERMINATE, SET_VARIABLE, JSON_JQ_TRANSFORM, INLINE, KAFKA_PUBLISH
+3. 每个任务的 taskReferenceName 在工作流内必须唯一，使用 snake_case
+4. SWITCH 替代 DECISION（DECISION 已废弃），需包含 evaluatorType、expression、decisionCases、defaultCase
+5. FORK_JOIN 后必须紧跟 JOIN 任务，joinOn 列出每个分支最后一个任务的 taskReferenceName
+6. 使用 JSONPath 引用变量: \${workflow.input.xxx}, \${taskRef.output.xxx}
+7. 复杂业务（超过 15 个任务）应拆解为多个 SUB_WORKFLOW 组合编排
+8. 生成的 JSON 用 \`\`\`json 代码块包裹
+
+## 输出格式
+- 先给出简要的流程说明
+- 然后输出完整的 WorkflowDef JSON（用 \`\`\`json 代码块包裹）
+- 如果拆解为多个子工作流，每个子工作流单独一个 JSON 代码块，主工作流放在最后
+
+## Conductor Schema 参考
+${schemaReference}`;
+
+/**
+ * 从 LLM 响应中提取 JSON 代码块
+ */
+function extractJsonBlocks(text: string): string[] {
+    const blocks: string[] = [];
+    const regex = /```json\s*\n([\s\S]*?)```/g;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+        blocks.push(match[1].trim());
+    }
+    // Fallback: try to find raw JSON object
+    if (blocks.length === 0) {
+        const rawMatch = text.match(/\{[\s\S]*"tasks"\s*:\s*\[[\s\S]*\][\s\S]*\}/);
+        if (rawMatch) {
+            blocks.push(rawMatch[0]);
+        }
+    }
+    return blocks;
+}
+
+/**
+ * 校验 WorkflowDef 必要字段
+ */
+function validateWorkflowDef(obj: any): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+
+    if (!obj || typeof obj !== 'object') {
+        return { valid: false, errors: ['Response is not a valid JSON object'] };
+    }
+    if (!obj.name || typeof obj.name !== 'string') {
+        errors.push('Missing or invalid "name" field');
+    }
+    if (!Array.isArray(obj.tasks)) {
+        errors.push('Missing or invalid "tasks" array');
+    } else {
+        const refNames = new Set<string>();
+        const validateTasks = (tasks: any[], path: string) => {
+            for (let i = 0; i < tasks.length; i++) {
+                const task = tasks[i];
+                const taskPath = `${path}[${i}]`;
+                if (!task.taskReferenceName) {
+                    errors.push(`${taskPath}: missing taskReferenceName`);
+                } else {
+                    if (refNames.has(task.taskReferenceName)) {
+                        errors.push(`${taskPath}: duplicate taskReferenceName "${task.taskReferenceName}"`);
+                    }
+                    refNames.add(task.taskReferenceName);
+                }
+                if (!task.type) {
+                    errors.push(`${taskPath}: missing type`);
+                }
+                // Validate FORK_JOIN has subsequent JOIN
+                if (task.type === 'FORK_JOIN') {
+                    if (task.forkTasks && Array.isArray(task.forkTasks)) {
+                        for (let b = 0; b < task.forkTasks.length; b++) {
+                            validateTasks(task.forkTasks[b], `${taskPath}.forkTasks[${b}]`);
+                        }
+                    }
+                    const nextTask = tasks[i + 1];
+                    if (!nextTask || nextTask.type !== 'JOIN') {
+                        errors.push(`${taskPath}: FORK_JOIN must be followed by a JOIN task`);
+                    }
+                }
+                // Validate SWITCH/DECISION cases
+                if (task.type === 'SWITCH' || task.type === 'DECISION') {
+                    if (task.decisionCases) {
+                        for (const [caseName, caseTasks] of Object.entries(task.decisionCases)) {
+                            if (Array.isArray(caseTasks)) {
+                                validateTasks(caseTasks as any[], `${taskPath}.decisionCases.${caseName}`);
+                            }
+                        }
+                    }
+                    if (task.defaultCase && Array.isArray(task.defaultCase)) {
+                        validateTasks(task.defaultCase, `${taskPath}.defaultCase`);
+                    }
+                }
+                // Validate DO_WHILE loop body
+                if (task.type === 'DO_WHILE' && task.loopOver && Array.isArray(task.loopOver)) {
+                    validateTasks(task.loopOver, `${taskPath}.loopOver`);
+                }
+            }
+        };
+        validateTasks(obj.tasks, 'tasks');
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+/**
+ * 调用 LLM 生成响应
+ */
+async function callLLM(ctx: SkillContext, userPrompt: string): Promise<string> {
+    const llm = ctx.llm as any;
+    if (!llm) {
+        throw new Error('LLM adapter not available in skill context');
+    }
+
+    const messages = [
+        { role: 'system' as const, content: SYSTEM_PROMPT },
+        { role: 'user' as const, content: userPrompt },
+    ];
+
+    const response = await llm.chat(messages, { temperature: 0.3, maxTokens: 8000 });
+    return typeof response.content === 'string'
+        ? response.content
+        : (response.content as any[]).map((p: any) => p.text || '').join('');
+}
+
+export const actions: Record<string, SkillAction> = {
+
+    generate_workflow: {
+        name: 'generate_workflow',
+        description: '根据自然语言描述生成 Conductor OSS v3.21.20 标准的 WorkflowDef JSON',
+        parameters: {
+            description: { type: 'string', description: '业务流程的自然语言描述', required: true },
+            name: { type: 'string', description: '工作流名称（可选，默认自动生成）' },
+        },
+        handler: async (ctx: SkillContext, params: Record<string, unknown>) => {
+            const { description, name } = params as { description: string; name?: string };
+            ctx.logger.info(`[conductor-workflow] Generating workflow from description: ${description.slice(0, 100)}...`);
+
+            const nameHint = name ? `\n工作流名称要求: "${name}"` : '';
+            const userPrompt = `请根据以下业务逻辑描述生成 Conductor 工作流定义 JSON：\n\n${description}${nameHint}\n\n要求:\n1. 输出完整可运行的 WorkflowDef JSON\n2. 合理使用任务类型和参数配置\n3. 如果流程复杂（超过15个任务），请拆解为多个子工作流并通过 SUB_WORKFLOW 编排\n4. 配置合理的错误处理和超时策略`;
+
+            const llmResponse = await callLLM(ctx, userPrompt);
+            const jsonBlocks = extractJsonBlocks(llmResponse);
+
+            if (jsonBlocks.length === 0) {
+                return {
+                    success: false,
+                    error: '未能从生成结果中提取到有效的 JSON',
+                    rawResponse: llmResponse,
+                };
+            }
+
+            const workflows: any[] = [];
+            const validationResults: any[] = [];
+
+            for (const block of jsonBlocks) {
+                try {
+                    const parsed = JSON.parse(block);
+                    const validation = validateWorkflowDef(parsed);
+                    workflows.push(parsed);
+                    validationResults.push(validation);
+                } catch (e: any) {
+                    validationResults.push({ valid: false, errors: [`JSON parse error: ${e.message}`] });
+                }
+            }
+
+            const mainWorkflow = workflows.length > 0 ? workflows[workflows.length - 1] : null;
+            const subWorkflows = workflows.length > 1 ? workflows.slice(0, -1) : [];
+            const allValid = validationResults.every((v: any) => v.valid);
+
+            ctx.logger.info(`[conductor-workflow] Generated ${workflows.length} workflow(s), all valid: ${allValid}`);
+
+            return {
+                success: true,
+                workflow: mainWorkflow,
+                subWorkflows: subWorkflows.length > 0 ? subWorkflows : undefined,
+                validation: validationResults,
+                allValid,
+                explanation: llmResponse.split('```')[0].trim(),
+                type: 'workflow_generated',
+            };
+        },
+    },
+
+    analyze_workflow: {
+        name: 'analyze_workflow',
+        description: '分析已有的 Conductor 工作流 JSON，输出结构解读和优化建议',
+        parameters: {
+            workflow_json: { type: 'string', description: '要分析的 WorkflowDef JSON 字符串', required: true },
+        },
+        handler: async (ctx: SkillContext, params: Record<string, unknown>) => {
+            const { workflow_json } = params as { workflow_json: string };
+            ctx.logger.info(`[conductor-workflow] Analyzing workflow...`);
+
+            let parsed: any;
+            try {
+                parsed = JSON.parse(workflow_json);
+            } catch (e: any) {
+                return { success: false, error: `Invalid JSON: ${e.message}` };
+            }
+
+            const validation = validateWorkflowDef(parsed);
+
+            const userPrompt = `请分析以下 Conductor 工作流定义，输出：
+1. **流程概述**: 用自然语言描述这个工作流的业务逻辑
+2. **结构分析**: 任务类型分布、执行路径、并行/分支结构
+3. **潜在问题**: 缺少错误处理、缺少超时配置、命名不规范等
+4. **优化建议**: 提升可靠性和性能的具体建议
+
+工作流 JSON：
+\`\`\`json
+${workflow_json}
+\`\`\``;
+
+            const analysis = await callLLM(ctx, userPrompt);
+
+            return {
+                success: true,
+                analysis,
+                validation,
+                workflowName: parsed.name,
+                taskCount: parsed.tasks?.length ?? 0,
+            };
+        },
+    },
+
+    update_workflow: {
+        name: 'update_workflow',
+        description: '根据自然语言指令修改已有的 Conductor 工作流定义',
+        parameters: {
+            workflow_json: { type: 'string', description: '现有的 WorkflowDef JSON 字符串', required: true },
+            instruction: { type: 'string', description: '修改指令的自然语言描述', required: true },
+        },
+        handler: async (ctx: SkillContext, params: Record<string, unknown>) => {
+            const { workflow_json, instruction } = params as { workflow_json: string; instruction: string };
+            ctx.logger.info(`[conductor-workflow] Updating workflow: ${instruction.slice(0, 100)}...`);
+
+            let parsed: any;
+            try {
+                parsed = JSON.parse(workflow_json);
+            } catch (e: any) {
+                return { success: false, error: `Invalid JSON: ${e.message}` };
+            }
+
+            const userPrompt = `以下是一个已有的 Conductor 工作流定义：
+
+\`\`\`json
+${workflow_json}
+\`\`\`
+
+请根据以下要求修改此工作流，并输出完整的更新后 WorkflowDef JSON：
+
+修改要求: ${instruction}
+
+注意:
+1. 返回完整的修改后 JSON（不是增量 patch）
+2. 保持原有合理的配置不变
+3. 确保修改后的 taskReferenceName 唯一性
+4. 如果修改涉及 FORK_JOIN，确保 JOIN 的 joinOn 正确更新`;
+
+            const llmResponse = await callLLM(ctx, userPrompt);
+            const jsonBlocks = extractJsonBlocks(llmResponse);
+
+            if (jsonBlocks.length === 0) {
+                return {
+                    success: false,
+                    error: '未能从更新结果中提取到有效的 JSON',
+                    rawResponse: llmResponse,
+                };
+            }
+
+            try {
+                const updated = JSON.parse(jsonBlocks[jsonBlocks.length - 1]);
+                const validation = validateWorkflowDef(updated);
+
+                return {
+                    success: true,
+                    workflow: updated,
+                    validation,
+                    explanation: llmResponse.split('```')[0].trim(),
+                    type: 'workflow_generated',
+                };
+            } catch (e: any) {
+                return {
+                    success: false,
+                    error: `JSON parse error: ${e.message}`,
+                    rawResponse: llmResponse,
+                };
+            }
+        },
+    },
+};

--- a/skills/built-in/conductor-workflow/index.ts
+++ b/skills/built-in/conductor-workflow/index.ts
@@ -1,4 +1,4 @@
-import type { SkillAction, SkillContext } from '../../../src/types.js';
+import type { SkillContext } from '../../../src/types.js';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -140,16 +140,7 @@ async function callLLM(ctx: SkillContext, userPrompt: string): Promise<string> {
         : (response.content as any[]).map((p: any) => p.text || '').join('');
 }
 
-export const actions: Record<string, SkillAction> = {
-
-    generate_workflow: {
-        name: 'generate_workflow',
-        description: '根据自然语言描述生成 Conductor OSS v3.21.20 标准的 WorkflowDef JSON',
-        parameters: {
-            description: { type: 'string', description: '业务流程的自然语言描述', required: true },
-            name: { type: 'string', description: '工作流名称（可选，默认自动生成）' },
-        },
-        handler: async (ctx: SkillContext, params: Record<string, unknown>) => {
+export async function generate_workflow(ctx: SkillContext, params: Record<string, unknown>) {
             const { description, name } = params as { description: string; name?: string };
             ctx.logger.info(`[conductor-workflow] Generating workflow from description: ${description.slice(0, 100)}...`);
 
@@ -196,16 +187,9 @@ export const actions: Record<string, SkillAction> = {
                 explanation: llmResponse.split('```')[0].trim(),
                 type: 'workflow_generated',
             };
-        },
-    },
+}
 
-    analyze_workflow: {
-        name: 'analyze_workflow',
-        description: '分析已有的 Conductor 工作流 JSON，输出结构解读和优化建议',
-        parameters: {
-            workflow_json: { type: 'string', description: '要分析的 WorkflowDef JSON 字符串', required: true },
-        },
-        handler: async (ctx: SkillContext, params: Record<string, unknown>) => {
+export async function analyze_workflow(ctx: SkillContext, params: Record<string, unknown>) {
             const { workflow_json } = params as { workflow_json: string };
             ctx.logger.info(`[conductor-workflow] Analyzing workflow...`);
 
@@ -238,17 +222,9 @@ ${workflow_json}
                 workflowName: parsed.name,
                 taskCount: parsed.tasks?.length ?? 0,
             };
-        },
-    },
+}
 
-    update_workflow: {
-        name: 'update_workflow',
-        description: '根据自然语言指令修改已有的 Conductor 工作流定义',
-        parameters: {
-            workflow_json: { type: 'string', description: '现有的 WorkflowDef JSON 字符串', required: true },
-            instruction: { type: 'string', description: '修改指令的自然语言描述', required: true },
-        },
-        handler: async (ctx: SkillContext, params: Record<string, unknown>) => {
+export async function update_workflow(ctx: SkillContext, params: Record<string, unknown>) {
             const { workflow_json, instruction } = params as { workflow_json: string; instruction: string };
             ctx.logger.info(`[conductor-workflow] Updating workflow: ${instruction.slice(0, 100)}...`);
 
@@ -304,6 +280,6 @@ ${workflow_json}
                     rawResponse: llmResponse,
                 };
             }
-        },
-    },
-};
+}
+
+export default { generate_workflow, analyze_workflow, update_workflow };

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -736,6 +736,7 @@ export class Agent {
                     memory: context.memory,
                     logger: this.logger,
                     config: this.skillConfig,
+                    llm: this.llm,
                 };
 
                 // Phase 21: 为每个外部工具调用开 span
@@ -780,6 +781,21 @@ export class Agent {
                             duration,
                             timestamp: new Date(),
                         };
+                        // Emit dedicated workflow_generated step so frontend can render the workflow card
+                        if (result.value && typeof result.value === 'object' && (result.value as any).type === 'workflow_generated') {
+                            const wf = result.value as any;
+                            yield {
+                                type: 'workflow_generated',
+                                content: resultStr,
+                                toolName,
+                                workflow: wf.workflow,
+                                subWorkflows: wf.subWorkflows,
+                                validation: wf.validation,
+                                allValid: wf.allValid,
+                                explanation: wf.explanation,
+                                timestamp: new Date(),
+                            } as any;
+                        }
                         messages.push({ role: 'tool', content: resultStr, toolCallId: toolCall.id });
                     } else {
                         const errorMsg = `Error: ${result.reason?.message || 'Unknown error'}`;

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -123,6 +123,16 @@ export function initDatabase(): DatabaseSync {
             updated_at TEXT NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS conductor_workflows (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            version INTEGER DEFAULT 1,
+            definition TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS webhooks (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -301,6 +301,14 @@ export function initDatabase(): DatabaseSync {
         }
     }
 
+    // Auto-migration: messages 表新增 metadata 列（存储 workflow_generated 等步骤数据）
+    {
+        const msgColumns = db.prepare('PRAGMA table_info(messages)').all() as Array<{ name: string }>;
+        if (!msgColumns.some(c => c.name === 'metadata')) {
+            db.prepare("ALTER TABLE messages ADD COLUMN metadata TEXT DEFAULT '{}'").run();
+        }
+    }
+
     // Auto-migration: Phase 21 — tasks 表新增 5 列
     {
         const taskColumns = db.prepare('PRAGMA table_info(tasks)').all() as Array<{ name: string }>;

--- a/src/core/repository.ts
+++ b/src/core/repository.ts
@@ -76,6 +76,15 @@ export class HistoryRepository {
             msg.attachments = attachments;
         }
 
+        // 解析 metadata（含 workflow_generated 等 steps 数据）
+        if (row.metadata && row.metadata !== '{}') {
+            try {
+                (msg as any).metadata = JSON.parse(row.metadata);
+            } catch {
+                // ignore
+            }
+        }
+
         return msg;
     }
 
@@ -88,17 +97,21 @@ export class HistoryRepository {
         const content = typeof message.content === 'string'
             ? message.content
             : JSON.stringify(message.content);
+        const metadata = (message as any).metadata
+            ? JSON.stringify((message as any).metadata)
+            : '{}';
 
         db.prepare(`
-            INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls, metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
         `).run(
             id,
             sessionId,
             message.role,
             content,
             message.toolCallId || null,
-            message.toolCalls ? JSON.stringify(message.toolCalls) : null
+            message.toolCalls ? JSON.stringify(message.toolCalls) : null,
+            metadata
         );
 
         if (message.attachments) {

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1050,6 +1050,92 @@ export class GatewayServer {
             }
         });
 
+        // ===== CONDUCTOR WORKFLOWS =====
+        this.app.get('/api/conductor-workflows', async () => {
+            const rows = (db as any).prepare('SELECT id, name, description, version, definition, created_at, updated_at FROM conductor_workflows ORDER BY updated_at DESC').all() as any[];
+            return rows.map((r: any) => {
+                const def = (() => { try { return JSON.parse(r.definition); } catch { return {}; } })();
+                return {
+                    id: r.id,
+                    name: r.name,
+                    description: r.description,
+                    version: r.version,
+                    definition: def,
+                    createdAt: r.created_at,
+                    updatedAt: r.updated_at,
+                };
+            });
+        });
+
+        this.app.get<{ Params: { id: string } }>('/api/conductor-workflows/:id', async (request, reply) => {
+            try {
+                const row = (db as any).prepare('SELECT id, name, description, version, definition, created_at, updated_at FROM conductor_workflows WHERE id = ?').get(request.params.id) as any;
+                if (!row) { reply.status(404); return { error: 'Conductor workflow not found' }; }
+                const def = (() => { try { return JSON.parse(row.definition); } catch { return {}; } })();
+                return {
+                    id: row.id,
+                    name: row.name,
+                    description: row.description,
+                    version: row.version,
+                    definition: def,
+                    createdAt: row.created_at,
+                    updatedAt: row.updated_at,
+                };
+            } catch (err: any) {
+                reply.status(500); return { error: err.message };
+            }
+        });
+
+        this.app.post<{ Body: { name: string; description?: string; version?: number; definition: any } }>('/api/conductor-workflows', async (request, reply) => {
+            try {
+                const { nanoid } = await import('nanoid');
+                const id = nanoid();
+                const now = new Date().toISOString();
+                const { name, description, version, definition } = request.body;
+
+                if (!definition) {
+                    reply.status(400); return { error: 'Missing definition' };
+                }
+
+                (db as any).prepare(`INSERT INTO conductor_workflows (id, name, description, version, definition, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`)
+                    .run(id, name, description || null, version || 1, typeof definition === 'string' ? definition : JSON.stringify(definition), now, now);
+                return { success: true, id };
+            } catch (err: any) {
+                reply.status(500); return { error: err.message };
+            }
+        });
+
+        this.app.put<{ Params: { id: string }; Body: { name: string; description?: string; version?: number; definition: any } }>('/api/conductor-workflows/:id', async (request, reply) => {
+            try {
+                const { id } = request.params;
+                const existing = (db as any).prepare('SELECT id FROM conductor_workflows WHERE id = ?').get(id);
+                if (!existing) { reply.status(404); return { error: 'Conductor workflow not found' }; }
+
+                const now = new Date().toISOString();
+                const { name, description, version, definition } = request.body;
+
+                if (!definition) {
+                    reply.status(400); return { error: 'Missing definition' };
+                }
+
+                (db as any).prepare(
+                    'UPDATE conductor_workflows SET name = ?, description = ?, version = ?, definition = ?, updated_at = ? WHERE id = ?'
+                ).run(name, description || null, version || 1, typeof definition === 'string' ? definition : JSON.stringify(definition), now, id);
+                return { success: true };
+            } catch (err: any) {
+                reply.status(500); return { error: err.message };
+            }
+        });
+
+        this.app.delete<{ Params: { id: string } }>('/api/conductor-workflows/:id', async (request, reply) => {
+            try {
+                (db as any).prepare('DELETE FROM conductor_workflows WHERE id = ?').run(request.params.id);
+                return { success: true };
+            } catch (err: any) {
+                reply.status(500); return { error: err.message };
+            }
+        });
+
         // ===== WEBHOOKS =====
         this.app.get('/api/webhooks', async () => {
             return webhookRepository.list();

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -226,6 +226,7 @@ export class GatewayServer {
             });
 
             let assistantAnswer = '';
+            const workflowSteps: any[] = [];
 
             // Use multimodal content if provided, otherwise fall back to plain string
             const userInput = (messageContent && messageContent.length > 0 ? messageContent : message) as string;
@@ -242,6 +243,19 @@ export class GatewayServer {
                     if (step.type === 'answer') {
                         assistantAnswer = step.content;
                     }
+                    // Collect workflow_generated steps for persistence
+                    if ((step as any).type === 'workflow_generated') {
+                        const wf = step as any;
+                        workflowSteps.push({
+                            workflow_generated: {
+                                workflow: wf.workflow,
+                                subWorkflows: wf.subWorkflows,
+                                validation: wf.validation,
+                                allValid: wf.allValid,
+                                explanation: wf.explanation,
+                            },
+                        });
+                    }
                     if (reply.raw.writable) {
                         reply.raw.write(`data: ${JSON.stringify(step)}\n\n`);
                     } else {
@@ -252,10 +266,13 @@ export class GatewayServer {
 
                 // Persist history after success — 用事务原子保存，并跳过空答案（客户端中途断连场景）
                 if (!abortController.signal.aborted && assistantAnswer) {
+                    const assistantMsgMetadata = workflowSteps.length > 0
+                        ? { custom: { steps: workflowSteps } }
+                        : undefined;
                     const { assistantMsgId } = historyRepository.saveConversationTurn(
                         sessionId,
                         { role: 'user', content: messageContent && messageContent.length > 0 ? messageContent : message, attachments },
-                        { role: 'assistant', content: assistantAnswer }
+                        { role: 'assistant', content: assistantAnswer, metadata: assistantMsgMetadata } as any
                     );
 
                     // Send meta chunk with assistant message ID for feedback correlation
@@ -1135,6 +1152,39 @@ export class GatewayServer {
                 reply.status(500); return { error: err.message };
             }
         });
+
+        // ===== CONDUCTOR AI COPILOT PROXY =====
+        // OpenAI-compatible streaming endpoint for WorkflowIDE AI Copilot
+        this.app.post<{ Body: { messages: Array<{ role: string; content: string }> } }>(
+            '/api/conductor/chat/completions',
+            async (request, reply) => {
+                const { messages } = request.body;
+                reply.raw.writeHead(200, {
+                    'Content-Type': 'text/event-stream',
+                    'Cache-Control': 'no-cache',
+                    'Connection': 'keep-alive',
+                });
+                const llmAdapter = this.agent.getLLMAdapter();
+                const llmMessages = messages.map((m) => ({
+                    role: m.role as 'system' | 'user' | 'assistant',
+                    content: m.content,
+                }));
+                try {
+                    for await (const chunk of llmAdapter.chatStream(llmMessages, {})) {
+                        if (chunk.type === 'content' && chunk.content) {
+                            const payload = {
+                                choices: [{ delta: { content: chunk.content }, finish_reason: null }],
+                            };
+                            reply.raw.write(`data: ${JSON.stringify(payload)}\n\n`);
+                        }
+                    }
+                } catch (err: any) {
+                    this.logger.error(`[conductor/copilot] Stream error: ${err.message}`);
+                }
+                reply.raw.write('data: [DONE]\n\n');
+                reply.raw.end();
+            }
+        );
 
         // ===== WEBHOOKS =====
         this.app.get('/api/webhooks', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,7 +173,7 @@ export interface AgentTask {
 }
 
 export interface ExecutionStep {
-    type: 'thought' | 'plan' | 'action' | 'observation' | 'answer' | 'content' | 'task_created' | 'task_completed' | 'task_failed' | 'meta' | 'suggestions' | 'interrupt' | 'context_compressed';
+    type: 'thought' | 'plan' | 'action' | 'observation' | 'answer' | 'content' | 'task_created' | 'task_completed' | 'task_failed' | 'meta' | 'suggestions' | 'interrupt' | 'context_compressed' | 'workflow_generated';
     content: string;
     toolName?: string;
     toolInput?: Record<string, unknown>;

--- a/tests/conductor-api.test.ts
+++ b/tests/conductor-api.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import Fastify from 'fastify';
+import { GatewayServer } from '../src/gateway/server.js';
+
+vi.mock('../src/core/database.js', () => {
+    return {
+        db: {
+            prepare: (sql: string) => {
+                return {
+                    all: () => {
+                        if (sql.includes('FROM conductor_workflows ORDER BY updated_at DESC')) {
+                            return [{ id: 'w1', name: 'Test', description: null, version: 1, definition: '{"name":"Test"}', created_at: '2023-01-01', updated_at: '2023-01-01' }];
+                        }
+                        return [];
+                    },
+                    get: (param?: any) => {
+                        if (sql.includes('FROM conductor_workflows WHERE id = ?')) {
+                            if (param === 'w1') return { id: 'w1', name: 'Test', description: null, version: 1, definition: '{"name":"Test"}', created_at: '2023-01-01', updated_at: '2023-01-01' };
+                        }
+                        if (sql.includes('SELECT id FROM conductor_workflows WHERE id = ?')) {
+                            if (param === 'w1') return { id: 'w1' };
+                        }
+                        return null;
+                    },
+                    run: (...params: any[]) => {
+                        return { changes: 1 };
+                    }
+                };
+            }
+        }
+    };
+});
+
+describe('Conductor Workflows API', () => {
+    let server: GatewayServer;
+
+    beforeAll(async () => {
+        server = new GatewayServer({
+            config: { logging: { prettyPrint: false, level: 'silent' }, server: { host: 'localhost', port: 0 } },
+            db: {} as any,
+            logger: { info: () => { }, error: () => { }, debug: () => { }, warn: () => { } } as any,
+            agent: { getSkillRegistry: () => ({ searchTools: () => [], getToolDefinitions: () => [] }) } as any,
+            sessionManager: {} as any
+        } as any);
+        await server.start(0, '127.0.0.1');
+    });
+
+    afterAll(async () => {
+        if (server) await server.stop();
+    });
+
+    it('should list conductor workflows', async () => {
+        const response = await server['app'].inject({
+            method: 'GET',
+            url: '/api/conductor-workflows',
+        });
+        expect(response.statusCode).toBe(200);
+        const data = JSON.parse(response.payload);
+        expect(Array.isArray(data)).toBe(true);
+        expect(data[0].id).toBe('w1');
+    });
+
+    it('should get a specific conductor workflow', async () => {
+        const response = await server['app'].inject({
+            method: 'GET',
+            url: '/api/conductor-workflows/w1',
+        });
+        expect(response.statusCode).toBe(200);
+        const data = JSON.parse(response.payload);
+        expect(data.id).toBe('w1');
+    });
+
+    it('should create a new conductor workflow', async () => {
+        const response = await server['app'].inject({
+            method: 'POST',
+            url: '/api/conductor-workflows',
+            payload: {
+                name: 'New Workflow',
+                version: 1,
+                definition: { name: 'New Workflow', tasks: [] }
+            }
+        });
+        expect(response.statusCode).toBe(200);
+        const data = JSON.parse(response.payload);
+        expect(data.id).toBeDefined();
+    });
+
+    it('should update an existing conductor workflow', async () => {
+        const response = await server['app'].inject({
+            method: 'PUT',
+            url: '/api/conductor-workflows/w1',
+            payload: {
+                name: 'Updated',
+                version: 2,
+                definition: { name: 'Updated' }
+            }
+        });
+        expect(response.statusCode).toBe(200);
+    });
+
+    it('should delete a conductor workflow', async () => {
+        const response = await server['app'].inject({
+            method: 'DELETE',
+            url: '/api/conductor-workflows/w1',
+        });
+        expect(response.statusCode).toBe(200);
+    });
+});

--- a/tests/conductor-workflow.test.ts
+++ b/tests/conductor-workflow.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { actions } from '../skills/built-in/conductor-workflow/index.js';
+import { generate_workflow, analyze_workflow, update_workflow } from '../skills/built-in/conductor-workflow/index.js';
+const actions = { generate_workflow: { handler: generate_workflow }, analyze_workflow: { handler: analyze_workflow }, update_workflow: { handler: update_workflow } };
 import type { SkillContext } from '../src/types.js';
 
 const mockLogger = {

--- a/tests/conductor-workflow.test.ts
+++ b/tests/conductor-workflow.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { actions } from '../skills/built-in/conductor-workflow/index.js';
+import type { SkillContext } from '../src/types.js';
+
+const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+};
+
+describe('Conductor Workflow Skill', () => {
+    let mockContext: SkillContext;
+    let mockLlmChat: any;
+
+    beforeEach(() => {
+        mockLlmChat = vi.fn();
+        mockContext = {
+            sessionId: 'test-session',
+            memory: { get: vi.fn(), set: vi.fn(), search: vi.fn() },
+            logger: mockLogger,
+            config: {},
+            llm: {
+                chat: mockLlmChat
+            } as any
+        };
+        vi.clearAllMocks();
+    });
+
+    describe('generate_workflow', () => {
+        it('should successfully extract and return valid WorkflowDef JSON', async () => {
+            const validWorkflowResp = {
+                name: 'Test_Workflow',
+                description: 'Test',
+                version: 1,
+                tasks: [
+                    {
+                        name: 'task_1',
+                        taskReferenceName: 't1',
+                        type: 'SIMPLE'
+                    }
+                ]
+            };
+
+            mockLlmChat.mockResolvedValueOnce({
+                content: `Here is the JSON:
+\`\`\`json
+${JSON.stringify(validWorkflowResp)}
+\`\`\`
+`
+            });
+
+            const result = await actions['generate_workflow'].handler(mockContext, { description: 'Test' }) as any;
+            expect(result).toBeDefined();
+            expect(result.workflow).toBeDefined();
+            expect(result.workflow.name).toBe('Test_Workflow');
+            expect(mockLlmChat).toHaveBeenCalledTimes(1);
+        });
+
+        it('should throw an error if LLM returns invalid JSON structure', async () => {
+            mockLlmChat.mockResolvedValueOnce({
+                content: `\`\`\`json
+{ "invalid": "data" }
+\`\`\``
+            });
+
+            const result = await actions['generate_workflow'].handler(mockContext, { description: 'x' }) as any;
+            expect(result.allValid).toBe(false);
+            expect(result.validation[0].errors).toContain('Missing or invalid "name" field');
+        });
+
+        it('should throw an error if JSON block is missing', async () => {
+            mockLlmChat.mockResolvedValueOnce({
+                content: `Sorry, I cannot do that.`
+            });
+
+            const result = await actions['generate_workflow'].handler(mockContext, { description: 'x' }) as any;
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('未能从生成结果中提取到有效的 JSON');
+        });
+    });
+
+    describe('analyze_workflow', () => {
+        it('should request analysis and return LLM string', async () => {
+            mockLlmChat.mockResolvedValueOnce({
+                content: `Analysis passed.`
+            });
+
+            const result = await actions['analyze_workflow'].handler(mockContext, {
+                workflow_json: '{"name": "w"}'
+            }) as any;
+
+            expect(result.analysis).toBe('Analysis passed.');
+            expect(mockLlmChat).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('update_workflow', () => {
+        it('should successfully extract and return valid updated WorkflowDef JSON', async () => {
+            const validWorkflowResp = {
+                name: 'Updated_Workflow',
+                description: 'Updated',
+                version: 2,
+                tasks: []
+            };
+
+            mockLlmChat.mockResolvedValueOnce({
+                content: `\`\`\`json
+${JSON.stringify(validWorkflowResp)}
+\`\`\`
+`
+            });
+
+            const result = await actions['update_workflow'].handler(mockContext, {
+                workflow_json: '{"name":"a"}',
+                instruction: 'Change name'
+            }) as any;
+
+            expect(result.workflow.name).toBe('Updated_Workflow');
+        });
+    });
+
+});

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
+  transpilePackages: ['reactflow-ui'],
 };
 
 export default nextConfig;

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
   output: 'export',
@@ -7,6 +8,10 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   transpilePackages: ['reactflow-ui'],
+  turbopack: {
+    // Set root to common parent so Turbopack can follow symlinks to linked packages
+    root: path.resolve(__dirname, "../../.."),
+  },
 };
 
 export default nextConfig;

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -7,7 +7,7 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  transpilePackages: ['reactflow-ui'],
+  transpilePackages: ['@yiyi_zhang/reactflow-ui'],
   turbopack: {
     // Set root to common parent so Turbopack can follow symlinks to linked packages
     root: path.resolve(__dirname, "../../.."),

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@yiyi_zhang/reactflow-ui": "^0.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "echarts": "^6.0.0",
@@ -39,7 +40,6 @@
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "reactflow": "^11.11.4",
-        "reactflow-ui": "file:/Users/zhang/Yiyi/ai/orch-flow-ui/reactflow-ui",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
@@ -58,6 +58,8 @@
     },
     "../../orch-flow-ui/reactflow-ui": {
       "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
       "dependencies": {
         "dagre": "^0.8.5",
         "lucide-react": "^0.562.0",
@@ -4923,6 +4925,33 @@
         "win32"
       ]
     },
+    "node_modules/@yiyi_zhang/reactflow-ui": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/@yiyi_zhang/reactflow-ui/-/reactflow-ui-0.1.0.tgz",
+      "integrity": "sha512-1sadSXs9EbxkwrNbiXcKr21LSbblYNmaTz3nmoTVSsZiFuhC8+0OrWAddAicKIwaMxVLRIsmmbUESqILaox/7g==",
+      "license": "MIT",
+      "dependencies": {
+        "dagre": "^0.8.5",
+        "lucide-react": "^0.562.0",
+        "react-hotkeys-hook": "^5.2.1",
+        "zundo": "^2.3.0",
+        "zustand": "^5.0.9"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "reactflow": "^11.11.4"
+      }
+    },
+    "node_modules/@yiyi_zhang/reactflow-ui/node_modules/lucide-react": {
+      "version": "0.562.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.562.0.tgz",
+      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.15.0.tgz",
@@ -6122,6 +6151,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmmirror.com/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/dagre-d3-es": {
@@ -7436,6 +7475,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmmirror.com/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmmirror.com/hachure-fill/-/hachure-fill-0.5.2.tgz",
@@ -8695,6 +8743,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.23",
@@ -10558,6 +10612,16 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-hotkeys-hook": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmmirror.com/react-hotkeys-hook/-/react-hotkeys-hook-5.2.4.tgz",
+      "integrity": "sha512-BgKg+A1+TawkYluh5Bo4cTmcgMN5L29uhJbDUQdHwPX+qgXRjIPYU5kIDHyxnAwCkCBiu9V5OpB2mpyeluVF2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmmirror.com/react-is/-/react-is-16.13.1.tgz",
@@ -10704,6 +10768,7 @@
       "resolved": "https://registry.npmmirror.com/reactflow/-/reactflow-11.11.4.tgz",
       "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@reactflow/background": "11.3.14",
         "@reactflow/controls": "11.2.14",
@@ -10716,10 +10781,6 @@
         "react": ">=17",
         "react-dom": ">=17"
       }
-    },
-    "node_modules/reactflow-ui": {
-      "resolved": "../../orch-flow-ui/reactflow-ui",
-      "link": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -12400,11 +12461,30 @@
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
       "license": "0BSD"
     },
+    "node_modules/zundo": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/zundo/-/zundo-2.3.0.tgz",
+      "integrity": "sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/charkour"
+      },
+      "peerDependencies": {
+        "zustand": "^4.3.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zustand": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/zustand": {
       "version": "5.0.10",
       "resolved": "https://registry.npmmirror.com/zustand/-/zustand-5.0.10.tgz",
       "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -38,6 +38,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
+        "reactflow-ui": "file:../../../../../../tmp/reactflow-ui-0.1.0.tgz",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
@@ -3400,6 +3401,276 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmmirror.com/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/background/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmmirror.com/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmmirror.com/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmmirror.com/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmmirror.com/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmmirror.com/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -5214,6 +5485,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmmirror.com/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmmirror.com/classnames/-/classnames-2.5.1.tgz",
@@ -5813,6 +6090,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmmirror.com/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/dagre-d3-es": {
@@ -7127,6 +7414,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmmirror.com/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmmirror.com/hachure-fill/-/hachure-fill-0.5.2.tgz",
@@ -8386,6 +8682,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.23",
@@ -10249,6 +10551,16 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-hotkeys-hook": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmmirror.com/react-hotkeys-hook/-/react-hotkeys-hook-5.2.4.tgz",
+      "integrity": "sha512-BgKg+A1+TawkYluh5Bo4cTmcgMN5L29uhJbDUQdHwPX+qgXRjIPYU5kIDHyxnAwCkCBiu9V5OpB2mpyeluVF2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmmirror.com/react-is/-/react-is-16.13.1.tgz",
@@ -10388,6 +10700,51 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmmirror.com/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/reactflow-ui": {
+      "version": "0.1.0",
+      "resolved": "file:../../../../../../tmp/reactflow-ui-0.1.0.tgz",
+      "integrity": "sha512-7/8n/3UYfwytp3sD9XnpwHBeWMlnhmuXEk8/KbKf3FxizxZk6byfO3gmgUYm7hb9QqH9vBjVdSM4BCUez6dEsw==",
+      "dependencies": {
+        "dagre": "^0.8.5",
+        "lucide-react": "^0.562.0",
+        "react-hotkeys-hook": "^5.2.1",
+        "zundo": "^2.3.0",
+        "zustand": "^5.0.9"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "reactflow": "^11.11.4"
+      }
+    },
+    "node_modules/reactflow-ui/node_modules/lucide-react": {
+      "version": "0.562.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.562.0.tgz",
+      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11801,7 +12158,6 @@
       "resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -12069,11 +12425,30 @@
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
       "license": "0BSD"
     },
+    "node_modules/zundo": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/zundo/-/zundo-2.3.0.tgz",
+      "integrity": "sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/charkour"
+      },
+      "peerDependencies": {
+        "zustand": "^4.3.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zustand": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/zustand": {
       "version": "5.0.10",
       "resolved": "https://registry.npmmirror.com/zustand/-/zustand-5.0.10.tgz",
       "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -38,7 +38,8 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
-        "reactflow-ui": "file:../../../../../../tmp/reactflow-ui-0.1.0.tgz",
+        "reactflow": "^11.11.4",
+        "reactflow-ui": "file:/Users/zhang/Yiyi/ai/orch-flow-ui/reactflow-ui",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
@@ -53,6 +54,37 @@
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5"
+      }
+    },
+    "../../orch-flow-ui/reactflow-ui": {
+      "version": "0.1.0",
+      "dependencies": {
+        "dagre": "^0.8.5",
+        "lucide-react": "^0.562.0",
+        "react-hotkeys-hook": "^5.2.1",
+        "zundo": "^2.3.0",
+        "zustand": "^5.0.9"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.1",
+        "@types/dagre": "^0.7.53",
+        "@types/react": "^19.2.5",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "eslint": "^9.39.1",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.4.24",
+        "globals": "^16.5.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "reactflow": "^11.11.4",
+        "typescript": "^5.9.3",
+        "vite": "^7.2.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "reactflow": "^11.11.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6092,16 +6124,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/dagre": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmmirror.com/dagre/-/dagre-0.8.5.tgz",
-      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/dagre-d3-es": {
       "version": "7.0.13",
       "resolved": "https://registry.npmmirror.com/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
@@ -7414,15 +7436,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmmirror.com/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmmirror.com/hachure-fill/-/hachure-fill-0.5.2.tgz",
@@ -8682,12 +8695,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.23",
@@ -10551,16 +10558,6 @@
         "react": "^19.2.3"
       }
     },
-    "node_modules/react-hotkeys-hook": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmmirror.com/react-hotkeys-hook/-/react-hotkeys-hook-5.2.4.tgz",
-      "integrity": "sha512-BgKg+A1+TawkYluh5Bo4cTmcgMN5L29uhJbDUQdHwPX+qgXRjIPYU5kIDHyxnAwCkCBiu9V5OpB2mpyeluVF2A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmmirror.com/react-is/-/react-is-16.13.1.tgz",
@@ -10707,7 +10704,6 @@
       "resolved": "https://registry.npmmirror.com/reactflow/-/reactflow-11.11.4.tgz",
       "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@reactflow/background": "11.3.14",
         "@reactflow/controls": "11.2.14",
@@ -10722,30 +10718,8 @@
       }
     },
     "node_modules/reactflow-ui": {
-      "version": "0.1.0",
-      "resolved": "file:../../../../../../tmp/reactflow-ui-0.1.0.tgz",
-      "integrity": "sha512-7/8n/3UYfwytp3sD9XnpwHBeWMlnhmuXEk8/KbKf3FxizxZk6byfO3gmgUYm7hb9QqH9vBjVdSM4BCUez6dEsw==",
-      "dependencies": {
-        "dagre": "^0.8.5",
-        "lucide-react": "^0.562.0",
-        "react-hotkeys-hook": "^5.2.1",
-        "zundo": "^2.3.0",
-        "zustand": "^5.0.9"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
-        "reactflow": "^11.11.4"
-      }
-    },
-    "node_modules/reactflow-ui/node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
+      "resolved": "../../orch-flow-ui/reactflow-ui",
+      "link": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -12158,6 +12132,7 @@
       "resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -12425,30 +12400,11 @@
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
       "license": "0BSD"
     },
-    "node_modules/zundo": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/zundo/-/zundo-2.3.0.tgz",
-      "integrity": "sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/charkour"
-      },
-      "peerDependencies": {
-        "zustand": "^4.3.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zustand": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/zustand": {
       "version": "5.0.10",
       "resolved": "https://registry.npmmirror.com/zustand/-/zustand-5.0.10.tgz",
       "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
-    "reactflow-ui": "file:../../../../../../tmp/reactflow-ui-0.1.0.tgz",
+    "reactflow": "^11.11.4",
+    "reactflow-ui": "file:/Users/zhang/Yiyi/ai/orch-flow-ui/reactflow-ui",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
+    "reactflow-ui": "file:../../../../../../tmp/reactflow-ui-0.1.0.tgz",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@yiyi_zhang/reactflow-ui": "^0.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "echarts": "^6.0.0",
@@ -40,7 +41,6 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "reactflow": "^11.11.4",
-    "reactflow-ui": "file:/Users/zhang/Yiyi/ai/orch-flow-ui/reactflow-ui",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -9,6 +9,7 @@ import { makeLightAsyncSyntaxHighlighter } from "@assistant-ui/react-syntax-high
 import { MyRuntimeAdapter } from "@/lib/assistant-runtime";
 import { ChatThinking } from "@/components/chat-thinking";
 import { DagView } from "@/components/dag-view";
+import { ConductorWorkflowCard } from "@/components/conductor-workflow-dialog";
 import { allToolUIs, FallbackToolUI } from "@/components/tool-ui";
 import { useMemo, memo, useRef, useEffect, useState, Suspense, useCallback } from "react";
 import "@assistant-ui/react-ui/styles/index.css";
@@ -136,11 +137,10 @@ const FeedbackButton = ({ rating, messageId, sessionId }: { rating: 'positive' |
     return (
         <button
             onClick={handleClick}
-            className={`inline-flex items-center justify-center h-7 w-7 rounded-md transition-colors ${
-                submitted
+            className={`inline-flex items-center justify-center h-7 w-7 rounded-md transition-colors ${submitted
                     ? (rating === 'positive' ? 'text-green-500 bg-green-500/10' : 'text-red-500 bg-red-500/10')
                     : 'text-muted-foreground hover:text-foreground hover:bg-muted/80'
-            }`}
+                }`}
             title={rating === 'positive' ? '有帮助' : '没帮助'}
             disabled={submitted}
         >
@@ -361,6 +361,18 @@ const CustomAssistantMessage = memo(() => {
                                 key={s.interrupt.id ?? i}
                                 interrupt={s.interrupt}
                                 sessionId={sessionId}
+                            />
+                        ))
+                    }
+
+                    {/* Conductor Workflow Generated cards */}
+                    {steps
+                        .filter((s: any) => s.workflow_generated)
+                        .map((s: any, i: number) => (
+                            <ConductorWorkflowCard
+                                key={`workflow-${i}`}
+                                workflowDef={s.workflow_generated.workflow}
+                                explanation={s.workflow_generated.explanation}
                             />
                         ))
                     }

--- a/web/src/app/conductor/page.tsx
+++ b/web/src/app/conductor/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import "reactflow/dist/style.css";
 import "reactflow-ui/style.css";
 import { fetchApi } from "@/lib/api";
-import { WorkflowIDE, WorkflowDef } from "reactflow-ui";
+import { WorkflowIDE, WorkflowDef, WorkflowIDERef } from "reactflow-ui";
+import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { Plus, Trash2, Edit3, ArrowLeft, Download, RotateCcw, Save } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
@@ -28,6 +29,9 @@ export default function ConductorPage() {
     const [view, setView] = useState<'list' | 'edit'>('list');
     const [editingWorkflow, setEditingWorkflow] = useState<SavedWorkflow | null>(null);
     const [isSaving, setIsSaving] = useState(false);
+    const ideRef = useRef<WorkflowIDERef>(null);
+    const { resolvedTheme } = useTheme();
+    const ideTheme = resolvedTheme === 'dark' ? 'dark' : 'light';
 
     const loadWorkflows = useCallback(async () => {
         setLoading(true);
@@ -155,7 +159,10 @@ export default function ConductorPage() {
                         <Button
                             size="sm"
                             disabled={isSaving}
-                            onClick={() => handleSave(editingWorkflow.definition)}
+                            onClick={async () => {
+                                const def = ideRef.current?.getWorkflowDef();
+                                if (def) await handleSave(def);
+                            }}
                         >
                             <Save className="w-4 h-4 mr-2" /> {isSaving ? "保存中..." : "保存"}
                         </Button>
@@ -165,9 +172,11 @@ export default function ConductorPage() {
                 {/* Workflow IDE Area */}
                 <div className="flex-1 min-h-0 relative">
                     <WorkflowIDE
+                        ref={ideRef}
                         workflowDef={editingWorkflow.definition}
-                        // Connect AI copilot if backend supports it natively, otherwise it uses default settings
+                        theme={ideTheme}
                         onSave={handleSave}
+                        aiConfig={{ baseUrl: '/api/conductor', model: 'assistant', apiKey: 'local' }}
                     />
                 </div>
             </div>

--- a/web/src/app/conductor/page.tsx
+++ b/web/src/app/conductor/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import "reactflow/dist/style.css";
+import "reactflow-ui/style.css";
+import { fetchApi } from "@/lib/api";
+import { WorkflowIDE, WorkflowDef } from "reactflow-ui";
+import { Button } from "@/components/ui/button";
+import { Plus, Trash2, Edit3, ArrowLeft, Download, RotateCcw, Save } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface SavedWorkflow {
+    id: string;
+    name: string;
+    description?: string;
+    version: number;
+    definition: WorkflowDef;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export default function ConductorPage() {
+    const [workflows, setWorkflows] = useState<SavedWorkflow[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    // View state: 'list' | 'edit'
+    const [view, setView] = useState<'list' | 'edit'>('list');
+    const [editingWorkflow, setEditingWorkflow] = useState<SavedWorkflow | null>(null);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const loadWorkflows = useCallback(async () => {
+        setLoading(true);
+        try {
+            const data = await fetchApi<SavedWorkflow[]>('/api/conductor-workflows');
+            setWorkflows(data);
+        } catch (error) {
+            console.error('Failed to load Conductor workflows:', error);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (view === 'list') {
+            loadWorkflows();
+        }
+    }, [view, loadWorkflows]);
+
+    const handleDelete = async (id: string) => {
+        if (!confirm('确定删除此工作流吗？')) return;
+        try {
+            await fetchApi(`/api/conductor-workflows/${id}`, { method: 'DELETE' });
+            setWorkflows(prev => prev.filter(w => w.id !== id));
+        } catch (error) {
+            console.error('Failed to delete workflow:', error);
+            alert('删除失败');
+        }
+    };
+
+    const handleCreateNew = () => {
+        const emptyDef: WorkflowDef = {
+            name: 'New_Workflow',
+            description: '',
+            version: 1,
+            tasks: [],
+            schemaVersion: 2
+        };
+        setEditingWorkflow({
+            id: '',
+            name: emptyDef.name,
+            version: 1,
+            definition: emptyDef,
+            createdAt: '',
+            updatedAt: ''
+        });
+        setView('edit');
+    };
+
+    const handleEdit = (w: SavedWorkflow) => {
+        setEditingWorkflow(w);
+        setView('edit');
+    };
+
+    const handleSave = async (def: WorkflowDef) => {
+        if (!editingWorkflow) return;
+        setIsSaving(true);
+        try {
+            const payload = {
+                name: def.name,
+                description: def.description,
+                version: def.version,
+                definition: def
+            };
+
+            if (editingWorkflow.id) {
+                // Update
+                await fetchApi(`/api/conductor-workflows/${editingWorkflow.id}`, {
+                    method: 'PUT',
+                    body: JSON.stringify(payload)
+                });
+            } else {
+                // Create
+                const res = await fetchApi<{ id: string }>('/api/conductor-workflows', {
+                    method: 'POST',
+                    body: JSON.stringify(payload)
+                });
+                editingWorkflow.id = res.id;
+            }
+            alert('保存成功');
+        } catch (error) {
+            console.error('Failed to save workflow:', error);
+            alert('保存失败');
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleExport = (def: WorkflowDef) => {
+        const blob = new Blob([JSON.stringify(def, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${def.name || 'workflow'}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    };
+
+    if (view === 'edit' && editingWorkflow) {
+        return (
+            <div className="flex flex-col h-full w-full overflow-hidden bg-background">
+                {/* Header Navbar */}
+                <div className="h-14 shrink-0 flex items-center justify-between px-6 border-b z-10 bg-card">
+                    <div className="flex items-center gap-4">
+                        <Button variant="ghost" size="sm" onClick={() => setView('list')} className="text-muted-foreground mr-2">
+                            <ArrowLeft className="w-4 h-4 mr-1" /> 返回列表
+                        </Button>
+                        <div>
+                            <h2 className="text-[15px] font-semibold flex items-center gap-2">
+                                {editingWorkflow.id ? '编辑工作流' : '新建工作流'}
+                                <Badge variant="secondary" className="font-mono text-[10px]">{editingWorkflow.definition.name}</Badge>
+                            </h2>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleExport(editingWorkflow.definition)}
+                        >
+                            <Download className="w-4 h-4 mr-2" /> 导出 JSON
+                        </Button>
+                        <Button
+                            size="sm"
+                            disabled={isSaving}
+                            onClick={() => handleSave(editingWorkflow.definition)}
+                        >
+                            <Save className="w-4 h-4 mr-2" /> {isSaving ? "保存中..." : "保存"}
+                        </Button>
+                    </div>
+                </div>
+
+                {/* Workflow IDE Area */}
+                <div className="flex-1 min-h-0 relative">
+                    <WorkflowIDE
+                        workflowDef={editingWorkflow.definition}
+                        // Connect AI copilot if backend supports it natively, otherwise it uses default settings
+                        onSave={handleSave}
+                    />
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="p-8 max-w-7xl mx-auto w-full h-full overflow-y-auto">
+            <div className="flex items-center justify-between mb-8">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight">Conductor 编排</h1>
+                    <p className="text-sm text-muted-foreground mt-1">
+                        管理和编辑企业级 Conductor OSS 工作流定义
+                    </p>
+                </div>
+                <div className="flex items-center gap-3">
+                    <Button variant="outline" onClick={loadWorkflows} disabled={loading}>
+                        <RotateCcw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+                        刷新
+                    </Button>
+                    <Button onClick={handleCreateNew}>
+                        <Plus className="w-4 h-4 mr-2" />
+                        新建工作流
+                    </Button>
+                </div>
+            </div>
+
+            {loading ? (
+                <div className="flex items-center justify-center h-64 text-muted-foreground">加载中...</div>
+            ) : workflows.length === 0 ? (
+                <div className="flex flex-col justify-center items-center h-64 border-2 border-dashed rounded-xl border-border bg-card/50 text-muted-foreground">
+                    <p>暂无 Conductor 工作流</p>
+                    <Button variant="link" onClick={handleCreateNew} className="mt-2">立即创建一个</Button>
+                </div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                    {workflows.map(w => (
+                        <Card key={w.id} className="group hover:shadow-md transition-shadow relative overflow-hidden flex flex-col">
+                            <CardHeader className="pb-3 break-words relative z-10">
+                                <CardTitle className="text-[16px] leading-snug line-clamp-1 flex justify-between items-start" title={w.name}>
+                                    <span className="font-mono text-[14px]">{w.name}</span>
+                                </CardTitle>
+                                <CardDescription className="line-clamp-2 min-h-[40px] text-xs">
+                                    {w.description || '无描述'}
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent className="flex-1 pb-2">
+                                <div className="flex flex-wrap gap-2">
+                                    <Badge variant="secondary" className="font-normal">v{w.version}</Badge>
+                                    <Badge variant="outline" className="font-normal border-primary/20 text-primary">
+                                        {w.definition?.tasks?.length || 0} 个节点
+                                    </Badge>
+                                </div>
+                            </CardContent>
+                            <CardFooter className="pt-2 pb-4 flex items-center justify-between border-t border-border/40 bg-muted/20">
+                                <div className="text-[11px] text-muted-foreground">
+                                    更新于 {new Date(w.updatedAt).toLocaleDateString()}
+                                </div>
+                                <div className="flex gap-1 h-8">
+                                    <Button variant="ghost" size="icon" className="h-7 w-7 rounded-sm" onClick={() => handleExport(w.definition)} title="导出 JSON">
+                                        <Download className="h-3.5 w-3.5 text-muted-foreground" />
+                                    </Button>
+                                    <Button variant="ghost" size="icon" className="h-7 w-7 rounded-sm text-blue-600 hover:text-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/40" onClick={() => handleEdit(w)} title="编辑">
+                                        <Edit3 className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button variant="ghost" size="icon" className="h-7 w-7 rounded-sm text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/40" onClick={() => handleDelete(w.id)} title="删除">
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                </div>
+                            </CardFooter>
+                        </Card>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/web/src/app/conductor/page.tsx
+++ b/web/src/app/conductor/page.tsx
@@ -2,9 +2,9 @@
 
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import "reactflow/dist/style.css";
-import "reactflow-ui/style.css";
+import "@yiyi_zhang/reactflow-ui/style.css";
 import { fetchApi } from "@/lib/api";
-import { WorkflowIDE, WorkflowDef, WorkflowIDERef } from "reactflow-ui";
+import { WorkflowIDE, WorkflowDef, WorkflowIDERef } from "@yiyi_zhang/reactflow-ui";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { Plus, Trash2, Edit3, ArrowLeft, Download, RotateCcw, Save } from "lucide-react";

--- a/web/src/components/conductor-workflow-dialog.tsx
+++ b/web/src/components/conductor-workflow-dialog.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+import "reactflow/dist/style.css";
+import "reactflow-ui/style.css";
+import { WorkflowIDE, WorkflowDef } from "reactflow-ui";
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { PlaySquare, Save } from "lucide-react";
+import { fetchApi } from "@/lib/api";
+
+interface ConductorWorkflowDialogProps {
+    workflowDef: WorkflowDef;
+    explanation?: string;
+    onSaveSuccess?: () => void;
+}
+
+export function ConductorWorkflowCard({ workflowDef, explanation, onSaveSuccess }: ConductorWorkflowDialogProps) {
+    const [open, setOpen] = useState(false);
+    const [saving, setSaving] = useState(false);
+
+    const handleSave = async (def: WorkflowDef) => {
+        setSaving(true);
+        try {
+            await fetchApi('/api/conductor-workflows', {
+                method: 'POST',
+                body: JSON.stringify({
+                    name: def.name || 'Untitled_Workflow',
+                    description: def.description || '',
+                    version: def.version || 1,
+                    definition: def
+                }),
+            });
+            if (onSaveSuccess) onSaveSuccess();
+        } catch (error) {
+            console.error('Failed to save workflow', error);
+            alert('保存工作流失败');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="my-4 p-4 rounded-xl border border-blue-200 dark:border-blue-900 bg-blue-50/50 dark:bg-blue-950/20 max-w-2xl">
+            <div className="flex items-center gap-3 mb-3">
+                <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400">
+                    <PlaySquare className="w-5 h-5" />
+                </div>
+                <div>
+                    <h3 className="text-sm font-semibold text-blue-900 dark:text-blue-100">
+                        {workflowDef.name || "生成的 Conductor 工作流"}
+                    </h3>
+                    <p className="text-xs text-blue-700/80 dark:text-blue-300/80">
+                        共 {workflowDef.tasks?.length || 0} 个任务节点
+                    </p>
+                </div>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    className="ml-auto border-blue-300 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/50 text-blue-700 dark:text-blue-300"
+                    onClick={() => setOpen(true)}
+                >
+                    在 IDE 中查看
+                </Button>
+            </div>
+
+            {explanation && (
+                <div className="text-[13px] text-blue-900/70 dark:text-blue-100/70 border-t border-blue-200/50 dark:border-blue-800/50 pt-3 mt-1">
+                    {explanation}
+                </div>
+            )}
+
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent className="max-w-[95vw] w-[95vw] h-[95vh] p-0 flex flex-col gap-0 overflow-hidden border-zinc-200 dark:border-zinc-800">
+                    <div className="sr-only">
+                        <DialogTitle>Conductor Workflow IDE</DialogTitle>
+                        <DialogDescription>可视化编辑您的 Conductor 工作流</DialogDescription>
+                    </div>
+                    {/* Toolbar header */}
+                    <div className="h-14 shrink-0 flex items-center justify-between px-4 border-b bg-background">
+                        <div className="flex items-center gap-3">
+                            <h2 className="text-sm font-medium">✨ 工作流预览与编辑</h2>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Button
+                                size="sm"
+                                onClick={() => handleSave(workflowDef)}
+                                disabled={saving}
+                                className="h-8"
+                            >
+                                <Save className="w-4 h-4 mr-1.5" />
+                                {saving ? "保存中..." : "保存到系统"}
+                            </Button>
+                        </div>
+                    </div>
+                    {/* IDE viewport */}
+                    <div className="flex-1 min-h-0 bg-zinc-50 dark:bg-zinc-950 relative">
+                        <WorkflowIDE
+                            workflowDef={workflowDef}
+                        />
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/web/src/components/conductor-workflow-dialog.tsx
+++ b/web/src/components/conductor-workflow-dialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from "react";
 import "reactflow/dist/style.css";
-import "reactflow-ui/style.css";
-import { WorkflowIDE, WorkflowDef, WorkflowIDERef } from "reactflow-ui";
+import "@yiyi_zhang/reactflow-ui/style.css";
+import { WorkflowIDE, WorkflowDef, WorkflowIDERef } from "@yiyi_zhang/reactflow-ui";
 import { useTheme } from "next-themes";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";

--- a/web/src/components/conductor-workflow-dialog.tsx
+++ b/web/src/components/conductor-workflow-dialog.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import "reactflow/dist/style.css";
 import "reactflow-ui/style.css";
-import { WorkflowIDE, WorkflowDef } from "reactflow-ui";
+import { WorkflowIDE, WorkflowDef, WorkflowIDERef } from "reactflow-ui";
+import { useTheme } from "next-themes";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { PlaySquare, Save } from "lucide-react";
@@ -16,6 +17,9 @@ interface ConductorWorkflowDialogProps {
 export function ConductorWorkflowCard({ workflowDef, explanation, onSaveSuccess }: ConductorWorkflowDialogProps) {
     const [open, setOpen] = useState(false);
     const [saving, setSaving] = useState(false);
+    const ideRef = useRef<WorkflowIDERef>(null);
+    const { resolvedTheme } = useTheme();
+    const ideTheme = resolvedTheme === 'dark' ? 'dark' : 'light';
 
     const handleSave = async (def: WorkflowDef) => {
         setSaving(true);
@@ -69,32 +73,37 @@ export function ConductorWorkflowCard({ workflowDef, explanation, onSaveSuccess 
             )}
 
             <Dialog open={open} onOpenChange={setOpen}>
-                <DialogContent className="max-w-[95vw] w-[95vw] h-[95vh] p-0 flex flex-col gap-0 overflow-hidden border-zinc-200 dark:border-zinc-800">
+                <DialogContent
+                    className="p-0 flex flex-col gap-0 overflow-hidden border-zinc-200 dark:border-zinc-800"
+                    style={{ width: '95vw', maxWidth: '95vw', height: '92vh' }}
+                >
                     <div className="sr-only">
                         <DialogTitle>Conductor Workflow IDE</DialogTitle>
                         <DialogDescription>可视化编辑您的 Conductor 工作流</DialogDescription>
                     </div>
                     {/* Toolbar header */}
-                    <div className="h-14 shrink-0 flex items-center justify-between px-4 border-b bg-background">
-                        <div className="flex items-center gap-3">
-                            <h2 className="text-sm font-medium">✨ 工作流预览与编辑</h2>
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <Button
-                                size="sm"
-                                onClick={() => handleSave(workflowDef)}
-                                disabled={saving}
-                                className="h-8"
-                            >
-                                <Save className="w-4 h-4 mr-1.5" />
-                                {saving ? "保存中..." : "保存到系统"}
-                            </Button>
-                        </div>
+                    <div className="h-12 shrink-0 flex items-center justify-between px-4 border-b bg-background">
+                        <h2 className="text-sm font-medium">✨ 工作流预览与编辑</h2>
+                        <Button
+                            size="sm"
+                            onClick={() => {
+                                const def = ideRef.current?.getWorkflowDef();
+                                if (def) handleSave(def);
+                            }}
+                            disabled={saving}
+                            className="h-8"
+                        >
+                            <Save className="w-4 h-4 mr-1.5" />
+                            {saving ? "保存中..." : "保存到系统"}
+                        </Button>
                     </div>
                     {/* IDE viewport */}
-                    <div className="flex-1 min-h-0 bg-zinc-50 dark:bg-zinc-950 relative">
+                    <div className="flex-1 min-h-0 relative">
                         <WorkflowIDE
+                            ref={ideRef}
                             workflowDef={workflowDef}
+                            theme={ideTheme}
+                            aiConfig={{ baseUrl: '/api/conductor', model: 'assistant', apiKey: 'local' }}
                         />
                     </div>
                 </DialogContent>

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -135,6 +135,7 @@ const data: SidebarData = {
       items: [
         { title: "仪表盘", url: "/" },
         { title: "工作流编排", url: "/workflow" },
+        { title: "Conductor 编排", url: "/conductor", badge: "NEW" },
       ],
     },
     {

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -150,6 +150,18 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
                     });
                     yield buildYield();
 
+                } else if (chunk.type === "workflow_generated") {
+                    currentSteps.push({
+                        workflow_generated: {
+                            workflow: chunk.workflow,
+                            subWorkflows: chunk.subWorkflows,
+                            validation: chunk.validation,
+                            allValid: chunk.allValid,
+                            explanation: chunk.explanation,
+                        }
+                    });
+                    yield buildYield();
+
                 } else if (chunk.type === "answer") {
                     // Final answer replaces any partial content chunks
                     currentContent = chunk.content;


### PR DESCRIPTION
## Summary

   Implements Conductor OSS workflow AI generation, ReactFlow visualization, and IDE editing, with all reported issues resolved.

   ### Issues Fixed

   - **reactflow-ui dependency**: Replaced temporary tgz path with `npm link`; fixed Turbopack workspace root detection by setting `turbopack.root` so the
   bundler correctly follows symlinks to the linked package
   - **Save button**: Replaced stale snapshot with `WorkflowIDERef.getWorkflowDef()` to read the IDE's current state; added `theme` (synced to app theme
   via `next-themes`) and `aiConfig` props
   - **workflow_generated SSE chain**: Fixed skill export format to match loader conventions (named exports + default export); injected `llm` into
   `skillContext` in `agent.ts`; yield `workflow_generated` step with flattened fields matching the frontend parser
   - **AI Copilot proxy**: Added `POST /api/conductor/chat/completions` OpenAI-compatible SSE endpoint forwarding to the configured LLM adapter
   - **Dialog width**: Used inline `style` to override shadcn `DialogContent`'s `max-w-lg` constraint, giving the IDE 95vw × 92vh
   - **History persistence**: Added `metadata` column to `messages` table (auto-migration); backend collects `workflow_generated` steps during streaming
   and persists them in `metadata.custom.steps`; `ThreadHydrator` already reads `m.metadata?.custom`, so workflow cards are restored on page reload

   ## Test Plan

   - [x] `npx tsc --noEmit` — 0 errors (frontend)
   - [x] `tsc --noEmit` — 0 errors (backend)
   - [x] `vitest run` — 118/118 tests passing
   - [x] `next build` — all 16 routes compiled successfully
   - [ ] Chat: ask "帮我创建一个用户注册审批工作流" → workflow card appears with "在 IDE 中查看" button
   - [ ] Click card → WorkflowIDE dialog opens at 95vw width with ReactFlow canvas
   - [ ] Save button → POST/PUT to correct endpoint with current IDE definition
   - [ ] AI Copilot input → receives streaming response
   - [ ] Refresh page / re-open session → workflow card still visible in history

   🤖 Generated with [Claude Code](https://claude.com/claude-code)