### PR TITLE
fix(agent): 托管实例三项问题修复（400错误/步数显示/持久化）

### DIFF
--- a/src/core/context-manager.ts
+++ b/src/core/context-manager.ts
@@ -150,6 +150,14 @@ export class ContextManager {
             splitIndex = Math.max(0, history.length - 2);
         }
 
+        // --- 关键保护 ---
+        // splitIndex 可能落在一条 'tool' 或 'assistant'(tool_calls) 消息上，
+        // 导致 kept[] 以孤立 tool 消息开头，进而使 LLM API 返回 400 错误。
+        // 向前推进 splitIndex，直到找到合法的 'user' 消息起点（或无消息可保留）。
+        while (splitIndex < history.length && history[splitIndex].role !== 'user') {
+            splitIndex++;
+        }
+
         return {
             trimmed: history.slice(0, splitIndex),
             kept: history.slice(splitIndex),

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -319,6 +319,23 @@ export function initDatabase(): DatabaseSync {
             updated_at  INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
         );
         CREATE INDEX IF NOT EXISTS idx_vault_key ON credential_vault(key);
+
+        -- Agent 实例持久化表（重启后历史记录不丢失）
+        CREATE TABLE IF NOT EXISTS agent_instances (
+            id           TEXT PRIMARY KEY,
+            spec_id      TEXT NOT NULL,
+            spec_name    TEXT NOT NULL,
+            state        TEXT NOT NULL DEFAULT 'running',
+            task         TEXT,
+            started_at   INTEGER,
+            completed_at INTEGER,
+            step_count   INTEGER NOT NULL DEFAULT 0,
+            last_score   REAL,
+            error        TEXT,
+            created_at   INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+        );
+        CREATE INDEX IF NOT EXISTS idx_ai_spec  ON agent_instances(spec_id);
+        CREATE INDEX IF NOT EXISTS idx_ai_state ON agent_instances(state);
     `);
 
     // Auto-migration for existing databases

--- a/src/core/harness/agent-pool.ts
+++ b/src/core/harness/agent-pool.ts
@@ -21,6 +21,7 @@ import type { SkillRegistry } from '../../skills/registry.js';
 import type { LongTermMemory } from '../../memory/long-term.js';
 import type { MemoryRouter } from '../../memory/memory-router.js';
 import type { SessionMemoryManager } from '../../memory/short-term.js';
+import type { DatabaseSync } from 'node:sqlite';
 
 export { SessionEventStore, CredentialVault };
 
@@ -47,8 +48,89 @@ export class AgentPool {
         private memoryRouter?: MemoryRouter,
         private sessionStore?: SessionEventStore,
         private credentialVault?: CredentialVault,
-        private sessionMemoryManager?: SessionMemoryManager
+        private sessionMemoryManager?: SessionMemoryManager,
+        private db?: DatabaseSync
     ) {}
+
+    // ─────────────────────────────────────────────────
+    // 持久化辅助（agent_instances 表）
+    // ─────────────────────────────────────────────────
+
+    private persistInstance(info: AgentInstanceInfo): void {
+        if (!this.db) return;
+        try {
+            this.db.prepare(`
+                INSERT INTO agent_instances
+                    (id, spec_id, spec_name, state, task, started_at, completed_at, step_count, last_score, error)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    state        = excluded.state,
+                    completed_at = excluded.completed_at,
+                    step_count   = excluded.step_count,
+                    last_score   = excluded.last_score,
+                    error        = excluded.error
+            `).run(
+                info.instanceId,
+                info.specId,
+                info.specName,
+                info.state,
+                info.task ?? null,
+                info.startedAt ? info.startedAt.getTime() : null,
+                info.completedAt ? info.completedAt.getTime() : null,
+                info.stepCount,
+                info.lastScore ?? null,
+                info.error ?? null,
+            );
+        } catch (err) {
+            this.logger.warn(`[agent-pool] persistInstance failed: ${(err as Error).message}`);
+        }
+    }
+
+    /** 从 DB 加载历史实例元数据（不在内存中的） */
+    private loadHistoricalInstances(): AgentInstanceInfo[] {
+        if (!this.db) return [];
+        try {
+            const liveIds = Array.from(this.instances.keys());
+            const placeholders = liveIds.length > 0
+                ? liveIds.map(() => '?').join(',')
+                : "'__none__'";  // 避免空 IN () 导致 SQL 语法错误
+            const rows = this.db.prepare(`
+                SELECT id, spec_id, spec_name, state, task, started_at, completed_at,
+                       step_count, last_score, error
+                FROM agent_instances
+                WHERE id NOT IN (${placeholders})
+                ORDER BY started_at DESC
+                LIMIT 200
+            `).all(...(liveIds as import('node:sqlite').SQLInputValue[])) as Array<{
+                id: string;
+                spec_id: string;
+                spec_name: string;
+                state: string;
+                task: string | null;
+                started_at: number | null;
+                completed_at: number | null;
+                step_count: number;
+                last_score: number | null;
+                error: string | null;
+            }>;
+            return rows.map(r => ({
+                instanceId: r.id,
+                specId: r.spec_id,
+                specName: r.spec_name,
+                state: r.state as AgentLifecycleState,
+                task: r.task ?? '',
+                revision: 0,
+                startedAt: r.started_at ? new Date(r.started_at) : new Date(0),
+                completedAt: r.completed_at ? new Date(r.completed_at) : undefined,
+                stepCount: r.step_count,
+                lastScore: r.last_score ?? undefined,
+                error: r.error ?? undefined,
+            }));
+        } catch (err) {
+            this.logger.warn(`[agent-pool] loadHistoricalInstances failed: ${(err as Error).message}`);
+            return [];
+        }
+    }
 
     // ─────────────────────────────────────────────────
     // Spec 管理
@@ -162,6 +244,21 @@ export class AgentPool {
 
         this.logger.info(`[agent-pool] Spawned ${spec.name} instance ${harness.instanceId}`);
 
+        // 持久化初始实例记录
+        this.persistInstance({
+            instanceId: harness.instanceId,
+            specId: spec.id,
+            specName: spec.name,
+            state: 'running',
+            task,
+            revision: 0,
+            startedAt: harness.getStartedAt(),
+            completedAt: undefined,
+            stepCount: 0,
+            lastScore: undefined,
+            error: undefined,
+        });
+
         // 异步驱动，步骤缓存到 steps map（使用含 sessionToken 的 enrichedContext）
         this.driveInstance(harness, task, enrichedContext).catch(err => {
             this.logger.error(`[agent-pool] Instance ${harness.instanceId} failed: ${err.message}`);
@@ -219,12 +316,40 @@ export class AgentPool {
                 state: harness.getState(),
                 lastScore: harness.getLastScore(),
             }, harness.instanceId);
+            // 持久化最终状态
+            this.persistInstance({
+                instanceId: harness.instanceId,
+                specId: harness.spec.id,
+                specName: harness.spec.name,
+                state: harness.getState(),
+                task,
+                revision: 0,
+                startedAt: harness.getStartedAt(),
+                completedAt: harness.getCompletedAt(),
+                stepCount: steps.length,
+                lastScore: harness.getLastScore(),
+                error: harness.getError(),
+            });
         } catch (err) {
             flushContent();
             agentBus.publish(`agent.error.${harness.instanceId}`, {
                 instanceId: harness.instanceId,
                 error: (err as Error).message,
             }, harness.instanceId);
+            // 持久化失败状态
+            this.persistInstance({
+                instanceId: harness.instanceId,
+                specId: harness.spec.id,
+                specName: harness.spec.name,
+                state: harness.getState(),
+                task,
+                revision: 0,
+                startedAt: harness.getStartedAt(),
+                completedAt: harness.getCompletedAt(),
+                stepCount: steps.length,
+                lastScore: harness.getLastScore(),
+                error: harness.getError() ?? (err as Error).message,
+            });
         } finally {
             this.runningCount.set(harness.spec.id, Math.max(0, (this.runningCount.get(harness.spec.id) ?? 1) - 1));
             this.drainQueue(harness.spec.id);
@@ -334,19 +459,29 @@ export class AgentPool {
     // ─────────────────────────────────────────────────
 
     listInstances(): AgentInstanceInfo[] {
-        return Array.from(this.instances.values()).map(h => ({
+        // 内存中的活跃/近期实例
+        const live: AgentInstanceInfo[] = Array.from(this.instances.values()).map(h => ({
             instanceId: h.instanceId,
             specId: h.spec.id,
             specName: h.spec.name,
             state: h.getState(),
-            task: '',   // task 存储在步骤中，此处省略
+            task: '',
             revision: 0,
             startedAt: h.getStartedAt(),
             completedAt: h.getCompletedAt(),
-            stepCount: h.getStepCount(),
+            // 使用 pool 缓存的已合并步骤数（UI 显示的步骤），而非 harness 内部的
+            // 流式 content chunk 计数（每个 token 块各自+1，会远大于实际步骤数）
+            stepCount: this.steps.get(h.instanceId)?.length ?? h.getStepCount(),
             lastScore: h.getLastScore(),
             error: h.getError(),
         }));
+
+        // 补充 DB 中历史记录（应用重启后仍可查看）
+        const historical = this.loadHistoricalInstances();
+
+        // 合并，去重（live 优先）
+        const liveIds = new Set(live.map(i => i.instanceId));
+        return [...live, ...historical.filter(i => !liveIds.has(i.instanceId))];
     }
 
     getInstanceSteps(instanceId: string): ExecutionStep[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,9 @@ async function main() {
         sessionStore,
         credentialVault,
         // D3: 注入 sessionMemoryManager，使 wake 恢复时可访问短期记忆
-        sessionManager
+        sessionManager,
+        // 注入 db，用于 agent 实例持久化（重启后历史记录不丢失）
+        db
     );
 
     // Phase 23: 加载 SOUL.md Agent 规格（新格式 + 兼容旧格式）


### PR DESCRIPTION
## Summary

- **Fix 1 — 400 错误根因**：`context-manager.ts` `splitHistory()` 现在在确定分割点后，向前推进到最近的 `user` 消息边界，确保 `kept[]` 不以孤立 `tool` 或 `assistant(tool_calls)` 消息开头
- **Fix 2 — 步数显示修正**：`listInstances()` 改用 pool 缓存的已合并步骤数（`this.steps.get()?.length`），而非 harness 内部的 `getStepCount()`（后者每个流式 content token 块各自+1，实测出现"888步"但详细步骤只有十几条的严重偏差）
- **Fix 3 — 实例持久化**：新增 `agent_instances` SQLite 表；spawn 时写入初始记录，完成/失败时更新；`listInstances()` 合并返回内存活跃实例 + DB 历史记录，应用重启后记录不再从 0 开始

## Root Cause Analysis

**400 错误**：`splitHistory()` 按 token 数倒序裁剪时，分割点可能落在 `tool` 消息上（位于 `assistant(tool_calls)` 之后），使 `kept[]` 以孤立 `tool` 消息开头。后续 LLM 调用的 messages 数组结构非法 → API 返回 `400 status code (no body)`。PR #25 中的 `buildMinimalContext()` 在 fallback 压缩路径上解决了这个问题，但根源在 `ContextManager.splitHistory()` 的主路径，本 PR 修复主路径。

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 139 tests passed
- [ ] 手动测试：运行 Researcher Agent 长任务，验证不再出现 400 错误
- [ ] 重启服务后确认历史实例仍显示在运行实例页
- [ ] 确认步数与详细步骤数一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)