### PR TITLE
fix: Windows compatibility follow-up (binExists/kill/join import)

### DIFF
--- a/skills/built-in/database-connector/index.ts
+++ b/skills/built-in/database-connector/index.ts
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
 import type { SkillContext } from '../../../src/types.js';
 import { expandPath } from '../../../src/skills/utils.js';
 

--- a/src/core/skill-generator.ts
+++ b/src/core/skill-generator.ts
@@ -66,7 +66,7 @@ export class SkillGenerator {
     private logger: Logger;
     private skillsDir: string;
 
-    constructor(llm: LLMAdapter, logger: Logger, skillsDir = 'skills/local') {
+    constructor(llm: LLMAdapter, logger: Logger, skillsDir = join('skills', 'local')) {
         this.llm = llm;
         this.logger = logger;
         this.skillsDir = skillsDir;

--- a/src/skills/os-sandbox.ts
+++ b/src/skills/os-sandbox.ts
@@ -37,11 +37,12 @@ const MACOS_PROFILE = `
 `.trim();
 
 /**
- * Check if a binary exists on PATH.
+ * Check if a binary exists on PATH (cross-platform: where on Windows, which on Unix).
  */
 async function binExists(name: string): Promise<boolean> {
     return new Promise(resolve => {
-        const p = spawn('which', [name], { stdio: 'ignore' });
+        const cmd = platform() === 'win32' ? 'where' : 'which';
+        const p = spawn(cmd, [name], { stdio: 'ignore' });
         p.on('close', code => resolve(code === 0));
         p.on('error', () => resolve(false));
     });
@@ -183,7 +184,7 @@ export class OsSandboxExecutor {
             child.stderr?.on('data', (d: Buffer) => stderrChunks.push(d));
 
             const timer = setTimeout(() => {
-                child.kill('SIGKILL');
+                child.kill();
                 resolve({
                     stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
                     stderr: `Command timed out after ${timeout / 1000}s`,


### PR DESCRIPTION
## 问题

在 PR #14 合并后，继续全面扫描 Windows 兼容性问题的结果。

## 修复内容

### 🔴 高优先级：所有平台运行时崩溃

**`skills/built-in/database-connector/index.ts`**
- 缺少 `import { join } from 'path'`，但代码使用了 `join()`
- 导致 `ReferenceError: join is not defined`（所有平台）

### 🟡 中优先级：Windows 不兼容

**`src/skills/os-sandbox.ts` — `binExists()`**
- `spawn('which', ...)` 是 Unix 专用，Windows 无此命令
- 修复：Windows 用 `where`，Unix 用 `which`

**`src/skills/os-sandbox.ts` — timeout kill**
- `child.kill('SIGKILL')` 在 Windows 上抛出异常（不支持 POSIX 信号名）
- 修复：改为 `child.kill()`（跨平台，Windows 自动 TerminateProcess）

**`src/core/skill-generator.ts` — Skill 生成默认路径**
- 默认参数 `skillsDir = 'skills/local'` 使用硬编码 `/` 分隔符
- Windows 上路径分隔符为 `\`，可能导致路径解析错误
- 修复：改为 `join('skills', 'local')`

## 扫描结论

其他相关文件已正确处理 Windows 兼容性：
- `src/skills/loader.ts`：正确使用 `pathToFileURL()` 处理动态 import 路径
- `src/skills/registry.ts`：路径处理正确
- `gemini-cli`、`claude-code`、`browser-automation` 等技能：均无问题

## 验证

- ✅ TypeScript 类型检查：0 错误
- ✅ 测试：118/118 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)