### PR TITLE
feat(phase24): Meta-Harness — Brain/Hands/Session 解耦

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -766,38 +766,61 @@ export class Agent {
                     const duration = Date.now() - toolStartTimes[i];
 
                     if (result.status === 'fulfilled') {
-                        const resultStr = typeof result.value === 'string'
-                            ? result.value
-                            : JSON.stringify(result.value, null, 2);
+                        const toolResult = result.value; // ToolResult
 
-                        // Phase 21: 结束工具 span
-                        spanRecorder.endSpan(toolSpanIds[i], resultStr.slice(0, 300));
+                        if (toolResult.kind === 'ok') {
+                            const resultStr = toolResult.value;
 
-                        yield {
-                            type: 'observation',
-                            content: resultStr,
-                            toolName,
-                            toolOutput: result.value,
-                            duration,
-                            timestamp: new Date(),
-                        };
-                        // Emit dedicated workflow_generated step so frontend can render the workflow card
-                        if (result.value && typeof result.value === 'object' && (result.value as any).type === 'workflow_generated') {
-                            const wf = result.value as any;
+                            // Phase 21: 结束工具 span
+                            spanRecorder.endSpan(toolSpanIds[i], resultStr.slice(0, 300));
+
+                            // 尝试解析 JSON 以供 toolOutput
+                            let parsedOutput: unknown = resultStr;
+                            try { parsedOutput = JSON.parse(resultStr); } catch { /* keep string */ }
+
                             yield {
-                                type: 'workflow_generated',
+                                type: 'observation',
                                 content: resultStr,
                                 toolName,
-                                workflow: wf.workflow,
-                                subWorkflows: wf.subWorkflows,
-                                validation: wf.validation,
-                                allValid: wf.allValid,
-                                explanation: wf.explanation,
+                                toolOutput: parsedOutput,
+                                duration,
                                 timestamp: new Date(),
-                            } as any;
+                            };
+                            // Emit dedicated workflow_generated step so frontend can render the workflow card
+                            if (parsedOutput && typeof parsedOutput === 'object' && (parsedOutput as any).type === 'workflow_generated') {
+                                const wf = parsedOutput as any;
+                                yield {
+                                    type: 'workflow_generated',
+                                    content: resultStr,
+                                    toolName,
+                                    workflow: wf.workflow,
+                                    subWorkflows: wf.subWorkflows,
+                                    validation: wf.validation,
+                                    allValid: wf.allValid,
+                                    explanation: wf.explanation,
+                                    timestamp: new Date(),
+                                } as any;
+                            }
+                            messages.push({ role: 'tool', content: resultStr, toolCallId: toolCall.id });
+                        } else {
+                            // ToolResult.error — Hands 层统一错误，交还给 Brain 决策
+                            const errorMsg = `Error: ${toolResult.message}`;
+
+                            // Phase 21: 结束工具 span（失败）
+                            spanRecorder.endSpan(toolSpanIds[i], undefined, errorMsg);
+
+                            yield {
+                                type: 'observation',
+                                content: errorMsg,
+                                toolName,
+                                toolOutput: { error: toolResult.message, retryable: toolResult.retryable },
+                                duration,
+                                timestamp: new Date(),
+                            };
+                            messages.push({ role: 'tool', content: errorMsg, toolCallId: toolCall.id });
                         }
-                        messages.push({ role: 'tool', content: resultStr, toolCallId: toolCall.id });
                     } else {
+                        // executeWithTimeout 超时抛出
                         const errorMsg = `Error: ${result.reason?.message || 'Unknown error'}`;
 
                         // Phase 21: 结束工具 span（失败）

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -291,6 +291,21 @@ export function initDatabase(): DatabaseSync {
         CREATE INDEX IF NOT EXISTS idx_spans_session ON agent_spans(session_id);
     `);
 
+    // Phase 24: session_events — Meta-Harness append-only event log
+    // Session 层独立于 Harness 进程，支持 wake(sessionId) 恢复
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS session_events (
+            id          TEXT PRIMARY KEY,
+            session_id  TEXT NOT NULL,
+            timestamp   INTEGER NOT NULL,
+            type        TEXT NOT NULL,
+            payload     TEXT NOT NULL DEFAULT '{}',
+            caused_by   TEXT REFERENCES session_events(id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_se_session ON session_events(session_id, timestamp);
+        CREATE INDEX IF NOT EXISTS idx_se_type    ON session_events(type);
+    `);
+
     // Auto-migration for existing databases
     try {
         db.prepare('ALTER TABLE sessions ADD COLUMN is_pinned BOOLEAN DEFAULT 0').run();

--- a/src/core/harness/agent-harness.ts
+++ b/src/core/harness/agent-harness.ts
@@ -50,6 +50,8 @@ export class AgentHarness {
     private agent: Agent;
     private grader: Grader;
     private hookRunner: HookRunner;
+    /** 可选的事件发射回调（由 AgentPool 注入，写入 SessionEventStore） */
+    private _emitEvent?: (type: string, payload: Record<string, unknown>, causedBy?: string) => string;
 
     constructor(
         readonly spec: AgentSpec,
@@ -58,8 +60,10 @@ export class AgentHarness {
         private logger: Logger,
         longTermMemory?: LongTermMemory,
         memoryRouter?: MemoryRouter,
-        private pauseSignal?: { paused: boolean }
+        private pauseSignal?: { paused: boolean },
+        emitEvent?: (type: string, payload: Record<string, unknown>, causedBy?: string) => string
     ) {
+        this._emitEvent = emitEvent;
         this.instanceId = nanoid(12);
 
         // 构建权限过滤视图
@@ -130,6 +134,16 @@ export class AgentHarness {
         this.state = 'running';
         this.startedAt = new Date();
 
+        // 发射 session_start 事件（best-effort，不阻断执行）
+        this.emit('session_start', {
+            specId: this.spec.id,
+            specName: this.spec.name,
+            instanceId: this.instanceId,
+            task,
+            userId: context.userId,
+            parentInstanceId: context.parentInstanceId,
+        });
+
         const hookCtx: HookContext = {
             instanceId: this.instanceId,
             specId: this.spec.id,
@@ -180,6 +194,10 @@ export class AgentHarness {
 
                     // onToolCall hooks
                     if (step.type === 'action') {
+                        this.emit('tool_call', {
+                            toolName: step.toolName,
+                            toolInput: step.toolInput,
+                        });
                         const stepCtx = { ...hookCtx, step };
                         try {
                             await this.hookRunner.run(this.spec.hooks.onToolCall ?? [], stepCtx);
@@ -197,6 +215,10 @@ export class AgentHarness {
 
                     // onToolResult hooks
                     if (step.type === 'observation') {
+                        this.emit('tool_result', {
+                            toolName: step.toolName,
+                            content: (step.content ?? '').slice(0, 500),
+                        });
                         await this.hookRunner.run(this.spec.hooks.onToolResult ?? [], { ...hookCtx, step });
                     }
 
@@ -258,12 +280,14 @@ ${failedCriteria ? `各维度具体问题：\n${failedCriteria}` : ''}`;
 
             this.state = 'completed';
             this.completedAt = new Date();
+            this.emit('session_end', { status: 'completed', instanceId: this.instanceId });
             await this.hookRunner.run(this.spec.hooks.onComplete ?? [], hookCtx);
 
         } catch (err) {
             this.state = 'failed';
             this.completedAt = new Date();
             this.error = (err as Error).message;
+            this.emit('session_end', { status: 'failed', error: this.error, instanceId: this.instanceId });
             await this.hookRunner.run(this.spec.hooks.onError ?? [], { ...hookCtx, error: err as Error });
             throw err;
         }
@@ -272,6 +296,18 @@ ${failedCriteria ? `各维度具体问题：\n${failedCriteria}` : ''}`;
     // ─────────────────────────────────────────────────
     // 工具方法
     // ─────────────────────────────────────────────────
+
+    /**
+     * 向 SessionEventStore 发射事件（best-effort，DB 失败不影响执行）
+     */
+    private emit(type: string, payload: Record<string, unknown>, causedBy?: string): string {
+        if (!this._emitEvent) return '';
+        try {
+            return this._emitEvent(type, payload, causedBy);
+        } catch {
+            return '';
+        }
+    }
 
     private makeStep(type: ExecutionStep['type'], content: string): ExecutionStep {
         return { type, content, timestamp: new Date() };

--- a/src/core/harness/agent-pool.ts
+++ b/src/core/harness/agent-pool.ts
@@ -1,21 +1,26 @@
 /**
  * AgentPool — Agent 实例池
  * Phase 23: Managed Agents Harness
+ * Phase 24: Session 持久化 + Wake 协议
  *
  * 管理 AgentSpec 注册和 AgentHarness 实例的完整生命周期：
  * - 并发控制（per-spec concurrency limit）
  * - 排队（超过并发上限时入队）
- * - 实例 CRUD 及步骤缓存
+ * - 实例 CRUD 及步骤缓存（内存 + SQLite 双写）
+ * - Wake 协议：任意实例崩溃后可从 session_events 恢复
  * - 自动 cleanup（超过阈值时回收已完成实例）
  */
 
 import { AgentHarness, type HarnessExecutionContext } from './agent-harness.js';
 import { defaultAgentSpec, type AgentSpec, type AgentInstanceInfo, type AgentLifecycleState } from './agent-spec.js';
 import { agentBus } from './agent-bus.js';
+import { SessionEventStore } from './session-store.js';
 import type { LLMAdapter, Logger, ExecutionStep } from '../../types.js';
 import type { SkillRegistry } from '../../skills/registry.js';
 import type { LongTermMemory } from '../../memory/long-term.js';
 import type { MemoryRouter } from '../../memory/memory-router.js';
+
+export { SessionEventStore };
 
 interface QueueItem {
     specId: string;
@@ -37,7 +42,8 @@ export class AgentPool {
         private baseRegistry: SkillRegistry,
         private logger: Logger,
         private longTermMemory?: LongTermMemory,
-        private memoryRouter?: MemoryRouter
+        private memoryRouter?: MemoryRouter,
+        private sessionStore?: SessionEventStore
     ) {}
 
     // ─────────────────────────────────────────────────
@@ -109,13 +115,29 @@ export class AgentPool {
     }
 
     private createInstance(spec: AgentSpec, task: string, context: HarnessExecutionContext): string {
+        // 构建 emitEvent 回调，绑定到当前 session
+        const sessionId = context.sessionId;
+        const emitEvent = this.sessionStore
+            ? (type: string, payload: Record<string, unknown>, causedBy?: string) => {
+                return this.sessionStore!.append({
+                    sessionId,
+                    timestamp: Date.now(),
+                    type: type as any,
+                    payload,
+                    causedBy,
+                });
+            }
+            : undefined;
+
         const harness = new AgentHarness(
             spec,
             this.getLLM,
             this.baseRegistry,
             this.logger,
             this.longTermMemory,
-            this.memoryRouter
+            this.memoryRouter,
+            undefined,
+            emitEvent
         );
 
         this.instances.set(harness.instanceId, harness);
@@ -285,5 +307,81 @@ export class AgentPool {
             this.instances.delete(id);
             this.steps.delete(id);
         }
+    }
+
+    // ─────────────────────────────────────────────────
+    // Wake 协议（Phase 24）
+    // ─────────────────────────────────────────────────
+
+    /**
+     * 从 session_events 日志恢复一个未完成的 Agent 实例。
+     * 重建执行上下文，提取原始 task 和 specId，重新 spawn。
+     */
+    async wake(sessionId: string): Promise<string | null> {
+        if (!this.sessionStore) return null;
+
+        const events = this.sessionStore.getEvents(sessionId);
+        const startEvent = events.find(e => e.type === 'session_start');
+        if (!startEvent) {
+            this.logger.warn(`[agent-pool] wake(${sessionId}): no session_start event found`);
+            return null;
+        }
+
+        const { specId, task, userId } = startEvent.payload as {
+            specId: string;
+            task: string;
+            userId?: string;
+        };
+
+        const spec = this.specs.get(specId);
+        if (!spec) {
+            this.logger.warn(`[agent-pool] wake(${sessionId}): spec "${specId}" not found, skipping`);
+            return null;
+        }
+
+        this.logger.info(`[agent-pool] Waking session ${sessionId} (spec=${specId})`);
+
+        // 写入 harness_wake 事件
+        this.sessionStore.append({
+            sessionId,
+            timestamp: Date.now(),
+            type: 'harness_wake',
+            payload: { specId, reason: 'startup_scan' },
+        });
+
+        return this.spawn(specId, task as string, {
+            sessionId,
+            userId: userId as string | undefined,
+            memory: {
+                get: async () => undefined,
+                set: async () => {},
+                search: async () => [],
+            },
+        });
+    }
+
+    /**
+     * 启动时扫描所有未完成 session 并自动 wake。
+     * 由 index.ts 在服务启动后调用。
+     */
+    async scanAndWake(): Promise<void> {
+        if (!this.sessionStore) return;
+
+        const unfinished = this.sessionStore.getUnfinished();
+        if (unfinished.length === 0) return;
+
+        this.logger.info(`[agent-pool] Found ${unfinished.length} unfinished session(s), attempting wake...`);
+        for (const sessionId of unfinished) {
+            await this.wake(sessionId).catch(err => {
+                this.logger.warn(`[agent-pool] wake(${sessionId}) failed: ${(err as Error).message}`);
+            });
+        }
+    }
+
+    /**
+     * 获取 sessionId 对应的持久化事件（跨重启可查询）
+     */
+    getSessionEvents(sessionId: string) {
+        return this.sessionStore?.getEvents(sessionId) ?? [];
     }
 }

--- a/src/core/harness/session-store.ts
+++ b/src/core/harness/session-store.ts
@@ -1,0 +1,83 @@
+/**
+ * SessionEventStore — Meta-Harness Session 持久层
+ * Phase 24: Brain/Hands/Session 三者解耦
+ *
+ * Session 作为 append-only 事件日志，生命周期独立于 Harness 进程。
+ * Harness 崩溃后，任意新实例可通过 wake(sessionId) 从最后事件恢复。
+ */
+
+import type { DatabaseSync } from 'node:sqlite';
+import { nanoid } from 'nanoid';
+import type { SessionEvent, SessionEventType } from '../../types.js';
+
+export type { SessionEvent };
+
+export class SessionEventStore {
+    private stmtAppend: ReturnType<DatabaseSync['prepare']>;
+    private stmtGetBySession: ReturnType<DatabaseSync['prepare']>;
+    private stmtGetUnfinished: ReturnType<DatabaseSync['prepare']>;
+
+    constructor(private db: DatabaseSync) {
+        this.stmtAppend = db.prepare(`
+            INSERT INTO session_events (id, session_id, timestamp, type, payload, caused_by)
+            VALUES (?, ?, ?, ?, ?, ?)
+        `);
+        this.stmtGetBySession = db.prepare(`
+            SELECT * FROM session_events WHERE session_id = ? ORDER BY timestamp ASC
+        `);
+        // 有 session_start 但无 session_end 的 sessionId
+        this.stmtGetUnfinished = db.prepare(`
+            SELECT DISTINCT session_id FROM session_events
+            WHERE type = 'session_start'
+              AND session_id NOT IN (
+                  SELECT session_id FROM session_events WHERE type = 'session_end'
+              )
+        `);
+    }
+
+    /**
+     * 追加一条事件，返回生成的事件 ID
+     */
+    append(event: Omit<SessionEvent, 'id'>): string {
+        const id = nanoid(16);
+        this.stmtAppend.run(
+            id,
+            event.sessionId,
+            event.timestamp,
+            event.type,
+            JSON.stringify(event.payload),
+            event.causedBy ?? null
+        );
+        return id;
+    }
+
+    /**
+     * 获取某 sessionId 的全部事件（按时间升序）
+     */
+    getEvents(sessionId: string): SessionEvent[] {
+        const rows = this.stmtGetBySession.all(sessionId) as Array<{
+            id: string;
+            session_id: string;
+            timestamp: number;
+            type: string;
+            payload: string;
+            caused_by: string | null;
+        }>;
+        return rows.map(r => ({
+            id: r.id,
+            sessionId: r.session_id,
+            timestamp: r.timestamp,
+            type: r.type as SessionEventType,
+            payload: JSON.parse(r.payload),
+            causedBy: r.caused_by ?? undefined,
+        }));
+    }
+
+    /**
+     * 返回所有"已开始但未结束"的 sessionId（供启动时 wake 扫描）
+     */
+    getUnfinished(): string[] {
+        const rows = this.stmtGetUnfinished.all() as Array<{ session_id: string }>;
+        return rows.map(r => r.session_id);
+    }
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1859,6 +1859,12 @@ export class GatewayServer {
             return { steps };
         });
 
+        // GET /api/agents/sessions/:id/events — 获取 Session 持久化事件日志（Phase 24）
+        this.app.get<{ Params: { id: string } }>('/api/agents/sessions/:id/events', async (request, reply) => {
+            const events = pool.getSessionEvents(request.params.id);
+            return { sessionId: request.params.id, events };
+        });
+
         this.logger.info('[harness] Managed Agents API routes registered (/api/agents/*)');
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { ConnectorManager } from './skills/connector-source.js';
 import { SelfImprovementEngine } from './core/self-improvement.js';
 import { initMemoryRouter } from './memory/memory-router.js';
 import { SoulLoader } from './core/soul-loader.js';
-import { AgentPool } from './core/harness/agent-pool.js';
+import { AgentPool, SessionEventStore } from './core/harness/agent-pool.js';
 
 async function main() {
     console.log(`
@@ -122,6 +122,9 @@ async function main() {
         knowledgeGraph,
     });
 
+    // Phase 24: SessionEventStore — Session 持久层（Meta-Harness Brain/Hands/Session 解耦）
+    const sessionStore = new SessionEventStore(db);
+
     // Phase 23: 初始化 AgentPool（Managed Agents Harness）
     const agentPool = new AgentPool(
         (provider?: string) => {
@@ -132,13 +135,17 @@ async function main() {
         skillRegistry,
         logger,
         longTermMemory,
-        memoryRouter
+        memoryRouter,
+        sessionStore
     );
 
     // Phase 23: 加载 SOUL.md Agent 规格（新格式 + 兼容旧格式）
     const soulLoader = new SoulLoader(agentPool, logger);
     await soulLoader.loadAgents(path.join(process.cwd(), 'agents'));
     await soulLoader.loadAgents(path.join(process.cwd(), 'agents/builtin'));
+
+    // Phase 24: 启动时扫描未完成 session，自动 wake（Harness as Cattle）
+    await agentPool.scanAndWake();
 
     const scheduler = new SchedulerService(logger);
 

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { glob } from 'glob';
 import matter from 'gray-matter';
-import type { Skill, SkillMetadata, SkillAction, SkillContext, SkillSource, ToolDefinition, Logger } from '../types.js';
+import type { Skill, SkillMetadata, SkillAction, SkillContext, SkillSource, ToolDefinition, Logger, ToolResult } from '../types.js';
 import { deepRedact } from '../utils/secret-ref.js';
 
 /**
@@ -126,7 +126,8 @@ interface PermissionsConfig {
  */
 export interface ISkillRegistry {
     getToolDefinitions(): Promise<ToolDefinition[]>;
-    executeAction(toolName: string, params: Record<string, unknown>, context: SkillContext): Promise<unknown>;
+    /** 执行工具调用。失败一律返回 ToolResult.error，不抛异常（Brain/Hands 边界）*/
+    executeAction(toolName: string, params: Record<string, unknown>, context: SkillContext): Promise<ToolResult>;
     getAllSources(): SkillSource[];
     registerSource(source: SkillSource): Promise<void>;
     unregisterSource(name: string): Promise<void>;
@@ -230,28 +231,38 @@ export class SkillRegistry implements ISkillRegistry {
         toolName: string,
         params: Record<string, unknown>,
         context: SkillContext
-    ): Promise<unknown> {
-        // Permission check
-        this.checkPermission(toolName, context);
+    ): Promise<ToolResult> {
+        try {
+            // Permission check（权限拒绝不可重试）
+            this.checkPermission(toolName, context);
 
-        for (const source of this.sources.values()) {
-            let tools: ToolDefinition[];
-            try {
-                tools = await source.getTools();
-            } catch (error) {
-                this.logger.warn(`Error getting tools from source ${source.name}: ${error}`);
-                continue;
+            for (const source of this.sources.values()) {
+                let tools: ToolDefinition[];
+                try {
+                    tools = await source.getTools();
+                } catch (error) {
+                    this.logger.warn(`Error getting tools from source ${source.name}: ${error}`);
+                    continue;
+                }
+
+                const found = tools.find(t => t.function.name === toolName);
+                if (found) {
+                    const rawResult = await source.execute(toolName, params, context);
+                    const redacted = deepRedact(rawResult);
+                    const value = typeof redacted === 'string'
+                        ? redacted
+                        : JSON.stringify(redacted, null, 2);
+                    return { kind: 'ok', value };
+                }
             }
 
-            const found = tools.find(t => t.function.name === toolName);
-            if (found) {
-                // 找到了就直接执行，对结果进行脱敏，执行错误自然传播（不 catch）
-                const rawResult = await source.execute(toolName, params, context);
-                return deepRedact(rawResult);
-            }
+            return { kind: 'error', message: `Tool "${toolName}" not found in any registered source`, retryable: false };
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            // 权限错误/参数错误不可重试；网络/超时类错误可重试
+            const retryable = !(message.includes('Access denied') || message.includes('not found') || message.includes('validation'));
+            return { kind: 'error', message, retryable };
         }
-
-        throw new Error(`Tool "${toolName}" not found in any registered source`);
     }
 
     /**
@@ -338,9 +349,13 @@ export class FilteredSkillRegistry implements ISkillRegistry {
         toolName: string,
         params: Record<string, unknown>,
         context: SkillContext
-    ): Promise<unknown> {
+    ): Promise<ToolResult> {
         if (!this.isAllowed(toolName)) {
-            throw new Error(`[FilteredRegistry] Tool "${toolName}" is not permitted for this agent`);
+            return {
+                kind: 'error',
+                message: `[FilteredRegistry] Tool "${toolName}" is not permitted for this agent`,
+                retryable: false,
+            };
         }
         return this.base.executeAction(toolName, params, context);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,40 @@ export interface ExecutionStep {
     timestamp: Date;
 }
 
+// ============ Meta-Harness Types ============
+
+/**
+ * ToolResult — 统一工具执行结果（不抛异常，错误作为值返回）
+ * Brain/Hands 边界的标准信封：任何 skill 执行失败一律转换为 ToolResult.error
+ */
+export type ToolResult =
+    | { kind: 'ok'; value: string }
+    | { kind: 'error'; message: string; retryable: boolean };
+
+/**
+ * SessionEvent — append-only 会话事件日志条目
+ * Session 层独立于 Harness 进程存活，支持 wake 恢复
+ */
+export type SessionEventType =
+    | 'session_start'
+    | 'session_end'
+    | 'llm_request'
+    | 'llm_response'
+    | 'tool_call'
+    | 'tool_result'
+    | 'tool_error'
+    | 'harness_wake'
+    | 'harness_transform';
+
+export interface SessionEvent {
+    id: string;
+    sessionId: string;
+    timestamp: number;
+    type: SessionEventType;
+    payload: Record<string, unknown>;
+    causedBy?: string;  // parent event id
+}
+
 // ============ Gateway Types ============
 
 export interface ChatRequest {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -132,11 +132,11 @@ describe('SkillRegistry', () => {
             };
 
             const result = await registry.executeAction('shell.execute', { cmd: 'ls' }, ctx);
-            expect(result).toBe('output');
+            expect(result).toEqual({ kind: 'ok', value: 'output' });
             expect(source.execute).toHaveBeenCalledWith('shell.execute', { cmd: 'ls' }, ctx);
         });
 
-        it('should throw for unknown tool', async () => {
+        it('should return ToolResult.error for unknown tool', async () => {
             const ctx: SkillContext = {
                 sessionId: 's1',
                 memory: { get: vi.fn(), set: vi.fn(), search: vi.fn() },
@@ -144,8 +144,9 @@ describe('SkillRegistry', () => {
                 config: {},
             };
 
-            await expect(registry.executeAction('unknown.tool', {}, ctx))
-                .rejects.toThrow('not found');
+            const result = await registry.executeAction('unknown.tool', {}, ctx);
+            expect(result.kind).toBe('error');
+            expect((result as any).message).toContain('not found');
         });
     });
 


### PR DESCRIPTION
## Summary

基于 masterBot v1.1.0-meta-harness-patch.md 方案，实现三个高优先级 Gap：

- **Gap 1 — Session 持久化**：新增 `SessionEventStore`（SQLite append-only 事件日志），`AgentHarness` 在关键节点写入 `session_start / tool_call / tool_result / session_end` 事件，Session 生命周期完全独立于 Harness 进程
- **Gap 2 — 执行边界统一（ToolResult）**：`ISkillRegistry.executeAction` 返回 `ToolResult`（`{ kind: 'ok' | 'error' }`），不再抛异常——Brain 不再感知 Hands 的失败模式，错误作为数据传回 LLM 决策
- **Gap 3 — Wake 协议**：`AgentPool.wake(sessionId)` 从事件日志重建上下文重新 spawn；启动时 `scanAndWake()` 自动恢复未完成 session

## Changed Files

| 文件 | 变更 |
|------|------|
| `src/core/harness/session-store.ts` | **新建** — SessionEventStore |
| `src/core/database.ts` | session_events 表 |
| `src/types.ts` | SessionEvent / ToolResult 类型 |
| `src/core/harness/agent-harness.ts` | emitEvent 注入 |
| `src/core/harness/agent-pool.ts` | store 注入 + wake() + scanAndWake() |
| `src/skills/registry.ts` | executeAction → ToolResult |
| `src/core/agent.ts` | 适配 ToolResult |
| `src/gateway/server.ts` | GET /api/agents/sessions/:id/events |
| `src/index.ts` | SessionEventStore 创建 + scanAndWake |
| `tests/registry.test.ts` | 更新 ToolResult 断言 |

## Test Plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 135/135 passed
- [ ] 启动后端，spawn agent，验证 `GET /api/agents/sessions/:id/events` 返回事件列表
- [ ] 重启后端，确认 wake 扫描日志出现
- [ ] 触发技能错误，确认返回 `{ kind: 'error' }` 而非 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)