### PR TITLE
fix: resolve Windows shell compatibility issues in command execution

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -55,6 +55,7 @@ skills:
     - ./skills/installed
     - ./skills/local
   shell:
+    preferGitBash: true
     sandbox:
       enabled: true
       mode: blocklist

--- a/skills/built-in/shell/index.ts
+++ b/skills/built-in/shell/index.ts
@@ -56,9 +56,9 @@ export async function execute(
         }
     }
 
-    // Windows: python/python3 命令自动补 .exe 避免 AppX 虚拟化 EPERM
-    if (platform() === 'win32' && /^python3?\s/.test(command)) {
-        command = command.replace(/^python3?\s/, 'python.exe ');
+    // Windows: 自动补 .exe 后缀，避免 AppX 虚拟化 EPERM（python/python3/pip/pip3）
+    if (platform() === 'win32') {
+        command = command.replace(/^(python3?|pip3?)\s/, '$1.exe ');
     }
 
     ctx.logger.info(`Executing command: ${command}`);
@@ -152,11 +152,14 @@ export async function execute_background(
 
     ctx.logger.info(`Spawning background command: ${command}`);
 
+    const isWin = platform() === 'win32';
     const child = spawn(command, [], {
         cwd,
-        shell: true,
+        // On Windows use PowerShell (consistent with execute()); on Unix shell:true uses /bin/sh
+        shell: isWin ? 'powershell.exe' : true,
         detached: true,
         stdio: 'ignore',
+        ...(isWin ? { windowsHide: true } : {}),
     });
 
     child.unref();

--- a/skills/built-in/shell/index.ts
+++ b/skills/built-in/shell/index.ts
@@ -63,86 +63,17 @@ export async function execute(
 
     ctx.logger.info(`Executing command: ${command}`);
 
-    // Layer 2: OS-level sandbox execution (macOS sandbox-exec / Linux bwrap / Windows Git Bash or PowerShell)
-    if (platform() !== 'win32') {
-        const osSandbox = new OsSandboxExecutor(ctx.logger);
-        const result = await osSandbox.execute(command, { cwd, timeout });
-        ctx.logger.info(`[OsSandbox] mode=${result.sandboxMode} exitCode=${result.exitCode}`);
-        return {
-            stdout: result.stdout,
-            stderr: result.stderr,
-            exitCode: result.exitCode,
-            platform: platform(),
-        };
-    }
-
-    // Windows: OS-level sandbox (Git Bash or PowerShell depending on preferGitBash)
+    // Layer 2: OS-level sandbox (macOS sandbox-exec / Linux bwrap / Windows Git Bash or PowerShell)
+    // OsSandboxExecutor handles all platforms including Windows; ENOENT fallback is done internally.
     const osSandbox = new OsSandboxExecutor(ctx.logger);
-    const sandboxResult = await osSandbox.execute(command, { cwd, timeout, preferGitBash });
-    ctx.logger.info(`[OsSandbox] mode=${sandboxResult.sandboxMode} exitCode=${sandboxResult.exitCode}`);
-
-    // If sandbox execution succeeded (no ENOENT of both bash and powershell), return directly
-    if (sandboxResult.exitCode !== 1 || !sandboxResult.stderr.includes('ENOENT')) {
-        return {
-            stdout: sandboxResult.stdout,
-            stderr: sandboxResult.stderr,
-            exitCode: sandboxResult.exitCode,
-            platform: platform(),
-        };
-    }
-
-    // Last-resort direct spawn fallback (should rarely be reached)
-    const { shell, hint } = getWindowsShell(preferGitBash);
-    ctx.logger.info(`Executing command [${hint}]: ${command}`);
-
-    return new Promise((resolve) => {
-        const stdoutChunks: Buffer[] = [];
-        const stderrChunks: Buffer[] = [];
-
-        const child = spawn(command, [], {
-            cwd,
-            shell: shell as string,
-            windowsHide: true,
-            stdio: ['ignore', 'pipe', 'pipe'],
-            env: { ...process.env },
-        });
-
-        child.stdout?.on('data', (d: Buffer) => stdoutChunks.push(d));
-        child.stderr?.on('data', (d: Buffer) => stderrChunks.push(d));
-
-        const timer = setTimeout(() => {
-            child.kill();
-            resolve({
-                stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
-                stderr: `Command timed out after ${timeout / 1000}s`,
-                exitCode: 124,
-                platform: platform(),
-            });
-        }, timeout);
-
-        child.on('close', (code: number | null) => {
-            clearTimeout(timer);
-            resolve({
-                stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
-                stderr: Buffer.concat(stderrChunks).toString('utf-8'),
-                exitCode: code ?? 1,
-                platform: platform(),
-            });
-        });
-
-        child.on('error', (err: NodeJS.ErrnoException) => {
-            clearTimeout(timer);
-            let errMsg: string;
-            if (err.code === 'ENOENT') {
-                errMsg = `命令未找到: ${command.split(' ')[0]}。请确认已安装并在 PATH 中。`;
-            } else if (err.code === 'EPERM' || err.code === 'EACCES') {
-                errMsg = `权限不足，无法执行: ${command}。\n请检查执行策略: Set-ExecutionPolicy RemoteSigned`;
-            } else {
-                errMsg = err.message;
-            }
-            resolve({ stdout: '', stderr: errMsg, exitCode: 1, platform: platform() });
-        });
-    });
+    const result = await osSandbox.execute(command, { cwd, timeout, preferGitBash });
+    ctx.logger.info(`[OsSandbox] mode=${result.sandboxMode} exitCode=${result.exitCode}`);
+    return {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+        platform: platform(),
+    };
 }
 
 /**

--- a/skills/built-in/shell/index.ts
+++ b/skills/built-in/shell/index.ts
@@ -3,7 +3,7 @@ import { platform } from 'os';
 import type { SkillContext } from '../../../src/types.js';
 import { CommandSandbox, type SandboxConfig } from '../../../src/skills/sandbox.js';
 import { OsSandboxExecutor } from '../../../src/skills/os-sandbox.js';
-import { expandPath } from '../../../src/skills/utils.js';
+import { expandPath, findGitBash } from '../../../src/skills/utils.js';
 
 function getSandbox(ctx: SkillContext): CommandSandbox | null {
     const sandboxConfig = (ctx.config as any)?.sandbox as SandboxConfig | undefined;
@@ -18,19 +18,17 @@ function getSandbox(ctx: SkillContext): CommandSandbox | null {
 export const resolvePath = expandPath;
 
 /**
- * Get platform-appropriate shell config
+ * Get platform-appropriate shell for Windows direct-spawn fallback.
+ * Priority: Git Bash (if available and preferred) → PowerShell
  */
-function getShellConfig(): { shell: string | boolean; hint: string } {
-    if (platform() === 'win32') {
-        return {
-            shell: 'powershell.exe',
-            hint: 'PowerShell syntax (Windows)',
-        };
+function getWindowsShell(preferGitBash: boolean): { shell: string; hint: string } {
+    if (preferGitBash) {
+        const bashPath = findGitBash();
+        if (bashPath) {
+            return { shell: bashPath, hint: 'Git Bash syntax (Windows)' };
+        }
     }
-    return {
-        shell: '/bin/sh',
-        hint: 'bash syntax',
-    };
+    return { shell: 'powershell.exe', hint: 'PowerShell syntax (Windows)' };
 }
 
 /**
@@ -61,10 +59,11 @@ export async function execute(
         command = command.replace(/^(python3?|pip3?)\s/, '$1.exe ');
     }
 
+    const preferGitBash = (ctx.config as any)?.skills?.shell?.preferGitBash !== false;
+
     ctx.logger.info(`Executing command: ${command}`);
 
-    // Layer 2: OS-level sandbox execution (macOS sandbox-exec / Linux bwrap)
-    // Windows falls back to direct execution (Layer 1 is the only protection there)
+    // Layer 2: OS-level sandbox execution (macOS sandbox-exec / Linux bwrap / Windows Git Bash or PowerShell)
     if (platform() !== 'win32') {
         const osSandbox = new OsSandboxExecutor(ctx.logger);
         const result = await osSandbox.execute(command, { cwd, timeout });
@@ -77,8 +76,23 @@ export async function execute(
         };
     }
 
-    // Windows: direct spawn fallback
-    const { shell, hint } = getShellConfig();
+    // Windows: OS-level sandbox (Git Bash or PowerShell depending on preferGitBash)
+    const osSandbox = new OsSandboxExecutor(ctx.logger);
+    const sandboxResult = await osSandbox.execute(command, { cwd, timeout, preferGitBash });
+    ctx.logger.info(`[OsSandbox] mode=${sandboxResult.sandboxMode} exitCode=${sandboxResult.exitCode}`);
+
+    // If sandbox execution succeeded (no ENOENT of both bash and powershell), return directly
+    if (sandboxResult.exitCode !== 1 || !sandboxResult.stderr.includes('ENOENT')) {
+        return {
+            stdout: sandboxResult.stdout,
+            stderr: sandboxResult.stderr,
+            exitCode: sandboxResult.exitCode,
+            platform: platform(),
+        };
+    }
+
+    // Last-resort direct spawn fallback (should rarely be reached)
+    const { shell, hint } = getWindowsShell(preferGitBash);
     ctx.logger.info(`Executing command [${hint}]: ${command}`);
 
     return new Promise((resolve) => {
@@ -153,10 +167,16 @@ export async function execute_background(
     ctx.logger.info(`Spawning background command: ${command}`);
 
     const isWin = platform() === 'win32';
+    let windowsShell = 'powershell.exe';
+    if (isWin) {
+        const preferGitBash = (ctx.config as any)?.skills?.shell?.preferGitBash !== false;
+        windowsShell = getWindowsShell(preferGitBash).shell;
+    }
+
     const child = spawn(command, [], {
         cwd,
-        // On Windows use PowerShell (consistent with execute()); on Unix shell:true uses /bin/sh
-        shell: isWin ? 'powershell.exe' : true,
+        // On Windows use Git Bash (or PowerShell fallback); on Unix shell:true uses /bin/sh
+        shell: isWin ? windowsShell : true,
         detached: true,
         stdio: 'ignore',
         ...(isWin ? { windowsHide: true } : {}),

--- a/src/skills/os-sandbox.ts
+++ b/src/skills/os-sandbox.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process';
 import { platform } from 'os';
 import type { Logger } from '../types.js';
+import { findGitBash } from './utils.js';
 
 export interface OsSandboxOptions {
     cwd?: string;
@@ -8,6 +9,8 @@ export interface OsSandboxOptions {
     /** Allow outbound network access (default: false on Linux bwrap) */
     allowNetwork?: boolean;
     logger?: Logger;
+    /** Windows: prefer Git Bash over PowerShell (default: true) */
+    preferGitBash?: boolean;
 }
 
 export interface OsSandboxResult {
@@ -89,14 +92,14 @@ export class OsSandboxExecutor {
     }
 
     async execute(command: string, opts: OsSandboxOptions = {}): Promise<OsSandboxResult> {
-        const { cwd = process.cwd(), timeout = 30000, allowNetwork = false } = opts;
+        const { cwd = process.cwd(), timeout = 30000, allowNetwork = false, preferGitBash = true } = opts;
 
         if (this.os === 'darwin') {
             return this.execMacOS(command, cwd, timeout);
         }
 
         if (this.os === 'win32') {
-            return this.execWindows(command, cwd, timeout);
+            return this.execWindows(command, cwd, timeout, preferGitBash);
         }
 
         if (this.os === 'linux') {
@@ -129,7 +132,18 @@ export class OsSandboxExecutor {
         return this.spawnWrapped('bwrap', buildBwrapArgs(command, cwd, allowNetwork), cwd, timeout, 'bwrap');
     }
 
-    private async execWindows(command: string, cwd: string, timeout: number): Promise<OsSandboxResult> {
+    private async execWindows(command: string, cwd: string, timeout: number, preferGitBash = true): Promise<OsSandboxResult> {
+        // Prefer Git Bash for bash-syntax compatibility (mirrors Claude Code's approach)
+        if (preferGitBash) {
+            const bashPath = findGitBash();
+            if (bashPath) {
+                this.logger?.info(`[OsSandbox] Windows Git Bash: ${command}`);
+                return this.spawnWrapped(bashPath, ['-c', command], cwd, timeout, 'windows-restricted');
+            }
+            this.logger?.warn('[OsSandbox] Git Bash not found, falling back to PowerShell');
+        }
+
+        // Fallback: restricted PowerShell
         this.logger?.info(`[OsSandbox] Windows restricted PowerShell: ${command}`);
         const args = [
             '-NoProfile',

--- a/src/skills/os-sandbox.ts
+++ b/src/skills/os-sandbox.ts
@@ -141,6 +141,10 @@ export class OsSandboxExecutor {
     }
 
     private async execDirect(command: string, cwd: string, timeout: number): Promise<OsSandboxResult> {
+        // Use platform-appropriate shell to avoid ENOENT on Windows
+        if (this.os === 'win32') {
+            return this.spawnWrapped('cmd.exe', ['/c', command], cwd, timeout, 'none');
+        }
         return this.spawnWrapped('/bin/sh', ['-c', command], cwd, timeout, 'none');
     }
 
@@ -186,10 +190,15 @@ export class OsSandboxExecutor {
 
             child.on('error', (err: NodeJS.ErrnoException) => {
                 clearTimeout(timer);
-                // If sandbox binary not found, fall back to direct
+                // If sandbox binary not found, fall back to direct execution
                 if (err.code === 'ENOENT' && sandboxMode !== 'none') {
-                    this.logger?.warn(`[OsSandbox] ${sandboxMode} not found, falling back to direct`);
-                    this.execDirect(args[args.length - 1] ?? '', cwd, timeout).then(resolve);
+                    this.logger?.warn(`[OsSandbox] ${bin} not found (${sandboxMode}), falling back to direct`);
+                    // Extract the actual user command from the sandbox args:
+                    // - sandbox-exec: [..., '/bin/sh', '-c', <command>] → last arg
+                    // - bwrap:        [..., '--', '/bin/sh', '-c', <command>] → last arg
+                    // - powershell:   [..., '-Command', <command>] → last arg
+                    const userCommand = args[args.length - 1] ?? '';
+                    this.execDirect(userCommand, cwd, timeout).then(resolve);
                 } else {
                     resolve({
                         stdout: '',

--- a/src/skills/utils.ts
+++ b/src/skills/utils.ts
@@ -1,6 +1,7 @@
 import { platform, homedir } from 'os';
-import { resolve, join } from 'path';
-import { spawn } from 'child_process';
+import { resolve, join, dirname } from 'path';
+import { spawn, execFileSync } from 'child_process';
+import { existsSync } from 'fs';
 
 /**
  * 统一路径展开：处理 ~ 和 undefined 防御
@@ -18,6 +19,74 @@ export function expandPath(p: unknown): string {
  */
 export function resolveCliCommand(name: string): string {
     return platform() === 'win32' ? `${name}.cmd` : name;
+}
+
+// 模块级缓存，整个进程生命周期内只探测一次
+let _gitBashCache: string | null | undefined = undefined;
+
+/**
+ * Windows 专用：查找 Git Bash (bash.exe) 可执行文件路径
+ * 参照 Claude Code 官方的 CLAUDE_CODE_GIT_BASH_PATH 机制。
+ *
+ * 优先级：
+ *   1. 环境变量 CMASTER_GIT_BASH_PATH（用户显式指定）
+ *   2. 从 `git` 命令路径推断（git.exe → ../../bin/bash.exe）
+ *   3. 常见安装路径 fallback
+ *   4. 返回 null（由调用方决定降级策略）
+ *
+ * 非 Windows 平台直接返回 null。结果被模块级缓存，只探测一次。
+ */
+export function findGitBash(): string | null {
+    if (platform() !== 'win32') return null;
+    if (_gitBashCache !== undefined) return _gitBashCache;
+
+    // 1. 用户显式环境变量覆盖
+    const envPath = process.env['CMASTER_GIT_BASH_PATH'];
+    if (envPath) {
+        if (existsSync(envPath)) {
+            _gitBashCache = envPath;
+            return _gitBashCache;
+        }
+        // 明确指定但不存在，警告并继续探测
+    }
+
+    // 2. 从 git 命令位置推断 bash.exe
+    //    git 路径通常是: C:\Program Files\Git\cmd\git.exe
+    //    bash.exe 路径:  C:\Program Files\Git\bin\bash.exe
+    try {
+        const gitRaw = execFileSync('where', ['git'], {
+            encoding: 'utf-8',
+            timeout: 3000,
+            windowsHide: true,
+        });
+        const gitPath = gitRaw.split('\n')[0]?.trim();
+        if (gitPath) {
+            const bashPath = resolve(join(dirname(gitPath), '..', 'bin', 'bash.exe'));
+            if (existsSync(bashPath)) {
+                _gitBashCache = bashPath;
+                return _gitBashCache;
+            }
+        }
+    } catch {
+        // where 命令失败：git 未安装或不在 PATH，继续 fallback
+    }
+
+    // 3. 常见安装路径 fallback
+    const candidates = [
+        'C:\\Program Files\\Git\\bin\\bash.exe',
+        'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+        'C:\\Git\\bin\\bash.exe',
+    ];
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) {
+            _gitBashCache = candidate;
+            return _gitBashCache;
+        }
+    }
+
+    // 4. 未找到
+    _gitBashCache = null;
+    return null;
 }
 
 /**

--- a/src/skills/utils.ts
+++ b/src/skills/utils.ts
@@ -42,12 +42,8 @@ export function findGitBash(): string | null {
 
     // 1. 用户显式环境变量覆盖
     const envPath = process.env['CMASTER_GIT_BASH_PATH'];
-    if (envPath) {
-        if (existsSync(envPath)) {
-            _gitBashCache = envPath;
-            return _gitBashCache;
-        }
-        // 明确指定但不存在，警告并继续探测
+    if (envPath && existsSync(envPath)) {
+        return (_gitBashCache = envPath);
     }
 
     // 2. 从 git 命令位置推断 bash.exe
@@ -63,8 +59,7 @@ export function findGitBash(): string | null {
         if (gitPath) {
             const bashPath = resolve(join(dirname(gitPath), '..', 'bin', 'bash.exe'));
             if (existsSync(bashPath)) {
-                _gitBashCache = bashPath;
-                return _gitBashCache;
+                return (_gitBashCache = bashPath);
             }
         }
     } catch {
@@ -79,14 +74,11 @@ export function findGitBash(): string | null {
     ];
     for (const candidate of candidates) {
         if (existsSync(candidate)) {
-            _gitBashCache = candidate;
-            return _gitBashCache;
+            return (_gitBashCache = candidate);
         }
     }
 
-    // 4. 未找到
-    _gitBashCache = null;
-    return null;
+    return (_gitBashCache = null);
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,7 @@ export interface Config {
         autoLoad: boolean;
         directories: string[];
         shell?: {
+            preferGitBash?: boolean;
             sandbox?: {
                 enabled: boolean;
                 mode: 'blocklist' | 'allowlist';


### PR DESCRIPTION
## 问题

在 Windows 操作系统中执行命令时出现兼容性错误，同时与 Claude Code 官方的执行模式不一致（Claude Code 强制要求 Git Bash）。

## 修复内容

### PR #14 第一批修复（commit 764149c）
1. `os-sandbox.ts` execDirect() 硬编码 `/bin/sh` → Windows 改用 `cmd.exe`
2. powershell.exe ENOENT fallback 死循环修复
3. `execute_background` 使用 `powershell.exe` + `windowsHide`
4. `.exe` 自动补全扩展覆盖 `pip/pip3`

### PR #14 第二批修复（commit 19ed51f）— 参照 Claude Code 官方模式
5. `src/skills/utils.ts`：新增 `findGitBash()` 探测函数（模块级缓存）
   - 优先读取 `CMASTER_GIT_BASH_PATH` 环境变量
   - 从 `git` 命令路径推断 bash.exe 位置
   - fallback 常见安装路径
6. `src/skills/os-sandbox.ts`：`execWindows()` 支持 Git Bash 优先执行
7. `skills/built-in/shell/index.ts`：execute/execute_background 读取配置动态选 Shell
8. `src/types.ts`：`Config.skills.shell` 新增 `preferGitBash?: boolean`
9. `config/default.yaml`：`preferGitBash: true`（默认开启）

## Windows Shell 执行优先级

```
Git Bash 可用 (preferGitBash=true) → bash.exe -c "command"
Git Bash 不可用 → PowerShell -ExecutionPolicy Restricted -Command
两者均失败 → cmd.exe /c（最终降级）
```

## 配置

```yaml
# config/default.yaml
skills:
  shell:
    preferGitBash: true  # 关闭则始终用 PowerShell
```

或设置环境变量：
```
CMASTER_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe
```

## 验证

- ✅ TypeScript 类型检查：0 错误
- ✅ 测试：118/118 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)