### PR TITLE
fix(llm): OpenAIAdapter 自动注入系统代理（https_proxy）

### DIFF
--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -9,6 +9,7 @@ import type {
     LLMConfig,
     ToolDefinition
 } from '../types.js';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 function recordTokenUsage(model: string, usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number } | null | undefined) {
     if (!usage) return;
@@ -32,9 +33,15 @@ export class OpenAIAdapter implements LLMAdapter {
 
     constructor(config: LLMConfig) {
         this.config = config;
+        // Node.js 18+ 内置 fetch 不读取 https_proxy 环境变量，
+        // 当系统配置了代理时（常见于需要科学上网的环境），需手动注入 httpAgent
+        const proxyUrl = process.env.https_proxy || process.env.HTTPS_PROXY
+            || process.env.http_proxy || process.env.HTTP_PROXY;
+        const httpAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
         this.client = new OpenAI({
             apiKey: config.apiKey,
             baseURL: config.baseUrl,
+            ...(httpAgent ? { httpAgent } : {}),
         });
     }
 


### PR DESCRIPTION
## 问题

Node.js 18+ 内置 `fetch`（OpenAI SDK 使用）不读取 `https_proxy`/`HTTPS_PROXY` 环境变量。在需要代理才能访问外网的环境中，`curl` 走代理正常，但 Node.js 发出的请求直连被墙，导致立即返回 `Request was aborted`，API 配置测试失败。

## 修复

在 `OpenAIAdapter` 构造函数中读取标准代理环境变量（`https_proxy`、`HTTPS_PROXY`、`http_proxy`、`HTTP_PROXY`），并通过 `https-proxy-agent` 注入 `httpAgent`，使 OpenAI SDK 走系统代理。

无代理时行为不变。

## 验证

- `npx tsc --noEmit` 0 errors
- 本地代理测试：`/api/config/models/test` 从 `Request was aborted` → 正常返回

🤖 Generated with [Claude Code](https://claude.com/claude-code)