### PR TITLE
feat(phase4): Skills tier 分层 + 4 个部门专家 Subagent

### DIFF
--- a/docs/migration/PROGRESS.md
+++ b/docs/migration/PROGRESS.md
@@ -1,6 +1,6 @@
 # masterBot v3 重构进度追踪
 
-最后更新：2026-05-11（Phase 3 完成 + Review 修复）
+最后更新：2026-05-11（Phase 4 完成）
 
 ---
 
@@ -13,7 +13,7 @@
 | **P2** | Hooks 重构 | ✅ 完成 | `v3-p2-hooks` | - | 2026-05-10 |
 | P2.5 | Identity & Policy | ⬜ TODO | - | - | - |
 | **P3** | ClaudeManagedAgent 上线 | ✅ 完成 | `v3-p3-claude-managed` | #35 | 2026-05-11 |
-| P4 | Skills + Subagents 升级 | ⬜ TODO | - | - | - |
+| **P4** | Skills + Subagents 升级 | 🔄 进行中 | `v3-p4-skills-subagents` | #36 | - |
 | P5 | Session 高级特性 | ⬜ TODO | - | - | - |
 | P6 | Memory 四层 + 租户隔离 | ⬜ TODO | - | - | - |
 | P7 | 企业 IM 一等公民 | ⬜ TODO | - | - | - |
@@ -208,3 +208,49 @@
 | AgentEvent → ExecutionStep 中间层 | 解耦 SDK 消息格式与前端 SSE 协议，SDK 升级时只需改适配层 |
 | 灰度默认 5% | SDK 路径未经生产验证，5% 足够收集指标同时控制风险 |
 | hitl HiTL PermissionRequest 为 no-op | SDK hook 是同步返回值模型，异步 IM 审批流程推迟到 Phase 7 IM 一等公民阶段实现 |
+
+---
+
+## Phase 4 详细进度（进行中）
+
+### 任务清单
+
+- [x] 任务 1：`src/types.ts` 新增 `SkillTier` / `SkillCategory` 类型，`ToolDefinition` 携带 tier/category
+- [x] 任务 2：`src/skills/registry.ts` `parseSkillMd` 读取 frontmatter tier/category
+- [x] 任务 3：`src/skills/loader.ts` `getTools()` 输出携带 tier/category
+- [x] 任务 4：所有 13 个 built-in SKILL.md 标注 tier/category
+  - [x] core: shell, file-manager, http-client
+  - [x] extended: notification, document-processor, vision, database-connector, log-analyzer, im-bot
+  - [x] experimental: browser-automation, gemini-cli, claude-code, conductor-workflow
+- [x] 任务 5：`src/skills/sdk-mcp-wrapper.ts` 新增 `tierFilter?: SkillTier[]` 参数
+- [x] 任务 6：`src/core/agent/subagents.ts` 实现 `buildSubagentDefs()`（4 个部门专家）
+- [x] 任务 7：`src/core/agent/claude-managed.ts` 集成 core-tier 过滤 + subagents
+- [x] 任务 8：`scripts/token-count.ts` token 节省测量脚本
+- [x] 任务 9：`tests/skills-tier.test.ts`（9 个测试）
+
+### 完成标准验证
+
+- [x] TypeScript 零错误（`npx tsc --noEmit`）
+- [x] 167 个测试全部通过（+9 个 Phase 4 新增）
+- [x] token 节省 ≥30%：实际 **81.3%**（208 → 39 tokens）
+- [x] 4 个部门专家 Subagent：hr-specialist / finance-analyst / it-support / engineering-assistant
+- [x] 权限隔离验证：hr-specialist 无 shell，it-support 有 shell
+- [x] PR #36 已提交（base: refactor/v3）
+
+### Token 节省报告
+
+| 路径 | 工具数 | 估算 tokens | 备注 |
+|------|--------|-------------|------|
+| Phase 3（全量） | 13 技能，38 actions | ~208 | 所有工具注入主 Agent |
+| Phase 4（core） | 3 技能，11 actions | ~39 | 仅 shell/file-manager/http-client |
+| **节省** | - | **~169 (81.3%)** | ✅ 超额完成 ≥30% 目标 |
+
+### 设计决策
+
+| 决策 | 原因 |
+|------|------|
+| core tier 只含 3 个技能 | shell/file/http 是绝大多数任务的基础工具，其余通过 Subagent 委派获取 |
+| Subagent tools 用 `skill.action` 格式 | 与 LocalSkillSource 的命名约定一致，便于 MCP wrapper 路由 |
+| hr-specialist 无 shell 权限 | 最小权限原则：HR 任务不需要任意代码执行能力 |
+| it-support maxTurns=30 | 运维任务可能需要多步骤诊断，给予更多轮次空间 |
+| ToolDefinition 携带 tier 字段 | 避免额外索引查询，过滤逻辑在 MCP wrapper 层一次完成 |

--- a/scripts/token-count.ts
+++ b/scripts/token-count.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env tsx
+/**
+ * Phase 4: Token 节省测量脚本
+ * 对比 Phase 3（全量工具）vs Phase 4（core-tier 过滤）的 input token 差异。
+ *
+ * 使用方式:
+ *   npx tsx scripts/token-count.ts
+ */
+
+import { readFileSync } from 'fs';
+import { join, resolve } from 'path';
+import matter from 'gray-matter';
+
+interface ToolEntry {
+    name: string;
+    description: string;
+    tier: string;
+    category: string;
+    actions: string[];
+}
+
+/** 粗略的 token 估算：按空格分词 × 1.3（英文中文混合系数） */
+function estimateTokens(text: string): number {
+    const words = text.trim().split(/\s+/).length;
+    return Math.ceil(words * 1.3);
+}
+
+/** 将工具列表格式化为类似系统提示中的工具描述文本 */
+function formatToolsForPrompt(tools: ToolEntry[]): string {
+    return tools.map(t =>
+        `Tool: ${t.name}\nDescription: ${t.description}\nActions: ${t.actions.join(', ')}`
+    ).join('\n\n');
+}
+
+async function loadBuiltinSkills(skillsDir: string): Promise<ToolEntry[]> {
+    const { readdirSync, existsSync } = await import('fs');
+    const tools: ToolEntry[] = [];
+
+    const entries = readdirSync(skillsDir, { withFileTypes: true });
+    for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const skillMd = join(skillsDir, entry.name, 'SKILL.md');
+        if (!existsSync(skillMd)) continue;
+
+        const content = readFileSync(skillMd, 'utf-8');
+        const { data: fm, content: body } = matter(content);
+
+        // 提取 action 名称
+        const actionRegex = /###\s+(\w+)/g;
+        const actions: string[] = [];
+        let m: RegExpExecArray | null;
+        while ((m = actionRegex.exec(body)) !== null) {
+            actions.push(m[1]);
+        }
+
+        tools.push({
+            name: fm.name ?? entry.name,
+            description: fm.description ?? '',
+            tier: fm.tier ?? 'extended',
+            category: fm.category ?? 'unknown',
+            actions,
+        });
+    }
+
+    return tools;
+}
+
+async function main() {
+    const skillsDir = resolve(process.cwd(), 'skills/built-in');
+    const allTools = await loadBuiltinSkills(skillsDir);
+
+    const coreTools = allTools.filter(t => t.tier === 'core');
+    const extendedTools = allTools.filter(t => t.tier === 'extended');
+    const experimentalTools = allTools.filter(t => t.tier === 'experimental');
+
+    const allPrompt = formatToolsForPrompt(allTools);
+    const corePrompt = formatToolsForPrompt(coreTools);
+
+    const allTokens = estimateTokens(allPrompt);
+    const coreTokens = estimateTokens(corePrompt);
+    const savedTokens = allTokens - coreTokens;
+    const savedPct = ((savedTokens / allTokens) * 100).toFixed(1);
+
+    console.log('\n📊 Phase 4 Token 节省分析报告');
+    console.log('='.repeat(50));
+
+    console.log('\n技能分布:');
+    console.log(`  core (主 Agent):   ${coreTools.length} 个技能 (${coreTools.map(t => t.name).join(', ')})`);
+    console.log(`  extended (子 Agent): ${extendedTools.length} 个技能 (${extendedTools.map(t => t.name).join(', ')})`);
+    console.log(`  experimental:      ${experimentalTools.length} 个技能 (${experimentalTools.map(t => t.name).join(', ')})`);
+
+    console.log('\nToken 估算 (系统提示中工具描述部分):');
+    console.log(`  Phase 3 (全量):    ~${allTokens} tokens`);
+    console.log(`  Phase 4 (core):    ~${coreTokens} tokens`);
+    console.log(`  节省:              ~${savedTokens} tokens (${savedPct}%)`);
+
+    const target = 30;
+    if (parseFloat(savedPct) >= target) {
+        console.log(`\n✅ 达成 Phase 4 目标：input tokens 减少 ≥${target}% (实际 ${savedPct}%)`);
+    } else {
+        console.log(`\n⚠️ 未达成 Phase 4 目标：期望 ≥${target}%，实际 ${savedPct}%`);
+        console.log('   建议：将更多技能移至 extended/experimental tier，或精简 core 工具描述');
+    }
+
+    console.log('\n各 Tier 详情:');
+    for (const tool of allTools) {
+        const marker = tool.tier === 'core' ? '★' : tool.tier === 'extended' ? '○' : '△';
+        console.log(`  ${marker} [${tool.tier.padEnd(12)}] ${tool.name.padEnd(22)} (${tool.actions.length} actions, cat=${tool.category})`);
+    }
+    console.log('\n图例: ★=core(主Agent) ○=extended(子Agent) △=experimental');
+}
+
+main().catch(err => {
+    console.error('❌ 分析失败:', err);
+    process.exit(1);
+});

--- a/skills/built-in/browser-automation/SKILL.md
+++ b/skills/built-in/browser-automation/SKILL.md
@@ -2,7 +2,8 @@
 name: browser-automation
 version: 1.0.0
 description: AI-RPA 浏览器自动化技能，基于 Playwright。支持截图、点击、键盘输入、文件上传、表格提取。跨平台：Windows 优先驱动 Edge（内置），macOS 优先驱动 Chrome。适合操作无 API 的内部遗留系统（ERP/OA/财务）。
-author: CMaster Bot
+tier: experimental
+category: web
 dependencies:
   playwright: "^1.40.0"
 ---

--- a/skills/built-in/browser-automation/SKILL.md
+++ b/skills/built-in/browser-automation/SKILL.md
@@ -2,6 +2,7 @@
 name: browser-automation
 version: 1.0.0
 description: AI-RPA 浏览器自动化技能，基于 Playwright。支持截图、点击、键盘输入、文件上传、表格提取。跨平台：Windows 优先驱动 Edge（内置），macOS 优先驱动 Chrome。适合操作无 API 的内部遗留系统（ERP/OA/财务）。
+author: CMaster Bot
 tier: experimental
 category: web
 dependencies:

--- a/skills/built-in/claude-code/SKILL.md
+++ b/skills/built-in/claude-code/SKILL.md
@@ -2,7 +2,8 @@
 name: claude-code
 version: 1.0.0
 description: 调用本地 Claude Code CLI 执行编码任务（代码分析、审查、生成等）
-author: CMaster Team
+tier: experimental
+category: ai
 ---
 
 # Claude Code Skill

--- a/skills/built-in/claude-code/SKILL.md
+++ b/skills/built-in/claude-code/SKILL.md
@@ -2,6 +2,7 @@
 name: claude-code
 version: 1.0.0
 description: 调用本地 Claude Code CLI 执行编码任务（代码分析、审查、生成等）
+author: CMaster Team
 tier: experimental
 category: ai
 ---

--- a/skills/built-in/conductor-workflow/SKILL.md
+++ b/skills/built-in/conductor-workflow/SKILL.md
@@ -2,7 +2,8 @@
 name: conductor-workflow
 version: 1.0.0
 description: 基于自然语言生成、分析和修改 Conductor OSS v3.21.20 标准工作流定义 JSON，用于企业编排引擎
-author: CMaster Bot
+tier: experimental
+category: enterprise
 ---
 
 ## Actions

--- a/skills/built-in/conductor-workflow/SKILL.md
+++ b/skills/built-in/conductor-workflow/SKILL.md
@@ -2,6 +2,7 @@
 name: conductor-workflow
 version: 1.0.0
 description: 基于自然语言生成、分析和修改 Conductor OSS v3.21.20 标准工作流定义 JSON，用于企业编排引擎
+author: CMaster Bot
 tier: experimental
 category: enterprise
 ---

--- a/skills/built-in/database-connector/SKILL.md
+++ b/skills/built-in/database-connector/SKILL.md
@@ -2,7 +2,8 @@
 name: database-connector
 version: 1.0.0
 description: 安全只读数据库连接器，支持 NL2SQL 场景。支持 MySQL、PostgreSQL、SQLite 等数据源，内置 SQL 安全沙箱（仅允许 SELECT），自动 mask 敏感字段。
-author: CMaster Bot
+tier: extended
+category: data
 dependencies:
   mysql2: "^3.6.0"
   pg: "^8.11.0"

--- a/skills/built-in/database-connector/SKILL.md
+++ b/skills/built-in/database-connector/SKILL.md
@@ -2,6 +2,7 @@
 name: database-connector
 version: 1.0.0
 description: 安全只读数据库连接器，支持 NL2SQL 场景。支持 MySQL、PostgreSQL、SQLite 等数据源，内置 SQL 安全沙箱（仅允许 SELECT），自动 mask 敏感字段。
+author: CMaster Bot
 tier: extended
 category: data
 dependencies:

--- a/skills/built-in/document-processor/SKILL.md
+++ b/skills/built-in/document-processor/SKILL.md
@@ -2,6 +2,7 @@
 name: document-processor
 version: 1.0.0
 description: 处理各种文档格式，包括 PDF、Word、Excel 文件的读取、转换和写入。
+author: CMaster Team
 tier: extended
 category: file
 dependencies:

--- a/skills/built-in/document-processor/SKILL.md
+++ b/skills/built-in/document-processor/SKILL.md
@@ -2,7 +2,8 @@
 name: document-processor
 version: 1.0.0
 description: 处理各种文档格式，包括 PDF、Word、Excel 文件的读取、转换和写入。
-author: CMaster Team
+tier: extended
+category: file
 dependencies:
   pdf-parse: "^1.1.0"
   mammoth: "^1.5.0"

--- a/skills/built-in/file-manager/SKILL.md
+++ b/skills/built-in/file-manager/SKILL.md
@@ -3,6 +3,8 @@ name: file-manager
 version: 1.0.0
 description: 文件管理技能，支持文件读写、目录操作和搜索
 author: CMaster Team
+tier: core
+category: file
 dependencies:
   glob: "^11.0.0"
 ---

--- a/skills/built-in/gemini-cli/SKILL.md
+++ b/skills/built-in/gemini-cli/SKILL.md
@@ -2,6 +2,7 @@
 name: gemini-cli
 version: 1.0.0
 description: 调用本地 Gemini CLI 执行 AI 任务（代码分析、文件处理、搜索等）
+author: CMaster Team
 tier: experimental
 category: ai
 ---

--- a/skills/built-in/gemini-cli/SKILL.md
+++ b/skills/built-in/gemini-cli/SKILL.md
@@ -2,7 +2,8 @@
 name: gemini-cli
 version: 1.0.0
 description: 调用本地 Gemini CLI 执行 AI 任务（代码分析、文件处理、搜索等）
-author: CMaster Team
+tier: experimental
+category: ai
 ---
 
 # Gemini CLI Skill

--- a/skills/built-in/http-client/SKILL.md
+++ b/skills/built-in/http-client/SKILL.md
@@ -3,6 +3,8 @@ name: http-client
 version: 1.0.0
 description: HTTP 请求技能，支持发送各种 HTTP 请求
 author: CMaster Team
+tier: core
+category: web
 ---
 
 # HTTP Client Skill

--- a/skills/built-in/im-bot/SKILL.md
+++ b/skills/built-in/im-bot/SKILL.md
@@ -2,6 +2,7 @@
 name: im-bot
 version: 1.0.0
 description: IM 机器人主动发送消息技能，支持向飞书等 IM 平台主动推送文本消息和通知卡片
+author: CMaster
 tier: extended
 category: communication
 ---

--- a/skills/built-in/im-bot/SKILL.md
+++ b/skills/built-in/im-bot/SKILL.md
@@ -2,7 +2,8 @@
 name: im-bot
 version: 1.0.0
 description: IM 机器人主动发送消息技能，支持向飞书等 IM 平台主动推送文本消息和通知卡片
-author: CMaster
+tier: extended
+category: communication
 ---
 
 # im-bot

--- a/skills/built-in/log-analyzer/SKILL.md
+++ b/skills/built-in/log-analyzer/SKILL.md
@@ -2,7 +2,8 @@
 name: log-analyzer
 version: 1.0.0
 description: 内部日志平台分析技能。从内部日志系统（ELK/自研平台）拉取日志，使用 LLM 进行异常聚类和根因分析。适合 AIOps 告警分诊场景。
-author: CMaster Bot
+tier: extended
+category: data
 ---
 
 # log-analyzer

--- a/skills/built-in/log-analyzer/SKILL.md
+++ b/skills/built-in/log-analyzer/SKILL.md
@@ -2,6 +2,7 @@
 name: log-analyzer
 version: 1.0.0
 description: 内部日志平台分析技能。从内部日志系统（ELK/自研平台）拉取日志，使用 LLM 进行异常聚类和根因分析。适合 AIOps 告警分诊场景。
+author: CMaster Bot
 tier: extended
 category: data
 ---

--- a/skills/built-in/notification/SKILL.md
+++ b/skills/built-in/notification/SKILL.md
@@ -2,7 +2,8 @@
 name: notification
 version: 1.0.0
 description: 发送通知到各种渠道，包括钉钉、飞书、企业微信和邮件。
-author: CMaster Team
+tier: extended
+category: communication
 dependencies:
   nodemailer: "^6.9.0"
 ---

--- a/skills/built-in/notification/SKILL.md
+++ b/skills/built-in/notification/SKILL.md
@@ -2,6 +2,7 @@
 name: notification
 version: 1.0.0
 description: 发送通知到各种渠道，包括钉钉、飞书、企业微信和邮件。
+author: CMaster Team
 tier: extended
 category: communication
 dependencies:

--- a/skills/built-in/shell/SKILL.md
+++ b/skills/built-in/shell/SKILL.md
@@ -3,6 +3,8 @@ name: shell
 version: 1.0.0
 description: Shell 命令执行技能，支持在系统终端运行命令
 author: CMaster Team
+tier: core
+category: execution
 ---
 
 # Shell Skill

--- a/skills/built-in/vision/SKILL.md
+++ b/skills/built-in/vision/SKILL.md
@@ -2,6 +2,7 @@
 name: vision
 version: 1.0.0
 description: 图像理解技能，使用 LLM 的视觉能力分析图像、执行 OCR 和描述图表。
+author: CMaster Team
 tier: extended
 category: ai
 ---

--- a/skills/built-in/vision/SKILL.md
+++ b/skills/built-in/vision/SKILL.md
@@ -2,7 +2,8 @@
 name: vision
 version: 1.0.0
 description: 图像理解技能，使用 LLM 的视觉能力分析图像、执行 OCR 和描述图表。
-author: CMaster Team
+tier: extended
+category: ai
 ---
 
 ### analyze_image

--- a/src/core/agent/claude-managed.ts
+++ b/src/core/agent/claude-managed.ts
@@ -3,6 +3,8 @@
  * 包装 Claude Agent SDK 的 query()，实现 IAgent 接口。
  * Phase 4 新增：
  *   - 主 Agent 只注入 core tier 技能（减少 input tokens）
+ *   - Extended/experimental 技能通过独立 MCP 服务器暴露给子 Agent
+ *   - 主 Agent 用 disallowedTools 过滤 extended 工具，子 Agent 通过 mcpServers 引用获取
  *   - 通过 options.agents 注入 4 个部门专家 Subagent
  */
 
@@ -15,6 +17,9 @@ import { buildSubagentDefs } from './subagents.js';
 import type { HookRegistry } from '../hooks/registry.js';
 import type { ISkillRegistry } from '../../skills/registry.js';
 import type { Logger, MemoryAccess } from '../../types.js';
+
+// 子 Agent 定义只需计算一次（静态结构，不含运行时状态）
+const SUBAGENT_DEFS = buildSubagentDefs();
 
 export interface ClaudeManagedAgentOptions {
     hookRegistry: HookRegistry;
@@ -54,10 +59,24 @@ export class ClaudeManagedAgent implements IAgent {
             mcpCtx,
             this.opts.logger,
             ['core'],
+            'masterbot-skills',
         );
 
-        // Phase 4: 部门专家 Subagent 定义（HR / 财务 / IT / 工程）
-        const agents = buildSubagentDefs();
+        // Phase 4 (P0 fix): extended/experimental 技能注册为独立 MCP 服务器供子 Agent 使用
+        // 主 Agent 通过 disallowedTools 过滤这些工具，子 Agent 通过 mcpServers 引用访问
+        const extendedMcp = await createMasterBotMcpServer(
+            this.opts.skillRegistry,
+            mcpCtx,
+            this.opts.logger,
+            ['extended', 'experimental'],
+            'masterbot-extended',
+        );
+
+        // 计算需要对主 Agent 隐藏的 extended/experimental 工具名称列表
+        const allToolDefs = await this.opts.skillRegistry.getToolDefinitions();
+        const disallowedTools = allToolDefs
+            .filter(d => (d.tier ?? 'extended') !== 'core')
+            .map(d => d.function.name);
 
         // 将上层 AbortSignal 桥接为 SDK 所需的 AbortController
         const abortController = new AbortController();
@@ -75,9 +94,11 @@ export class ClaudeManagedAgent implements IAgent {
                 thinking: { type: 'adaptive' },
                 abortController,
                 hooks,
-                agents,
+                agents: SUBAGENT_DEFS,
+                disallowedTools,
                 mcpServers: {
                     'masterbot-skills': coreMcp,
+                    'masterbot-extended': extendedMcp,
                 },
                 env: {
                     CLAUDE_AGENT_SDK_CLIENT_APP: 'masterbot/4.0.0',

--- a/src/core/agent/claude-managed.ts
+++ b/src/core/agent/claude-managed.ts
@@ -1,7 +1,9 @@
 /**
- * Task 1: ClaudeManagedAgent
+ * Phase 3/4: ClaudeManagedAgent
  * 包装 Claude Agent SDK 的 query()，实现 IAgent 接口。
- * Anthropic provider 通过此类享受 SDK 的 caching / compaction / subagent 能力。
+ * Phase 4 新增：
+ *   - 主 Agent 只注入 core tier 技能（减少 input tokens）
+ *   - 通过 options.agents 注入 4 个部门专家 Subagent
  */
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
@@ -9,6 +11,7 @@ import type { IAgent, AgentInput, AgentEvent, AgentCapabilities } from './types.
 import { translateSdkStream } from './event-translator.js';
 import { buildSdkHooks } from './sdk-hook-adapter.js';
 import { createMasterBotMcpServer } from '../../skills/sdk-mcp-wrapper.js';
+import { buildSubagentDefs } from './subagents.js';
 import type { HookRegistry } from '../hooks/registry.js';
 import type { ISkillRegistry } from '../../skills/registry.js';
 import type { Logger, MemoryAccess } from '../../types.js';
@@ -42,13 +45,19 @@ export class ClaudeManagedAgent implements IAgent {
         // 构建 SDK hook 配置，桥接 globalHookRegistry
         const hooks = buildSdkHooks(this.opts.hookRegistry, ctx);
 
-        // 构建 in-process MCP Server（包装所有 SKILL.md 技能）
         const memory = this.opts.memoryFactory?.(input.sessionId) ?? makeFallbackMemory();
-        const masterbotMcp = await createMasterBotMcpServer(
+        const mcpCtx = { sessionId: input.sessionId, userId: input.userId, tenantId: input.tenantId, memory };
+
+        // Phase 4: 主 Agent 只注入 core tier 技能，减少无关工具的 token 消耗
+        const coreMcp = await createMasterBotMcpServer(
             this.opts.skillRegistry,
-            { sessionId: input.sessionId, userId: input.userId, tenantId: input.tenantId, memory },
+            mcpCtx,
             this.opts.logger,
+            ['core'],
         );
+
+        // Phase 4: 部门专家 Subagent 定义（HR / 财务 / IT / 工程）
+        const agents = buildSubagentDefs();
 
         // 将上层 AbortSignal 桥接为 SDK 所需的 AbortController
         const abortController = new AbortController();
@@ -66,11 +75,12 @@ export class ClaudeManagedAgent implements IAgent {
                 thinking: { type: 'adaptive' },
                 abortController,
                 hooks,
+                agents,
                 mcpServers: {
-                    'masterbot-skills': masterbotMcp,
+                    'masterbot-skills': coreMcp,
                 },
                 env: {
-                    CLAUDE_AGENT_SDK_CLIENT_APP: 'masterbot/3.0.0',
+                    CLAUDE_AGENT_SDK_CLIENT_APP: 'masterbot/4.0.0',
                 },
             },
         });

--- a/src/core/agent/subagents.ts
+++ b/src/core/agent/subagents.ts
@@ -1,0 +1,161 @@
+/**
+ * Phase 4: 部门专家 Subagent 定义
+ * 基于 Claude Agent SDK AgentDefinition 格式，将复杂任务路由到专领域的子 Agent，
+ * 避免将所有工具注入主 Agent，显著减少 input tokens。
+ */
+
+import type { AgentDefinition } from '@anthropic-ai/claude-agent-sdk';
+
+/**
+ * 构建部门专家 Subagent 定义表。
+ * 返回值直接传入 query() options.agents。
+ *
+ * 各 Subagent 的 tools 列表使用 "${skillName}.${actionName}" 格式，
+ * 与 LocalSkillSource.getTools() 生成的工具名保持一致。
+ * 通配符 "shell.*" 表示 shell 技能的所有动作。
+ */
+export function buildSubagentDefs(): Record<string, AgentDefinition> {
+    return {
+
+        // ── HR 专家 ────────────────────────────────────────────────────────────
+        'hr-specialist': {
+            description:
+                '处理人力资源相关任务：员工政策查询、招聘流程协助、绩效评估、假期/薪酬计算、劳动法规咨询、员工关系处理。当用户涉及 HR、人事、招聘、薪酬、培训相关请求时由主 Agent 委派。',
+            prompt: `你是一位专业的 HR 顾问和数据分析师。
+你的职责：
+- 查询和解答公司 HR 政策、员工手册、劳动法规
+- 协助处理招聘、入职、离职、绩效评估流程
+- 计算薪酬、社保、公积金等数据
+- 分析 HR 报表（从 Excel 或数据库中提取）
+- 起草 HR 相关邮件、通知、报告
+
+工作原则：
+- 严格遵守劳动法，给出合规建议
+- 敏感信息（如薪酬）仅在必要时提及，注意隐私保护
+- 对于不确定的法律问题，建议咨询法律顾问
+
+请用专业、简洁、友好的语气回答。`,
+            tools: [
+                'file-manager.read_file',
+                'file-manager.list_directory',
+                'document-processor.read_pdf',
+                'document-processor.read_docx',
+                'document-processor.read_xlsx',
+                'document-processor.write_xlsx',
+                'database-connector.query',
+                'http-client.get',
+                'notification.send_email',
+            ],
+            model: 'inherit',
+            maxTurns: 20,
+        },
+
+        // ── 财务分析师 ──────────────────────────────────────────────────────────
+        'finance-analyst': {
+            description:
+                '处理财务分析任务：财务报表解读、预算规划、成本分析、利润核算、税务计算、报销审批辅助、数据可视化。当用户涉及财务、会计、预算、成本、利润相关请求时由主 Agent 委派。',
+            prompt: `你是一位专业的财务分析师和 CFO 助理。
+你的职责：
+- 读取、分析财务报表（利润表、资产负债表、现金流量表）
+- 执行预算对比、成本分解、利润率计算
+- 从数据库或 Excel 提取并汇总财务数据
+- 生成财务分析报告
+- 协助处理报销审批（核查金额合规性）
+
+工作原则：
+- 数字计算必须精确，避免四舍五入误差
+- 明确区分预算/实际/预测三种数据
+- 税率计算参考最新税法（如有疑问请标注日期）
+- 财务数据严格保密，不得外传
+
+请使用精确的数字和专业术语，在关键节点给出结论性判断。`,
+            tools: [
+                'file-manager.read_file',
+                'file-manager.write_file',
+                'document-processor.read_xlsx',
+                'document-processor.write_xlsx',
+                'document-processor.read_pdf',
+                'database-connector.query',
+                'http-client.get',
+            ],
+            model: 'inherit',
+            maxTurns: 20,
+        },
+
+        // ── IT 支持工程师 ────────────────────────────────────────────────────────
+        'it-support': {
+            description:
+                '处理 IT 运维和技术支持任务：服务器运维、日志分析、网络故障排查、系统配置、自动化脚本编写、告警分诊。当用户涉及系统运维、日志、服务器、网络故障相关请求时由主 Agent 委派。',
+            prompt: `你是一位经验丰富的 IT 运维工程师和 SRE。
+你的职责：
+- 执行 Shell 命令诊断系统状态（进程、磁盘、内存、网络）
+- 分析日志文件，识别错误模式和异常
+- 编写和调试自动化运维脚本
+- 排查网络连通性、服务可用性问题
+- 配置管理和文件操作
+
+工作原则：
+- 执行危险命令前必须说明影响范围
+- 修改配置文件前先备份（cp -p 原文件 原文件.bak）
+- 优先诊断再操作，避免盲目重启服务
+- 记录所有变更操作
+
+请提供具体命令而非模糊建议，并解释每个关键命令的作用。`,
+            tools: [
+                'shell.execute',
+                'shell.execute_background',
+                'file-manager.read_file',
+                'file-manager.write_file',
+                'file-manager.list_directory',
+                'log-analyzer.analyze',
+                'log-analyzer.fetch_logs',
+                'http-client.get',
+                'http-client.post',
+                'notification.send_dingtalk',
+                'notification.send_feishu',
+            ],
+            model: 'inherit',
+            maxTurns: 30,
+        },
+
+        // ── 工程助手 ─────────────────────────────────────────────────────────────
+        'engineering-assistant': {
+            description:
+                '处理软件工程任务：代码审查、架构设计、代码生成、重构建议、技术文档编写、API 集成、数据库 Schema 设计。当用户涉及编程、代码、架构、技术方案相关请求时由主 Agent 委派。',
+            prompt: `你是一位全栈高级工程师和技术架构师。
+你的职责：
+- 代码审查：分析代码质量、性能、安全性
+- 架构设计：提供系统设计方案和技术选型建议
+- 代码生成：根据需求生成高质量、可维护的代码
+- 重构建议：识别技术债务并提供改造路径
+- 技术文档：API 文档、架构说明、操作手册
+- 数据库：SQL 查询优化、Schema 设计
+
+工作原则：
+- 代码必须有注释，关键逻辑必须解释
+- 安全第一：不生成含有注入漏洞、硬编码密钥的代码
+- 性能敏感场景给出时间/空间复杂度分析
+- 遵循当前项目的语言和框架规范
+
+提供可直接使用的代码，而非伪代码。在架构建议中比较不同方案的优劣。`,
+            tools: [
+                'shell.execute',
+                'file-manager.read_file',
+                'file-manager.write_file',
+                'file-manager.list_directory',
+                'file-manager.search_files',
+                'http-client.get',
+                'http-client.post',
+                'database-connector.query',
+                'document-processor.read_pdf',
+            ],
+            model: 'inherit',
+            maxTurns: 30,
+        },
+    };
+}
+
+/** 获取所有 Subagent ID 列表 */
+export function getSubagentIds(): string[] {
+    return ['hr-specialist', 'finance-analyst', 'it-support', 'engineering-assistant'];
+}

--- a/src/core/agent/subagents.ts
+++ b/src/core/agent/subagents.ts
@@ -2,17 +2,24 @@
  * Phase 4: 部门专家 Subagent 定义
  * 基于 Claude Agent SDK AgentDefinition 格式，将复杂任务路由到专领域的子 Agent，
  * 避免将所有工具注入主 Agent，显著减少 input tokens。
+ *
+ * 架构说明：
+ *   - 主 Agent：只注入 core tier 技能（masterbot-skills MCP 服务器）
+ *   - 子 Agent：通过 mcpServers 引用 masterbot-extended MCP 服务器获取 extended/experimental 技能
+ *     （masterbot-extended 在父级 Options.mcpServers 中注册，但主 Agent 通过 disallowedTools 过滤）
  */
 
 import type { AgentDefinition } from '@anthropic-ai/claude-agent-sdk';
 
+/** masterbot-extended MCP 服务器的 McpSdkServerConfig 引用（子 Agent 共用） */
+const EXTENDED_MCP_REF = { 'masterbot-extended': { type: 'sdk' as const, name: 'masterbot-extended' } };
+
 /**
- * 构建部门专家 Subagent 定义表。
+ * 构建部门专家 Subagent 定义表（模块级常量，只计算一次）。
  * 返回值直接传入 query() options.agents。
  *
  * 各 Subagent 的 tools 列表使用 "${skillName}.${actionName}" 格式，
  * 与 LocalSkillSource.getTools() 生成的工具名保持一致。
- * 通配符 "shell.*" 表示 shell 技能的所有动作。
  */
 export function buildSubagentDefs(): Record<string, AgentDefinition> {
     return {
@@ -35,6 +42,7 @@ export function buildSubagentDefs(): Record<string, AgentDefinition> {
 - 对于不确定的法律问题，建议咨询法律顾问
 
 请用专业、简洁、友好的语气回答。`,
+            mcpServers: [EXTENDED_MCP_REF],
             tools: [
                 'file-manager.read_file',
                 'file-manager.list_directory',
@@ -69,6 +77,7 @@ export function buildSubagentDefs(): Record<string, AgentDefinition> {
 - 财务数据严格保密，不得外传
 
 请使用精确的数字和专业术语，在关键节点给出结论性判断。`,
+            mcpServers: [EXTENDED_MCP_REF],
             tools: [
                 'file-manager.read_file',
                 'file-manager.write_file',
@@ -101,6 +110,7 @@ export function buildSubagentDefs(): Record<string, AgentDefinition> {
 - 记录所有变更操作
 
 请提供具体命令而非模糊建议，并解释每个关键命令的作用。`,
+            mcpServers: [EXTENDED_MCP_REF],
             tools: [
                 'shell.execute',
                 'shell.execute_background',
@@ -138,6 +148,7 @@ export function buildSubagentDefs(): Record<string, AgentDefinition> {
 - 遵循当前项目的语言和框架规范
 
 提供可直接使用的代码，而非伪代码。在架构建议中比较不同方案的优劣。`,
+            mcpServers: [EXTENDED_MCP_REF],
             tools: [
                 'shell.execute',
                 'file-manager.read_file',
@@ -153,9 +164,4 @@ export function buildSubagentDefs(): Record<string, AgentDefinition> {
             maxTurns: 30,
         },
     };
-}
-
-/** 获取所有 Subagent ID 列表 */
-export function getSubagentIds(): string[] {
-    return ['hr-specialist', 'finance-analyst', 'it-support', 'engineering-assistant'];
 }

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -221,6 +221,8 @@ export class LocalSkillSource implements SkillSource {
                                 .map(([k]) => k),
                         },
                     },
+                    tier: skill.metadata.tier,
+                    category: skill.metadata.category,
                 });
             }
         }

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -37,6 +37,8 @@ export async function parseSkillMd(filePath: string): Promise<ParsedSkillMd> {
         description: frontmatter.description || '',
         author: frontmatter.author,
         dependencies: frontmatter.dependencies,
+        tier: frontmatter.tier,
+        category: frontmatter.category,
     };
 
     // 解析 markdown 中的 actions

--- a/src/skills/sdk-mcp-wrapper.ts
+++ b/src/skills/sdk-mcp-wrapper.ts
@@ -54,6 +54,7 @@ function jsonSchemaToZod(schema: Record<string, unknown>): Record<string, z.ZodT
  *
  * @param tierFilter 若指定，只包装匹配 tier 的技能（缺省 tier 视为 'extended'）。
  *   主 Agent 传 ['core']，子 Agent 或全量传 undefined。
+ * @param serverName MCP Server 名称，默认 'masterbot-skills'。创建多个服务器时传入不同名称。
  */
 export async function createMasterBotMcpServer(
     skillRegistry: ISkillRegistry,
@@ -65,6 +66,7 @@ export async function createMasterBotMcpServer(
     },
     logger: Logger,
     tierFilter?: SkillTier[],
+    serverName = 'masterbot-skills',
 ) {
     const allToolDefs = await skillRegistry.getToolDefinitions();
 
@@ -113,7 +115,7 @@ export async function createMasterBotMcpServer(
     logger.info?.(`[sdk-mcp-wrapper] 包装了 ${sdkTools.length}/${allToolDefs.length} 个技能 (tier=${tierLabel})`);
 
     return createSdkMcpServer({
-        name: 'masterbot-skills',
+        name: serverName,
         version: '1.0.0',
         tools: sdkTools,
     });

--- a/src/skills/sdk-mcp-wrapper.ts
+++ b/src/skills/sdk-mcp-wrapper.ts
@@ -1,13 +1,14 @@
 /**
- * Task 3: createMasterBotMcpServer
+ * Phase 3/4: createMasterBotMcpServer
  * 将现有 SKILL.md 技能包装成 SDK 的 in-process MCP Server。
- * 使用 createSdkMcpServer + tool()，保护所有 SKILL.md 技能投资。
+ * Phase 4 新增 tierFilter 参数，支持只向主 Agent 暴露 core 层技能，
+ * 其余 extended/experimental 技能保留给专家 Subagent 使用。
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod/v4';
 import type { ISkillRegistry } from './registry.js';
-import type { Logger, MemoryAccess } from '../types.js';
+import type { Logger, MemoryAccess, SkillTier } from '../types.js';
 
 /**
  * 将 ToolDefinition.parameters JSON Schema 转换为 Zod schema（简化版）。
@@ -48,8 +49,11 @@ function jsonSchemaToZod(schema: Record<string, unknown>): Record<string, z.ZodT
 }
 
 /**
- * 创建包装了 masterBot 所有 SKILL.md 技能的 in-process MCP Server 配置。
+ * 创建包装了 masterBot SKILL.md 技能的 in-process MCP Server 配置。
  * 返回值可直接放入 `query({ options: { mcpServers: { masterbot: <返回值> } } })`。
+ *
+ * @param tierFilter 若指定，只包装匹配 tier 的技能（缺省 tier 视为 'extended'）。
+ *   主 Agent 传 ['core']，子 Agent 或全量传 undefined。
  */
 export async function createMasterBotMcpServer(
     skillRegistry: ISkillRegistry,
@@ -60,8 +64,14 @@ export async function createMasterBotMcpServer(
         memory: MemoryAccess;
     },
     logger: Logger,
+    tierFilter?: SkillTier[],
 ) {
-    const toolDefs = await skillRegistry.getToolDefinitions();
+    const allToolDefs = await skillRegistry.getToolDefinitions();
+
+    // Phase 4: 按 tier 过滤，缺省 tier 的工具视为 'extended'
+    const toolDefs = tierFilter
+        ? allToolDefs.filter(def => tierFilter.includes(def.tier ?? 'extended'))
+        : allToolDefs;
 
     const sdkTools = toolDefs.map(def => {
         const fnDef = def.function;
@@ -99,7 +109,8 @@ export async function createMasterBotMcpServer(
         );
     });
 
-    logger.info?.(`[sdk-mcp-wrapper] 包装了 ${sdkTools.length} 个 SKILL.md 技能为 MCP Server`);
+    const tierLabel = tierFilter ? tierFilter.join('+') : 'all';
+    logger.info?.(`[sdk-mcp-wrapper] 包装了 ${sdkTools.length}/${allToolDefs.length} 个技能 (tier=${tierLabel})`);
 
     return createSdkMcpServer({
         name: 'masterbot-skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,10 @@ export interface ToolDefinition {
         description: string;
         parameters: Record<string, unknown>;
     };
+    /** Phase 4: 来自 SKILL.md 的层级标注，用于按需过滤 */
+    tier?: SkillTier;
+    /** Phase 4: 来自 SKILL.md 的功能分类 */
+    category?: SkillCategory;
 }
 
 export interface LLMAdapter {
@@ -79,6 +83,12 @@ export interface LLMConfig {
 
 // ============ Skill Types ============
 
+/** Phase 4: 技能加载层级，用于按需注入 agent 上下文，减少 input tokens */
+export type SkillTier = 'core' | 'extended' | 'experimental';
+
+/** 技能功能分类 */
+export type SkillCategory = 'execution' | 'file' | 'web' | 'data' | 'communication' | 'ai' | 'enterprise';
+
 export interface SkillMetadata {
     name: string;
     version: string;
@@ -87,6 +97,10 @@ export interface SkillMetadata {
     dependencies?: Record<string, string>;
     loadError?: string;              // 加载失败原因
     status?: 'active' | 'degraded'; // 可用性状态
+    /** Phase 4: 加载层级（缺省视为 extended） */
+    tier?: SkillTier;
+    /** Phase 4: 功能分类 */
+    category?: SkillCategory;
 }
 
 export interface SkillAction {

--- a/tests/skills-tier.test.ts
+++ b/tests/skills-tier.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Phase 4: Skills Tier 系统测试
+ * 验证 SKILL.md tier/category 元数据正确加载，以及 sdk-mcp-wrapper 的 tier 过滤逻辑。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSkillMd } from '../src/skills/registry.js';
+import { join, resolve } from 'path';
+import { existsSync } from 'fs';
+import { readdirSync } from 'fs';
+import type { SkillTier } from '../src/types.js';
+
+const BUILTIN_SKILLS_DIR = resolve(process.cwd(), 'skills/built-in');
+
+const EXPECTED_TIERS: Record<string, SkillTier> = {
+    shell: 'core',
+    'file-manager': 'core',
+    'http-client': 'core',
+    notification: 'extended',
+    'document-processor': 'extended',
+    vision: 'extended',
+    'database-connector': 'extended',
+    'log-analyzer': 'extended',
+    'im-bot': 'extended',
+    'browser-automation': 'experimental',
+    'gemini-cli': 'experimental',
+    'claude-code': 'experimental',
+    'conductor-workflow': 'experimental',
+};
+
+describe('Skills Tier System', () => {
+    it('所有 built-in 技能目录应有 SKILL.md', () => {
+        const entries = readdirSync(BUILTIN_SKILLS_DIR, { withFileTypes: true })
+            .filter(e => e.isDirectory());
+        expect(entries.length).toBeGreaterThan(0);
+        for (const entry of entries) {
+            const skillMd = join(BUILTIN_SKILLS_DIR, entry.name, 'SKILL.md');
+            expect(existsSync(skillMd), `${entry.name} 缺少 SKILL.md`).toBe(true);
+        }
+    });
+
+    it('所有 built-in 技能应包含有效的 tier 元数据', async () => {
+        const validTiers: SkillTier[] = ['core', 'extended', 'experimental'];
+        const entries = readdirSync(BUILTIN_SKILLS_DIR, { withFileTypes: true })
+            .filter(e => e.isDirectory());
+
+        for (const entry of entries) {
+            const skillMd = join(BUILTIN_SKILLS_DIR, entry.name, 'SKILL.md');
+            if (!existsSync(skillMd)) continue;
+            const parsed = await parseSkillMd(skillMd);
+            expect(
+                parsed.metadata.tier,
+                `${entry.name} 缺少 tier 元数据`
+            ).toBeDefined();
+            expect(
+                validTiers.includes(parsed.metadata.tier!),
+                `${entry.name} 的 tier "${parsed.metadata.tier}" 不合法`
+            ).toBe(true);
+        }
+    });
+
+    it('所有 built-in 技能应包含 category 元数据', async () => {
+        const validCategories = ['execution', 'file', 'web', 'data', 'communication', 'ai', 'enterprise'];
+        const entries = readdirSync(BUILTIN_SKILLS_DIR, { withFileTypes: true })
+            .filter(e => e.isDirectory());
+
+        for (const entry of entries) {
+            const skillMd = join(BUILTIN_SKILLS_DIR, entry.name, 'SKILL.md');
+            if (!existsSync(skillMd)) continue;
+            const parsed = await parseSkillMd(skillMd);
+            expect(
+                parsed.metadata.category,
+                `${entry.name} 缺少 category 元数据`
+            ).toBeDefined();
+            expect(
+                validCategories.includes(parsed.metadata.category!),
+                `${entry.name} 的 category "${parsed.metadata.category}" 不合法`
+            ).toBe(true);
+        }
+    });
+
+    it('各技能的 tier 应与预期一致', async () => {
+        for (const [skillName, expectedTier] of Object.entries(EXPECTED_TIERS)) {
+            const skillMd = join(BUILTIN_SKILLS_DIR, skillName, 'SKILL.md');
+            if (!existsSync(skillMd)) continue;
+            const parsed = await parseSkillMd(skillMd);
+            expect(
+                parsed.metadata.tier,
+                `${skillName} 的 tier 应为 ${expectedTier}`
+            ).toBe(expectedTier);
+        }
+    });
+
+    it('core tier 技能应为 3 个（shell / file-manager / http-client）', async () => {
+        const entries = readdirSync(BUILTIN_SKILLS_DIR, { withFileTypes: true })
+            .filter(e => e.isDirectory());
+
+        const coreSkills: string[] = [];
+        for (const entry of entries) {
+            const skillMd = join(BUILTIN_SKILLS_DIR, entry.name, 'SKILL.md');
+            if (!existsSync(skillMd)) continue;
+            const parsed = await parseSkillMd(skillMd);
+            if (parsed.metadata.tier === 'core') {
+                coreSkills.push(parsed.metadata.name);
+            }
+        }
+
+        expect(coreSkills).toHaveLength(3);
+        expect(coreSkills).toContain('shell');
+        expect(coreSkills).toContain('file-manager');
+        expect(coreSkills).toContain('http-client');
+    });
+});
+
+describe('Subagent Definitions', () => {
+    it('buildSubagentDefs 应返回 4 个部门专家', async () => {
+        const { buildSubagentDefs } = await import('../src/core/agent/subagents.js');
+        const defs = buildSubagentDefs();
+        const ids = Object.keys(defs);
+        expect(ids).toHaveLength(4);
+        expect(ids).toContain('hr-specialist');
+        expect(ids).toContain('finance-analyst');
+        expect(ids).toContain('it-support');
+        expect(ids).toContain('engineering-assistant');
+    });
+
+    it('每个 Subagent 应有 description、prompt、tools', async () => {
+        const { buildSubagentDefs } = await import('../src/core/agent/subagents.js');
+        const defs = buildSubagentDefs();
+        for (const [id, def] of Object.entries(defs)) {
+            expect(def.description, `${id} 缺少 description`).toBeTruthy();
+            expect(def.prompt, `${id} 缺少 prompt`).toBeTruthy();
+            expect(def.tools, `${id} 缺少 tools`).toBeDefined();
+            expect((def.tools ?? []).length, `${id} 的 tools 为空`).toBeGreaterThan(0);
+        }
+    });
+
+    it('it-support 应有 shell 工具访问权', async () => {
+        const { buildSubagentDefs } = await import('../src/core/agent/subagents.js');
+        const { tools } = buildSubagentDefs()['it-support'];
+        expect(tools?.some(t => t.startsWith('shell.'))).toBe(true);
+    });
+
+    it('hr-specialist 不应有 shell 工具（最小权限）', async () => {
+        const { buildSubagentDefs } = await import('../src/core/agent/subagents.js');
+        const { tools } = buildSubagentDefs()['hr-specialist'];
+        expect(tools?.some(t => t.startsWith('shell.'))).toBe(false);
+    });
+});


### PR DESCRIPTION
## 概述

Phase 4 实现 Progressive Disclosure + Subagent 隔离，主 Agent 工具描述 token 减少 **81%**，远超规划的 30% 目标。

## 变更内容

### 技能分层系统（Progressive Disclosure）
- `src/types.ts`：新增 `SkillTier`（core/extended/experimental）和 `SkillCategory` 类型，`ToolDefinition` 携带 tier/category 字段
- `src/skills/registry.ts`：`parseSkillMd` 读取 SKILL.md frontmatter 中的 tier/category
- `src/skills/loader.ts`：`getTools()` 输出中携带 tier/category
- 所有 13 个 built-in SKILL.md 标注 tier/category

| Tier | 技能 | 主 Agent 可见 |
|------|------|:---:|
| core | shell, file-manager, http-client | ✅ |
| extended | notification, document-processor, vision, database-connector, log-analyzer, im-bot | ❌ |
| experimental | browser-automation, gemini-cli, claude-code, conductor-workflow | ❌ |

### Token 节省
- `src/skills/sdk-mcp-wrapper.ts`：新增 `tierFilter?: SkillTier[]` 参数
- `src/core/agent/claude-managed.ts`：主 Agent 传入 `tierFilter: ['core']`
- **工具描述 token 减少 ~81.3%**（208 → 39 tokens）

### 部门专家 Subagent（`src/core/agent/subagents.ts`）
4 个开箱即用的部门专家，通过 SDK `options.agents` 注入：
- `hr-specialist`：人事/招聘/薪酬，无 shell 权限（最小权限原则）
- `finance-analyst`：财务分析/报表/预算
- `it-support`：Shell + 日志分析，30轮对话上限
- `engineering-assistant`：代码/架构/数据库

### 测量脚本
- `scripts/token-count.ts`：统计各 tier 技能数量和 token 节省比例

## 测试
- 新增 `tests/skills-tier.test.ts`（9 个测试）
  - tier/category 格式验证
  - core tier 技能数量验证
  - Subagent 权限隔离（hr-specialist 无 shell，it-support 有 shell）
- 全量：**167 个测试通过**，TypeScript 零错误

## Token 节省报告

```
Phase 3 (全量): ~208 tokens
Phase 4 (core): ~39 tokens
节省:           ~169 tokens (81.3%) ✅ 达成 ≥30% 目标
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)