### PR TITLE
fix(harness): grader failed 状态应触发修订循环而非抛出异常

### DIFF
--- a/src/core/harness/agent-harness.ts
+++ b/src/core/harness/agent-harness.ts
@@ -291,13 +291,10 @@ export class AgentHarness {
 
                 if (graderResult.status === 'satisfied') break;
 
-                if (graderResult.status === 'failed' || graderResult.status === 'grader_error') {
-                    if (graderResult.status === 'failed') {
-                        throw new Error(`[Grader] 任务质量评估失败: ${graderResult.feedback}`);
-                    }
-                    break;  // grader_error 不影响 Agent 结果，接受当前输出
-                }
+                // grader_error：Grader 自身调用失败，不惩罚 Agent，接受当前输出
+                if (graderResult.status === 'grader_error') break;
 
+                // failed / needs_revision：均应触发修订循环，不直接抛出异常
                 if (revision > maxRevisions) {
                     yield this.makeStep('meta', `🔄 已达到最大修订次数 ${maxRevisions}，以当前输出为最终结果`);
                     break;
@@ -311,7 +308,7 @@ export class AgentHarness {
                     revisedTask: currentTask.slice(0, 500),
                 });
 
-                // needs_revision：注入 Grader 反馈重试
+                // failed / needs_revision：注入 Grader 反馈重试
                 const failedCriteria = graderResult.criteriaResults
                     .filter(r => !r.passed && r.suggestions)
                     .map(r => `• [${r.criterionId}] ${r.suggestions}`)
@@ -324,7 +321,8 @@ ${graderResult.feedback}
 
 ${failedCriteria ? `各维度具体问题：\n${failedCriteria}` : ''}`;
 
-                yield this.makeStep('meta', `🔄 评分 ${graderResult.overallScore}/100，正在根据 Grader 建议进行第 ${revision + 1} 次修订...`);
+                const statusLabel = graderResult.status === 'failed' ? '必要项未达标' : '需修订';
+                yield this.makeStep('meta', `🔄 评分 ${graderResult.overallScore}/100（${statusLabel}），正在根据 Grader 建议进行第 ${revision + 1} 次修订...`);
             }
 
             this.state = 'completed';


### PR DESCRIPTION
## 问题

`AgentHarness.execute()` 中 Grader 返回 `failed`（required 标准 score < 60）时，代码直接 `throw new Error()`，触发 `catch` 块将 harness 置为 `failed` 状态并重抛异常。**修订循环完全被跳过**，Agent 没有机会根据 Grader 反馈改进输出。

## 根本原因

`failed` 不是编程错误，而是"必要评估标准未达标"的业务信号，与 `needs_revision` 本质相同——都应该触发带反馈的重试。

## 修复

`src/core/harness/agent-harness.ts`：
- 移除 `failed` 状态的 `throw new Error()`
- `failed` 与 `needs_revision` 统一走修订循环，直到 `revision > maxRevisions` 为止
- `grader_error`（Grader 自身 LLM 调用失败）仍 break，接受当前输出
- 修订提示文案区分两种状态（`必要项未达标` vs `需修订`）

## 修复后的状态机

| Grader 状态 | 行为 |
|---|---|
| `satisfied` | 退出循环（成功） |
| `needs_revision` | 注入反馈，重试 |
| `failed` | 注入反馈，重试（**修复点**） |
| `grader_error` | 接受当前输出，退出 |

## Test plan

- [x] `npx vitest run` — 139 tests passed, 0 failures
- [x] `npx tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)