### PR TITLE
fix: delegate_to_agent Tier1误清工具 & agents页实例列表不可滚动

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -467,9 +467,11 @@ export class Agent {
 
         const tier = classifyComplexity(inputText, externalTools.length);
         if (tier === 1) {
-            this.logger.info(`[AdaptiveThinking] Routing to Tier 1: Fast direct reply. Skipping tools.`);
+            this.logger.info(`[AdaptiveThinking] Routing to Tier 1: Fast direct reply. Skipping external tools.`);
             activeMaxIterations = 1;
-            tools = []; // Don't give it tools to avoid overthinking simple chats
+            // Tier 1 只去掉外部技能工具，保留内置工具（plan/memory/delegate 等）
+            // 确保 delegate_to_agent 在有可用 Harness Agent 时始终可调用
+            tools = builtinTools;
         } else if (tier === 3) {
             this.logger.info(`[AdaptiveThinking] Routing to Tier 3: Deep thinking required.`);
             activeMaxIterations = 25; // Extended patience

--- a/web/src/app/agents/page.tsx
+++ b/web/src/app/agents/page.tsx
@@ -624,17 +624,19 @@ export default function AgentsPage() {
                             <p className="text-xs">在"Agent 规格"标签页中点击"启动任务"</p>
                         </div>
                     ) : (
-                        <div className="flex flex-col gap-2">
-                            {/* active first, then completed/failed */}
-                            {[...instances]
-                                .sort((a, b) => {
-                                    const order = { running: 0, paused: 1, queued: 2, completed: 3, failed: 4, cancelled: 5 };
-                                    return (order[a.state] ?? 9) - (order[b.state] ?? 9);
-                                })
-                                .map(inst => (
-                                    <InstanceRow key={inst.instanceId} inst={inst} onAction={handleAction} />
-                                ))}
-                        </div>
+                        <ScrollArea className="h-[calc(100vh-280px)] min-h-[300px]">
+                            <div className="flex flex-col gap-2 pr-2">
+                                {/* active first, then completed/failed */}
+                                {[...instances]
+                                    .sort((a, b) => {
+                                        const order = { running: 0, paused: 1, queued: 2, completed: 3, failed: 4, cancelled: 5 };
+                                        return (order[a.state] ?? 9) - (order[b.state] ?? 9);
+                                    })
+                                    .map(inst => (
+                                        <InstanceRow key={inst.instanceId} inst={inst} onAction={handleAction} />
+                                    ))}
+                            </div>
+                        </ScrollArea>
                     )}
                 </TabsContent>
             </Tabs>


### PR DESCRIPTION
## 问题

### Bug 1: Chat 对话无法调用 Harness Agent
**根因**：`classifyComplexity()` 在 `externalTools.length === 0`（无外部技能）且消息较短时返回 Tier 1，
随后 `tools = []` **清空全部工具**，包括内置的 `delegate_to_agent`，导致 LLM 无法感知也无法调用任何 Agent。

**修复**：Tier 1 路由时改为 `tools = builtinTools`，仅去掉外部技能工具，保留 `delegate_to_agent` / `plan_task` / `memory_*` 等内置工具。

### Bug 2: /agents 运行实例界面无法滚动
**根因**：instances tab 的实例列表容器为普通 `<div>`，无高度约束，实例多时内容溢出页面无法滚动。

**修复**：用 `<ScrollArea className="h-[calc(100vh-280px)]">` 包裹实例列表，与现有 StepsPanel 内部滚动保持独立。

## 影响范围
- `src/core/agent.ts`：Tier 1 工具处理逻辑（1 行改动）
- `web/src/app/agents/page.tsx`：instances tab 布局（ScrollArea 包裹）

## Test plan
- [x] `npx tsc --noEmit` — 0 错误
- [x] `npx vitest run` — 139 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)