### PR TITLE
feat(harness): v1.1.1 Harness-Chat 桥接与架构补全 (Phase 26-29)

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -226,7 +226,7 @@ const DELEGATE_AGENT_TOOL: ToolDefinition = {
     type: 'function',
     function: {
         name: 'delegate_to_agent',
-        description: 'Delegate a subtask to a specialized worker agent with different skills or LLM.',
+        description: 'Delegate a subtask to a specialized managed agent. The agent runs with its own tool permissions, quality grading, and lifecycle hooks. Available agents: use worker_id matching the agent spec ID.',
         parameters: {
             type: 'object',
             properties: {
@@ -297,6 +297,7 @@ export class Agent {
     private knowledgeGraph?: any;
     private deepThinkingProvider?: () => LLMAdapter;
     private sessionStore?: SessionEventStore;
+    private agentPool?: import('./harness/agent-pool.js').AgentPool;
 
     constructor(options: {
         llm: LLMAdapter | (() => LLMAdapter);
@@ -312,6 +313,7 @@ export class Agent {
         knowledgeGraph?: any;
         deepThinkingProvider?: () => LLMAdapter;
         sessionStore?: SessionEventStore;
+        agentPool?: import('./harness/agent-pool.js').AgentPool;
     }) {
         this.llmGetter = typeof options.llm === 'function' ? options.llm : () => options.llm as LLMAdapter;
         this.skillRegistry = options.skillRegistry;
@@ -325,6 +327,7 @@ export class Agent {
         this.knowledgeGraph = options.knowledgeGraph;
         this.deepThinkingProvider = options.deepThinkingProvider;
         this.sessionStore = options.sessionStore;
+        this.agentPool = options.agentPool;
         this.contextManager = new ContextManager({
             maxTokens: options.maxContextTokens,
             logger: options.logger,
@@ -379,12 +382,36 @@ export class Agent {
             }
         }
 
+        // Phase 26: 注入可用 Harness Agent 列表（供 LLM 决策 delegate）
+        if (this.agentPool) {
+            const specs = this.agentPool.listSpecs();
+            if (specs.length > 0) {
+                const agentListStr = specs
+                    .map(s => `- ${s.id}: ${s.name} — ${s.description.slice(0, 100)}`)
+                    .join('\n');
+                systemContent += `\n\n可用的专业 Agent（通过 delegate_to_agent 工具调用）:\n${agentListStr}`;
+            }
+        }
+
         const systemMessage: Message = { role: 'system', content: systemContent };
         const currentInput: Message[] = [{
             role: 'user',
             content: input,
             attachments: context.attachments
         }];
+
+        // D1: 发射 user_message 事件（仅当 sessionStore 存在时）
+        if (this.sessionStore) {
+            this.sessionStore.append({
+                sessionId: context.sessionId,
+                timestamp: Date.now(),
+                type: 'user_message',
+                payload: {
+                    content: inputText.slice(0, 1000),
+                    userId: context.userId,
+                },
+            });
+        }
 
         // Apply context window management to prevent exceeding LLM context limit
         const trimResult = await this.contextManager.trimMessages(
@@ -463,6 +490,16 @@ export class Agent {
             let fullContent = '';
             let toolCalls: any[] = [];
 
+            // D1: LLM 调用前发射 llm_request 事件
+            if (this.sessionStore) {
+                this.sessionStore.append({
+                    sessionId: context.sessionId,
+                    timestamp: Date.now(),
+                    type: 'llm_request',
+                    payload: { model: this.llm.provider, messageCount: messages.length, iteration },
+                });
+            }
+
             // 调用 LLM (流式获取内容和工具调用)
             try {
                 for await (const chunk of activeLlm.chatStream(messages, { tools, abortSignal: context.abortSignal })) {
@@ -523,6 +560,19 @@ export class Agent {
                 toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
             };
             messages.push(response);
+
+            // D1: LLM 调用后发射 llm_response 事件
+            if (this.sessionStore) {
+                this.sessionStore.append({
+                    sessionId: context.sessionId,
+                    timestamp: Date.now(),
+                    type: 'llm_response',
+                    payload: {
+                        hasToolCalls: !!response.toolCalls?.length,
+                        contentLength: typeof response.content === 'string' ? response.content.length : 0,
+                    },
+                });
+            }
 
             // 如果没有工具调用，返回最终答案
             if (!response.toolCalls || response.toolCalls.length === 0) {
@@ -655,21 +705,55 @@ export class Agent {
                         yield { type: 'observation', content: errorMsg, toolName, timestamp: new Date() };
                         messages.push({ role: 'tool', content: errorMsg, toolCallId: toolCall.id });
                     }
-                } else if (toolName === 'delegate_to_agent' && this.orchestrator) {
+                } else if (toolName === 'delegate_to_agent') {
                     const { worker_id, task } = params as { worker_id: string; task: string; context_summary?: string };
                     yield { type: 'action', content: `Delegating to agent: ${worker_id}`, toolName, toolInput: params, timestamp: new Date() };
-                    // Phase 21: 开 delegate span
+
                     const delegateSpanId = spanRecorder.startSpan(traceId, agentSpanId, `delegate:${worker_id}`, {
                         sessionId: context.sessionId, workerId: worker_id,
                     });
+
                     try {
-                        // Phase 21: 流式委托 — 实时 yield Worker 每个步骤
                         let lastAnswer = '';
-                        const delegateCtx = { ...context, traceId };
-                        for await (const step of this.orchestrator.delegateStream(worker_id, task, delegateCtx)) {
-                            yield step; // 已带 delegatedFrom 标记
-                            if (step.type === 'answer') lastAnswer = step.content;
+
+                        // Phase 26: 优先走 AgentPool（Harness 路径）
+                        if (this.agentPool?.getSpec(worker_id)) {
+                            const childSessionId = `harness-${nanoid(12)}`;
+                            const instanceId = await this.agentPool.spawn(worker_id, task, {
+                                sessionId: childSessionId,
+                                userId: context.userId,
+                                memory: context.memory,
+                                parentInstanceId: traceId,
+                                parentSessionId: context.sessionId,
+                                trigger: 'chat_delegate',
+                            });
+
+                            // 通知前端：子 Agent 已启动
+                            yield {
+                                type: 'meta' as any,
+                                content: `🤖 托管 Agent [${worker_id}] 已启动 (instance: ${instanceId})`,
+                                harnessInstanceId: instanceId,
+                                delegatedFrom: worker_id,
+                                timestamp: new Date(),
+                            };
+
+                            // 流式消费子 Agent 步骤，内联到 Chat SSE 流
+                            for await (const step of this.agentPool.streamInstance(instanceId)) {
+                                yield { ...step, delegatedFrom: worker_id, harnessInstanceId: instanceId };
+                                if (step.type === 'answer') lastAnswer = step.content ?? '';
+                            }
                         }
+                        // 回退旧路径：MultiAgentOrchestrator
+                        else if (this.orchestrator) {
+                            const delegateCtx = { ...context, traceId };
+                            for await (const step of this.orchestrator.delegateStream(worker_id, task, delegateCtx)) {
+                                yield step;
+                                if (step.type === 'answer') lastAnswer = step.content ?? '';
+                            }
+                        } else {
+                            throw new Error(`Agent "${worker_id}" not found in AgentPool or Orchestrator`);
+                        }
+
                         spanRecorder.endSpan(delegateSpanId, lastAnswer.slice(0, 300));
                         messages.push({ role: 'tool', content: lastAnswer || '(no answer)', toolCallId: toolCall.id });
                     } catch (err: any) {

--- a/src/core/harness/agent-bus.ts
+++ b/src/core/harness/agent-bus.ts
@@ -25,7 +25,11 @@ export class AgentBus extends EventEmitter {
     private static instance: AgentBus;
 
     static getInstance(): AgentBus {
-        if (!AgentBus.instance) AgentBus.instance = new AgentBus();
+        if (!AgentBus.instance) {
+            AgentBus.instance = new AgentBus();
+            // D5: 防止大量并发 Agent 实例触发 EventEmitter 内存泄漏警告
+            AgentBus.instance.setMaxListeners(200);
+        }
         return AgentBus.instance;
     }
 

--- a/src/core/harness/agent-harness.ts
+++ b/src/core/harness/agent-harness.ts
@@ -39,6 +39,10 @@ export interface HarnessExecutionContext {
     parentInstanceId?: string;
     /** Opaque session token（由 CredentialVault 生成，注入到 SkillContext）*/
     sessionToken?: string;
+    /** Phase 26: 父 Chat Session 的 sessionId（建立 Chat → Harness 关联）*/
+    parentSessionId?: string;
+    /** Phase 26: 触发来源（区分 Chat 委派 / 手动 / API / 定时 / Wake 恢复）*/
+    trigger?: 'chat_delegate' | 'manual_spawn' | 'api_spawn' | 'scheduled' | 'wake_recovery';
 }
 
 export class AgentHarness {
@@ -153,6 +157,8 @@ export class AgentHarness {
             task,
             userId: context.userId,
             parentInstanceId: context.parentInstanceId,
+            parentSessionId: context.parentSessionId,
+            trigger: context.trigger ?? 'manual_spawn',
         });
 
         const hookCtx: HookContext = {
@@ -274,6 +280,15 @@ export class AgentHarness {
                     timestamp: new Date(),
                 } as ExecutionStep;
 
+                // D6: Grader 评分结果持久化
+                this.emit('grader_evaluation', {
+                    instanceId: this.instanceId,
+                    revision,
+                    overallScore: graderResult.overallScore,
+                    status: graderResult.status,
+                    feedback: graderResult.feedback?.slice(0, 500),
+                });
+
                 if (graderResult.status === 'satisfied') break;
 
                 if (graderResult.status === 'failed' || graderResult.status === 'grader_error') {
@@ -287,6 +302,14 @@ export class AgentHarness {
                     yield this.makeStep('meta', `🔄 已达到最大修订次数 ${maxRevisions}，以当前输出为最终结果`);
                     break;
                 }
+
+                // D6: 修订循环持久化
+                this.emit('grader_revision', {
+                    instanceId: this.instanceId,
+                    fromRevision: revision,
+                    toRevision: revision + 1,
+                    revisedTask: currentTask.slice(0, 500),
+                });
 
                 // needs_revision：注入 Grader 反馈重试
                 const failedCriteria = graderResult.criteriaResults

--- a/src/core/harness/agent-pool.ts
+++ b/src/core/harness/agent-pool.ts
@@ -20,6 +20,7 @@ import type { LLMAdapter, Logger, ExecutionStep } from '../../types.js';
 import type { SkillRegistry } from '../../skills/registry.js';
 import type { LongTermMemory } from '../../memory/long-term.js';
 import type { MemoryRouter } from '../../memory/memory-router.js';
+import type { SessionMemoryManager } from '../../memory/short-term.js';
 
 export { SessionEventStore, CredentialVault };
 
@@ -45,7 +46,8 @@ export class AgentPool {
         private longTermMemory?: LongTermMemory,
         private memoryRouter?: MemoryRouter,
         private sessionStore?: SessionEventStore,
-        private credentialVault?: CredentialVault
+        private credentialVault?: CredentialVault,
+        private sessionMemoryManager?: SessionMemoryManager
     ) {}
 
     // ─────────────────────────────────────────────────
@@ -252,6 +254,7 @@ export class AgentPool {
         let done = false;
 
         const unsubStep = agentBus.subscribe(`agent.step.${instanceId}`, (msg) => {
+            lastActivity = Date.now();
             const step = msg.payload as ExecutionStep;
             if (resolve) { resolve({ value: step, done: false }); resolve = null; }
             else buffer.push(step);
@@ -263,9 +266,20 @@ export class AgentPool {
             unsubStep();
             unsubComplete();
             unsubError();
+            clearInterval(autoCleanupTimer);
             // 通知等待中的 consumer 结束
             if (resolve) { resolve({ value: undefined as any, done: true }); resolve = null; }
         };
+
+        // D5: 10 分钟无新步骤自动 cleanup，防止订阅泄漏
+        const AUTO_CLEANUP_MS = 10 * 60 * 1000;
+        let lastActivity = Date.now();
+        const autoCleanupTimer = setInterval(() => {
+            if (Date.now() - lastActivity > AUTO_CLEANUP_MS) {
+                this.logger.warn(`[agent-pool] subscribeToInstance(${instanceId}) auto-cleanup after inactivity`);
+                cleanup();
+            }
+        }, 30_000);
 
         // 必须先声明再赋值，避免 cleanup 引用未初始化的变量
         let unsubComplete: () => void;
@@ -398,15 +412,17 @@ export class AgentPool {
             },
         });
 
+        // D3: 从 ShortTermMemory 重建 MemoryAccess（若无则创建空实现）
+        const memory = this.sessionMemoryManager
+            ? this.sessionMemoryManager.getSession(sessionId)
+            : { get: async () => undefined, set: async () => {}, search: async () => [] };
+
         return this.spawn(ctx.specId, ctx.originalTask, {
             sessionId,
             userId: ctx.userId,
             history: ctx.resumeHistory,
-            memory: {
-                get: async () => undefined,
-                set: async () => {},
-                search: async () => [],
-            },
+            memory,
+            trigger: 'wake_recovery',
         });
     }
 
@@ -436,5 +452,35 @@ export class AgentPool {
         return selector
             ? this.sessionStore.getEvents(sessionId, selector)
             : this.sessionStore.getEvents(sessionId);
+    }
+
+    // ─────────────────────────────────────────────────
+    // Phase 28: supervisorDelegate LLM 路由（从 MultiAgentOrchestrator 迁移）
+    // ─────────────────────────────────────────────────
+
+    /**
+     * 通过 LLM 为任务选择最合适的 AgentSpec。
+     * 从 MultiAgentOrchestrator.supervisorDelegate() 提取的路由逻辑。
+     */
+    async selectSpec(task: string, llm: LLMAdapter): Promise<string | null> {
+        const specs = this.listSpecs();
+        if (specs.length === 0) return null;
+
+        const descriptions = specs
+            .map(s => `- ${s.id}: ${s.name} — ${s.description.slice(0, 200)}`)
+            .join('\n');
+
+        const prompt = `根据以下可用 Agent 描述，为任务选择最合适的 Agent。
+可用 Agents:\n${descriptions}\n
+任务: ${task.slice(0, 500)}\n
+直接回复 Agent ID（一个词）:`;
+
+        const response = await llm.chat([{ role: 'user', content: prompt }]);
+        const content = typeof response.content === 'string'
+            ? response.content
+            : (response.content as any[]).map(p => (p as any).text ?? '').join('');
+
+        const specId = content.trim().split(/[\s\n]/)[0];
+        return this.getSpec(specId) ? specId : null;
     }
 }

--- a/src/core/harness/credential-vault.ts
+++ b/src/core/harness/credential-vault.ts
@@ -12,7 +12,7 @@
  * 并自动生成审计事件。
  */
 
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
+import { createCipheriv, createDecipheriv, createHmac, randomBytes, scryptSync } from 'crypto';
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
 import type { SessionEventStore } from './session-store.js';
@@ -35,6 +35,8 @@ export class CredentialVault {
     private stmtGet: ReturnType<DatabaseSync['prepare']>;
     private stmtList: ReturnType<DatabaseSync['prepare']>;
     private stmtDelete: ReturnType<DatabaseSync['prepare']>;
+    /** D4: sessionToken → sessionId 映射表，用于 retrieveWithToken() 反查 */
+    private tokenToSession = new Map<string, string>();
 
     constructor(
         private db: DatabaseSync,
@@ -148,12 +150,16 @@ export class CredentialVault {
     // ─────────────────────────────────────────────────
 
     /**
-     * 为 sessionId 生成 opaque sessionToken。
-     * 当前实现：sessionToken = sessionId（已足够隔离，可升级为 HMAC 签名）
+     * D4: 为 sessionId 生成 HMAC-SHA256 签名的 opaque sessionToken。
      * skill 代码只持有 sessionToken，不能访问跨 session 的凭证。
      */
     generateSessionToken(sessionId: string): string {
-        return sessionId;
+        const token = createHmac('sha256', this.key)
+            .update(`session:${sessionId}:${Date.now()}`)
+            .digest('hex')
+            .slice(0, 32);
+        this.tokenToSession.set(token, sessionId);
+        return token;
     }
 
     /**
@@ -161,7 +167,8 @@ export class CredentialVault {
      * 写入 credential_access 审计事件。
      */
     retrieveWithToken(key: string, sessionToken: string): string | null {
-        // 当前 sessionToken = sessionId，直接复用 retrieve
-        return this.retrieve(key, sessionToken);
+        // D4: 通过 HMAC token 反查 sessionId
+        const sessionId = this.tokenToSession.get(sessionToken) ?? sessionToken;
+        return this.retrieve(key, sessionId);
     }
 }

--- a/src/core/harness/session-store.ts
+++ b/src/core/harness/session-store.ts
@@ -109,31 +109,51 @@ export class SessionEventStore {
      */
     getEvents(sessionId: string, selector: EventSelector): SessionEvent[];
     getEvents(sessionId: string, selector?: EventSelector): SessionEvent[] {
-        const rows = this.stmtGetBySession.all(sessionId) as Array<{
-            id: string;
-            session_id: string;
-            timestamp: number;
-            type: string;
-            payload: string;
-            caused_by: string | null;
-        }>;
-
-        let events: SessionEvent[] = rows.map(r => ({
-            id: r.id,
-            sessionId: r.session_id,
-            timestamp: r.timestamp,
-            type: r.type as SessionEventType,
-            payload: JSON.parse(r.payload),
-            causedBy: r.caused_by ?? undefined,
-        }));
-
-        if (!selector) return events;
-
-        // 按类型过滤
-        if (selector.types && selector.types.length > 0) {
-            events = events.filter(e => selector.types!.includes(e.type));
+        if (!selector) {
+            const rows = this.stmtGetBySession.all(sessionId) as Array<{
+                id: string; session_id: string; timestamp: number; type: string; payload: string; caused_by: string | null;
+            }>;
+            return this.parseRows(rows);
         }
-        // 按 toolName 过滤
+
+        // D2: 动态构建 SQL WHERE 子句，将过滤下推到 SQLite 层
+        const conditions: string[] = ['session_id = ?'];
+        const params: unknown[] = [sessionId];
+
+        if (selector.types && selector.types.length > 0) {
+            const placeholders = selector.types.map(() => '?').join(',');
+            conditions.push(`type IN (${placeholders})`);
+            params.push(...selector.types);
+        }
+        if (selector.fromTimestamp !== undefined) {
+            conditions.push('timestamp >= ?');
+            params.push(selector.fromTimestamp);
+        }
+        if (selector.toTimestamp !== undefined) {
+            conditions.push('timestamp <= ?');
+            params.push(selector.toTimestamp);
+        }
+
+        const whereClause = conditions.join(' AND ');
+        let sql: string;
+
+        if (selector.last !== undefined && selector.last > 0) {
+            // 取最后 N 条：先反序取 N 条再正序
+            sql = `SELECT * FROM (
+                SELECT * FROM session_events WHERE ${whereClause}
+                ORDER BY timestamp DESC LIMIT ?
+            ) sub ORDER BY timestamp ASC`;
+            params.push(selector.last);
+        } else {
+            sql = `SELECT * FROM session_events WHERE ${whereClause} ORDER BY timestamp ASC`;
+        }
+
+        const rows = this.db.prepare(sql).all(...(params as import('node:sqlite').SQLInputValue[])) as Array<{
+            id: string; session_id: string; timestamp: number; type: string; payload: string; caused_by: string | null;
+        }>;
+        let events = this.parseRows(rows);
+
+        // toolName 过滤仍需内存处理（payload 内字段，无法 SQL 索引）
         if (selector.toolName) {
             const tn = selector.toolName;
             events = events.filter(e => {
@@ -141,19 +161,21 @@ export class SessionEventStore {
                 return p.toolName === tn;
             });
         }
-        // 时间范围过滤
-        if (selector.fromTimestamp !== undefined) {
-            events = events.filter(e => e.timestamp >= selector.fromTimestamp!);
-        }
-        if (selector.toTimestamp !== undefined) {
-            events = events.filter(e => e.timestamp <= selector.toTimestamp!);
-        }
-        // 取最后 N 条
-        if (selector.last !== undefined && selector.last > 0) {
-            events = events.slice(-selector.last);
-        }
 
         return events;
+    }
+
+    private parseRows(rows: Array<{
+        id: string; session_id: string; timestamp: number; type: string; payload: string; caused_by: string | null;
+    }>): SessionEvent[] {
+        return rows.map(r => ({
+            id: r.id,
+            sessionId: r.session_id,
+            timestamp: r.timestamp,
+            type: r.type as SessionEventType,
+            payload: JSON.parse(r.payload),
+            causedBy: r.caused_by ?? undefined,
+        }));
     }
 
     /**

--- a/src/core/multi-agent.ts
+++ b/src/core/multi-agent.ts
@@ -26,6 +26,11 @@ export interface DelegateContext {
 }
 
 /**
+ * @deprecated Phase 28: MultiAgentOrchestrator 已进入渐进退役阶段。
+ * delegate_to_agent 工具现优先走 AgentPool（Harness 路径），此类仅作回退用。
+ * 新 Worker 请通过 SOUL.md 或 API 注册为 AgentSpec。
+ * 计划在 Phase 30 确认无回退调用后完全移除此文件。
+ *
  * Orchestrator that manages worker agents and delegates tasks
  * Phase 21: added delegateStream + supervisorDelegate
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,28 +109,8 @@ async function main() {
     }
     const { memoryRouter } = await import('./memory/memory-router.js');
 
-    // Initialize agent with dynamic LLM getter for hot-reloading
-    const agent = new Agent({
-        llm: () => {
-            const provider = config.models.default;
-            const llmConfig = config.models.providers[provider];
-            return llmFactory.getAdapter(provider, llmConfig);
-        },
-        skillRegistry,
-        logger,
-        maxIterations: config.agent?.maxIterations ?? 10,
-        maxContextTokens: config.agent?.maxContextTokens,
-        longTermMemory,
-        memoryRouter,
-        skillConfig: {
-            sandbox: config.skills.shell?.sandbox,
-        },
-        skillGenerator,
-        orchestrator,
-        knowledgeGraph,
-    });
-
     // Phase 24: SessionEventStore — Session 持久层（Meta-Harness Brain/Hands/Session 解耦）
+    // 注意：移到 Agent 创建前，确保 sessionStore 可以直接注入 Agent
     const sessionStore = new SessionEventStore(db);
 
     // Phase 25: CredentialVault — 凭证隔离层（Gap 4）
@@ -153,7 +133,9 @@ async function main() {
         longTermMemory,
         memoryRouter,
         sessionStore,
-        credentialVault
+        credentialVault,
+        // D3: 注入 sessionMemoryManager，使 wake 恢复时可访问短期记忆
+        sessionManager
     );
 
     // Phase 23: 加载 SOUL.md Agent 规格（新格式 + 兼容旧格式）
@@ -161,8 +143,47 @@ async function main() {
     await soulLoader.loadAgents(path.join(process.cwd(), 'agents'));
     await soulLoader.loadAgents(path.join(process.cwd(), 'agents/builtin'));
 
+    // Phase 28: 将 MultiAgentOrchestrator 中的旧 Worker 统一注册为 AgentSpec
+    if (typeof orchestrator.hasWorkers === 'function' && orchestrator.hasWorkers()) {
+        for (const worker of orchestrator.listWorkers()) {
+            if (!agentPool.getSpec(worker.id)) {
+                agentPool.registerLegacyWorker(
+                    worker.id,
+                    worker.name,
+                    worker.description ?? '',
+                    worker.systemPrompt,
+                    worker.skills
+                );
+                logger.info(`[startup] Legacy worker "${worker.name}" registered as AgentSpec`);
+            }
+        }
+    }
+
     // Phase 24: 启动时扫描未完成 session，自动 wake（Harness as Cattle）
     await agentPool.scanAndWake();
+
+    // Phase 26: Agent 在 agentPool 创建后初始化，确保 agentPool 和 sessionStore 可直接注入
+    const agent = new Agent({
+        llm: () => {
+            const provider = config.models.default;
+            const llmConfig = config.models.providers[provider];
+            return llmFactory.getAdapter(provider, llmConfig);
+        },
+        skillRegistry,
+        logger,
+        maxIterations: config.agent?.maxIterations ?? 10,
+        maxContextTokens: config.agent?.maxContextTokens,
+        longTermMemory,
+        memoryRouter,
+        skillConfig: {
+            sandbox: config.skills.shell?.sandbox,
+        },
+        skillGenerator,
+        orchestrator,
+        knowledgeGraph,
+        sessionStore,
+        agentPool,
+    });
 
     const scheduler = new SchedulerService(logger);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,8 @@ export interface ExecutionStep {
     spanId?: string;
     // Phase 22: context compression
     droppedCount?: number;
+    // Phase 26: Harness instance tracking（供前端关联子任务面板）
+    harnessInstanceId?: string;
     timestamp: Date;
 }
 
@@ -223,7 +225,10 @@ export type SessionEventType =
     | 'credential_access'   // Gap 4: 凭证访问审计
     | 'permission_check'    // Gap 4: 权限检查审计
     | 'memory_write'        // M3: 记忆写入审计（memory_remember）
-    | 'memory_read';        // M3: 记忆读取审计（memory_recall）
+    | 'memory_read'         // M3: 记忆读取审计（memory_recall）
+    | 'user_message'        // D1: 用户消息记录
+    | 'grader_evaluation'   // D6: Grader 评分结果持久化
+    | 'grader_revision';    // D6: Grader 修订循环持久化
 
 export interface SessionEvent {
     id: string;

--- a/web/src/components/chat-thinking.tsx
+++ b/web/src/components/chat-thinking.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Sparkles, ChevronRight, ListTodo, CheckCircle2, XCircle, Clock, Loader2, BrainCircuit, ChevronDown } from "lucide-react";
+import { Sparkles, ChevronRight, ListTodo, CheckCircle2, XCircle, Clock, Loader2, BrainCircuit, ChevronDown, Bot, ExternalLink, BarChart2 } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
@@ -17,6 +17,16 @@ function isErrorObservation(observation: string): boolean {
     );
 }
 
+export interface SubTaskInfo {
+    delegatedFrom: string;
+    instanceId: string;
+    steps: any[];
+    status: 'running' | 'completed' | 'failed';
+    startTime: Date;
+    endTime?: Date;
+    graderScore?: number;
+}
+
 export interface ChatStep {
     thought?: string;
     plan?: string[]; // Array of plan steps
@@ -24,6 +34,10 @@ export interface ChatStep {
     observation?: string;
     duration?: number;  // ms — tool execution time
     status?: 'pending' | 'running' | 'completed' | 'failed';
+    // Phase 26: 子 Agent 步骤分组（delegatedFrom 标记）
+    subTask?: SubTaskInfo;
+    // Harness Grader 评分
+    grading?: { type: string; content: string };
 }
 
 function ThoughtCard({ thought }: { thought: string }) {
@@ -55,6 +69,97 @@ function ThoughtCard({ thought }: { thought: string }) {
                     )}
                 </div>
             </div>
+        </Card>
+    );
+}
+
+// ─── SubTaskPanel: 子 Agent 执行面板（Phase 26）──────────────────────────────
+
+function SubTaskPanel({ subTask }: { subTask: SubTaskInfo }) {
+    const [collapsed, setCollapsed] = useState(true);
+
+    const actionSteps = subTask.steps.filter((s: any) => s.type === 'action' || s.type === 'observation');
+    const duration = subTask.endTime
+        ? subTask.endTime.getTime() - subTask.startTime.getTime()
+        : null;
+
+    return (
+        <Card className="border border-indigo-200 dark:border-indigo-800/40 bg-indigo-50/30 dark:bg-indigo-950/10 text-xs">
+            <div
+                className="flex items-center gap-2 p-3 cursor-pointer select-none"
+                onClick={() => setCollapsed(v => !v)}
+            >
+                <Bot className="w-3.5 h-3.5 text-indigo-500 shrink-0" />
+                <span className="font-medium text-indigo-700 dark:text-indigo-300">
+                    托管 Agent: {subTask.delegatedFrom}
+                </span>
+                {subTask.status === 'running' && (
+                    <Loader2 className="w-3 h-3 animate-spin text-amber-500" />
+                )}
+                {subTask.status === 'completed' && (
+                    <CheckCircle2 className="w-3 h-3 text-green-500" />
+                )}
+                {subTask.status === 'failed' && (
+                    <XCircle className="w-3 h-3 text-red-500" />
+                )}
+                {subTask.graderScore !== undefined && (
+                    <span className="flex items-center gap-1 text-[10px] text-muted-foreground ml-1">
+                        <BarChart2 className="w-3 h-3" />
+                        质量评分: {subTask.graderScore}/100
+                    </span>
+                )}
+                {duration !== null && (
+                    <span className="text-[10px] text-muted-foreground ml-auto">
+                        {duration >= 1000 ? `${(duration / 1000).toFixed(1)}s` : `${duration}ms`}
+                    </span>
+                )}
+                <a
+                    href="/agents"
+                    className="flex items-center gap-0.5 text-[10px] text-indigo-500 hover:underline ml-1"
+                    onClick={e => e.stopPropagation()}
+                    title="在 /agents 管理台查看详情"
+                >
+                    <ExternalLink className="w-3 h-3" />
+                </a>
+                <ChevronDown className={cn("w-3.5 h-3.5 text-muted-foreground transition-transform", !collapsed && "rotate-180")} />
+            </div>
+
+            <AnimatePresence initial={false}>
+                {!collapsed && (
+                    <motion.div
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.2 }}
+                        className="overflow-hidden"
+                    >
+                        <div className="px-3 pb-3 space-y-1.5 border-t border-indigo-100 dark:border-indigo-900/30 pt-2">
+                            {actionSteps.map((step: any, idx: number) => (
+                                <div key={idx} className="flex items-start gap-2">
+                                    {step.type === 'action' ? (
+                                        <>
+                                            <ChevronRight className="w-3 h-3 text-indigo-400 mt-0.5 shrink-0" />
+                                            <span className="font-mono text-[10px] text-indigo-600 dark:text-indigo-400">
+                                                {step.toolName || step.content}
+                                            </span>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <CheckCircle2 className="w-3 h-3 text-green-500 mt-0.5 shrink-0" />
+                                            <span className="text-muted-foreground text-[10px] line-clamp-2">
+                                                {(step.content ?? '').slice(0, 150)}
+                                            </span>
+                                        </>
+                                    )}
+                                </div>
+                            ))}
+                            {actionSteps.length === 0 && subTask.status === 'running' && (
+                                <span className="text-muted-foreground/60 text-[10px]">Agent 执行中…</span>
+                            )}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
         </Card>
     );
 }
@@ -140,6 +245,33 @@ export function ChatThinking({ steps }: { steps: ChatStep[] }) {
                                                         <span className="text-muted-foreground">{planStep}</span>
                                                     </div>
                                                 ))}
+                                            </div>
+                                        </Card>
+                                    )}
+
+                                    {/* Phase 26: 子 Agent 托管任务面板 */}
+                                    {step.subTask && (
+                                        <SubTaskPanel subTask={step.subTask} />
+                                    )}
+
+                                    {/* Grader 评分步骤 */}
+                                    {step.grading && (
+                                        <Card className="p-2 text-xs bg-amber-50/30 dark:bg-amber-950/10 border border-amber-200 dark:border-amber-800/30">
+                                            <div className="flex items-center gap-1.5 text-amber-600 dark:text-amber-400">
+                                                <BarChart2 className="w-3.5 h-3.5" />
+                                                <span>
+                                                    {step.grading.type === 'grading'
+                                                        ? step.grading.content
+                                                        : (() => {
+                                                            try {
+                                                                const r = JSON.parse(step.grading.content);
+                                                                return `质量评分: ${r.overallScore}/100 — ${r.status}`;
+                                                            } catch {
+                                                                return step.grading.content;
+                                                            }
+                                                        })()
+                                                    }
+                                                </span>
                                             </div>
                                         </Card>
                                     )}

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -162,6 +162,48 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
                     });
                     yield buildYield();
 
+                } else if (chunk.type === "grading" || chunk.type === "grade_result") {
+                    // Harness Grader 评分步骤
+                    currentSteps.push({
+                        grading: {
+                            type: chunk.type,
+                            content: chunk.content,
+                        }
+                    });
+                    yield buildYield();
+
+                } else if (chunk.delegatedFrom && chunk.harnessInstanceId) {
+                    // Phase 26: 带 delegatedFrom 标记的子 Agent 步骤
+                    // 聚合到子任务分组中
+                    const instanceId = chunk.harnessInstanceId;
+                    const existingSubTask = currentSteps.find(
+                        (s: any) => s.subTask?.instanceId === instanceId
+                    );
+                    if (existingSubTask) {
+                        existingSubTask.subTask.steps.push(chunk);
+                        if (chunk.type === 'answer') {
+                            existingSubTask.subTask.status = 'completed';
+                            existingSubTask.subTask.endTime = new Date();
+                        }
+                        if (chunk.type === 'grade_result') {
+                            try {
+                                const graderResult = JSON.parse(chunk.content ?? '{}');
+                                existingSubTask.subTask.graderScore = graderResult.overallScore;
+                            } catch { /* ignore */ }
+                        }
+                    } else {
+                        currentSteps.push({
+                            subTask: {
+                                delegatedFrom: chunk.delegatedFrom,
+                                instanceId,
+                                steps: [chunk],
+                                status: 'running',
+                                startTime: new Date(),
+                            }
+                        });
+                    }
+                    yield buildYield();
+
                 } else if (chunk.type === "answer") {
                     // Final answer replaces any partial content chunks
                     currentContent = chunk.content;


### PR DESCRIPTION
## Summary

实现 masterBot-v1.1.1-harness-integration-plan.md 中的全部计划内容，完成 Harness Agent 与 Chat 对话模式并存，并修复 7 项架构缺陷。

### Phase 26 — Harness-Chat 桥接 (P0)
- `delegate_to_agent` 工具**优先走 AgentPool（Harness 路径）**，仅在 spec 未注册时 fallback 到 MultiAgentOrchestrator
- 系统提示词动态注入当前可用 Agent 列表，辅助 LLM 决策
- `HarnessExecutionContext` 增加 `parentSessionId` / `trigger` 字段，建立 Chat → Harness 的 session 父子关联
- `session_start` 事件附带 `parentSessionId: 父Chat SessionId` 和 `trigger: "chat_delegate"`
- `index.ts` 调整初始化顺序：`sessionStore` → `agentPool` → `Agent`，确保依赖可直接注入

### Phase 27 — 架构缺陷修复 (D1-D6)
| 缺陷 | 修复内容 |
|------|---------|
| D1 | `agent.run()` 主循环发射 `user_message` / `llm_request` / `llm_response` 事件 |
| D2 | `SessionEventStore.getEvents()` 过滤下推 SQL 层，动态构建 WHERE 子句（原：全表扫描后内存过滤） |
| D3 | `AgentPool.wake()` 注入真实 `SessionMemoryManager` 而非空 MemoryAccess |
| D4 | `CredentialVault.generateSessionToken()` 改为 HMAC-SHA256 签名，内存 Map 维护 token→sessionId 反查 |
| D5 | `AgentBus.setMaxListeners(200)`；`subscribeToInstance` 10 分钟无活动自动 cleanup |
| D6 | Grader 评分后发射 `grader_evaluation` / `grader_revision` 事件持久化修订状态 |

### Phase 28 — MultiAgentOrchestrator 渐进退役 (P1)
- `multi-agent.ts` 标记 `@deprecated`，明确退役路径（Phase 30 彻底移除）
- 启动时将旧 Worker 统一注册为 AgentSpec
- `AgentPool.selectSpec()` 新方法（迁移 supervisorDelegate LLM 路由逻辑）
- `AgentPool` 构造函数增加 `sessionMemoryManager` 注入

### Phase 29 — 前端适配 (P1)
- `SubTaskPanel` 可折叠子任务面板：展示子 Agent 名称/步骤/耗时/质量评分，提供跳转 /agents 的链接
- `assistant-runtime.ts` SSE 步骤聚合：带 `delegatedFrom` 标记的步骤按 `harnessInstanceId` 分组
- 处理 `grading` / `grade_result` 步骤类型，在执行面板显示评分信息

## Test plan
- [x] 后端 `npx tsc --noEmit` — 0 错误
- [x] `npx vitest run` — 139 tests, 13 files, all passed
- [ ] 集成验证：Chat 中发送 "请用 coder 帮我写一个 hello world"，SSE 流中出现子 Agent 步骤
- [ ] 独立验证：`/api/agents/spawn` 入口独立正常工作
- [ ] session 关联验证：子 Agent 的 session_start 事件 payload 含 parentSessionId

🤖 Generated with [Claude Code](https://claude.com/claude-code)