### PR TITLE
feat(phase5): Session Fork / Resume / Checkpoint

### DIFF
--- a/src/core/agent/claude-managed.ts
+++ b/src/core/agent/claude-managed.ts
@@ -136,8 +136,12 @@ export class ClaudeManagedAgent implements IAgent {
         this.opts.logger.info?.(`[ClaudeManagedAgent] fork session=${sessionId}`);
         const result = await forkSession(sessionId);
         const newSessionId = result.sessionId;
-        // 通知上层记录父子关系（server.ts 注入 onFork 回调将写 sessions 表）
-        this.opts.onFork?.(sessionId, newSessionId);
+        // onFork 失败不能回滚 SDK 侧分叉，故只记录告警，仍返回新 sessionId
+        try {
+            this.opts.onFork?.(sessionId, newSessionId);
+        } catch (err) {
+            this.opts.logger.warn?.(`[ClaudeManagedAgent] onFork callback failed (DB record lost): ${(err as Error).message}`);
+        }
         this.opts.logger.info?.(`[ClaudeManagedAgent] fork ok: ${sessionId} → ${newSessionId}`);
         return newSessionId;
     }
@@ -170,12 +174,17 @@ export class ClaudeManagedAgent implements IAgent {
                     timestamp: new Date().toISOString(),
                     metadata: '{}',
                 }));
-        } catch {
-            // SDK 消息读取失败时从 DB 读取
+        } catch (sdkErr) {
+            // SDK 读取失败，fallback 到 DB
+            this.opts.logger.warn?.(`[ClaudeManagedAgent] getSessionMessages failed, falling back to DB: ${(sdkErr as Error).message}`);
             if (this.opts.historyRepository) {
                 const dbMsgs = this.opts.historyRepository.getMessages(sessionId, { limit: 500 });
                 messages = dbMsgs as Message[];
             }
+        }
+
+        if (messages.length === 0) {
+            this.opts.logger.warn?.(`[ClaudeManagedAgent] checkpoint for session=${sessionId} has 0 messages (SDK unavailable and no historyRepository?)`);
         }
 
         const cpId = this.opts.checkpointManager.save(sessionId, messages, label);

--- a/src/core/agent/claude-managed.ts
+++ b/src/core/agent/claude-managed.ts
@@ -1,14 +1,18 @@
 /**
- * Phase 3/4: ClaudeManagedAgent
+ * Phase 3/4/5: ClaudeManagedAgent
  * 包装 Claude Agent SDK 的 query()，实现 IAgent 接口。
  * Phase 4 新增：
  *   - 主 Agent 只注入 core tier 技能（减少 input tokens）
  *   - Extended/experimental 技能通过独立 MCP 服务器暴露给子 Agent
  *   - 主 Agent 用 disallowedTools 过滤 extended 工具，子 Agent 通过 mcpServers 引用获取
  *   - 通过 options.agents 注入 4 个部门专家 Subagent
+ * Phase 5 新增：
+ *   - fork()：调用 SDK forkSession()，在 sessions 表记录父子关系
+ *   - checkpoint()：将当前消息历史快照存入 CheckpointManager
+ *   - capabilities() 更新：supportsFork / supportsCheckpoint = true
  */
 
-import { query } from '@anthropic-ai/claude-agent-sdk';
+import { query, forkSession, getSessionMessages } from '@anthropic-ai/claude-agent-sdk';
 import type { IAgent, AgentInput, AgentEvent, AgentCapabilities } from './types.js';
 import { translateSdkStream } from './event-translator.js';
 import { buildSdkHooks } from './sdk-hook-adapter.js';
@@ -16,7 +20,9 @@ import { createMasterBotMcpServer } from '../../skills/sdk-mcp-wrapper.js';
 import { buildSubagentDefs } from './subagents.js';
 import type { HookRegistry } from '../hooks/registry.js';
 import type { ISkillRegistry } from '../../skills/registry.js';
-import type { Logger, MemoryAccess } from '../../types.js';
+import type { Logger, MemoryAccess, Message } from '../../types.js';
+import type { CheckpointManager } from '../checkpoint-manager.js';
+import type { HistoryRepository } from '../repository.js';
 
 // 子 Agent 定义只需计算一次（静态结构，不含运行时状态）
 const SUBAGENT_DEFS = buildSubagentDefs();
@@ -31,6 +37,12 @@ export interface ClaudeManagedAgentOptions {
     defaultModel?: string;
     /** 最大对话轮次 */
     maxTurns?: number;
+    /** Phase 5: checkpoint 存储，可选（缺省时 checkpoint() 退化为 no-op） */
+    checkpointManager?: CheckpointManager;
+    /** Phase 5: 会话历史仓库，用于 fork/checkpoint 读取消息 */
+    historyRepository?: HistoryRepository;
+    /** Phase 5: fork 后在 sessions 表记录父子关系的回调 */
+    onFork?: (parentSessionId: string, newSessionId: string) => void;
 }
 
 export class ClaudeManagedAgent implements IAgent {
@@ -116,19 +128,66 @@ export class ClaudeManagedAgent implements IAgent {
         throw new Error(`ClaudeManagedAgent.resume: use execute({ resumeFrom: "${sessionId}" }) instead`);
     }
 
-    async fork(_sessionId: string): Promise<string> {
-        throw new Error('ClaudeManagedAgent.fork: Phase 5 will implement this via SDK forkSession');
+    /**
+     * Phase 5: 分叉会话——基于 SDK forkSession() 创建对话分支。
+     * 返回新会话的 UUID，可直接用于后续 execute({ sessionId: newId })。
+     */
+    async fork(sessionId: string): Promise<string> {
+        this.opts.logger.info?.(`[ClaudeManagedAgent] fork session=${sessionId}`);
+        const result = await forkSession(sessionId);
+        const newSessionId = result.sessionId;
+        // 通知上层记录父子关系（server.ts 注入 onFork 回调将写 sessions 表）
+        this.opts.onFork?.(sessionId, newSessionId);
+        this.opts.logger.info?.(`[ClaudeManagedAgent] fork ok: ${sessionId} → ${newSessionId}`);
+        return newSessionId;
     }
 
-    async checkpoint(_sessionId: string): Promise<string> {
-        throw new Error('ClaudeManagedAgent.checkpoint: Phase 5 will implement via SDK sessionId persistence');
+    /**
+     * Phase 5: 创建检查点——将当前消息历史快照存入 CheckpointManager。
+     * 优先从 SDK getSessionMessages() 读取；fallback 读 DB 消息。
+     * 返回检查点 ID。
+     */
+    async checkpoint(sessionId: string, label?: string): Promise<string> {
+        if (!this.opts.checkpointManager) {
+            throw new Error('[ClaudeManagedAgent] checkpoint requires checkpointManager to be provided');
+        }
+        this.opts.logger.info?.(`[ClaudeManagedAgent] checkpoint session=${sessionId}`);
+
+        let messages: Message[] = [];
+
+        // 尝试从 SDK JSONL 读取最新消息（更准确）
+        try {
+            const sdkMsgs = await getSessionMessages(sessionId);
+            messages = sdkMsgs
+                .filter(m => m.role === 'user' || m.role === 'assistant')
+                .map(m => ({
+                    id: m.uuid ?? '',
+                    sessionId,
+                    role: m.role as 'user' | 'assistant',
+                    content: typeof m.message === 'string'
+                        ? m.message
+                        : (m.message as { content?: unknown })?.content?.toString() ?? '',
+                    timestamp: new Date().toISOString(),
+                    metadata: '{}',
+                }));
+        } catch {
+            // SDK 消息读取失败时从 DB 读取
+            if (this.opts.historyRepository) {
+                const dbMsgs = this.opts.historyRepository.getMessages(sessionId, { limit: 500 });
+                messages = dbMsgs as Message[];
+            }
+        }
+
+        const cpId = this.opts.checkpointManager.save(sessionId, messages, label);
+        this.opts.logger.info?.(`[ClaudeManagedAgent] checkpoint ok: ${cpId} (${messages.length} messages)`);
+        return cpId;
     }
 
     capabilities(): AgentCapabilities {
         return {
             supportsStreaming: true,
-            supportsFork: false,       // Phase 5
-            supportsCheckpoint: false, // Phase 5
+            supportsFork: true,        // Phase 5 ✅
+            supportsCheckpoint: true,  // Phase 5 ✅
             maxContextTokens: 200_000,
         };
     }

--- a/src/core/agent/legacy.ts
+++ b/src/core/agent/legacy.ts
@@ -81,7 +81,7 @@ export class LegacySelfHostedAgent implements IAgent {
         throw new Error('LegacySelfHostedAgent does not support fork');
     }
 
-    async checkpoint(_sessionId: string): Promise<string> {
+    async checkpoint(_sessionId: string, _label?: string): Promise<string> {
         throw new Error('LegacySelfHostedAgent does not support checkpoint');
     }
 

--- a/src/core/agent/router.ts
+++ b/src/core/agent/router.ts
@@ -6,8 +6,6 @@
 
 import type { IAgent, AgentInput, AgentEvent, AgentCapabilities } from './types.js';
 import type { Logger } from '../../types.js';
-import type { CheckpointManager } from '../checkpoint-manager.js';
-import { historyRepository } from '../repository.js';
 
 // ─── Feature Flag Service ─────────────────────────────────────────────────────
 
@@ -43,14 +41,12 @@ export interface AgentRouterOptions {
     claudeFactory?: AgentFactory;
     featureFlags?: IFeatureFlagService;
     logger: Logger;
-    /** Phase 5: 当 agent 不支持 checkpoint 时的 fallback */
-    checkpointManager?: CheckpointManager;
 }
 
 // ─── AgentRouter ──────────────────────────────────────────────────────────────
 
 export class AgentRouter implements IAgent {
-    private readonly opts: Required<Omit<AgentRouterOptions, 'claudeFactory' | 'checkpointManager'>> & { claudeFactory?: AgentFactory; checkpointManager?: CheckpointManager };
+    private readonly opts: Required<Omit<AgentRouterOptions, 'claudeFactory'>> & { claudeFactory?: AgentFactory };
     private readonly legacyAgent: IAgent;
     private claudeAgent?: IAgent;
 
@@ -60,7 +56,6 @@ export class AgentRouter implements IAgent {
             claudeFactory: options.claudeFactory,
             featureFlags: options.featureFlags ?? new EnvFeatureFlagService(),
             logger: options.logger,
-            checkpointManager: options.checkpointManager,
         };
         this.legacyAgent = options.legacyFactory();
         if (options.claudeFactory) {

--- a/src/core/agent/router.ts
+++ b/src/core/agent/router.ts
@@ -6,6 +6,8 @@
 
 import type { IAgent, AgentInput, AgentEvent, AgentCapabilities } from './types.js';
 import type { Logger } from '../../types.js';
+import type { CheckpointManager } from '../checkpoint-manager.js';
+import { historyRepository } from '../repository.js';
 
 // ─── Feature Flag Service ─────────────────────────────────────────────────────
 
@@ -41,12 +43,14 @@ export interface AgentRouterOptions {
     claudeFactory?: AgentFactory;
     featureFlags?: IFeatureFlagService;
     logger: Logger;
+    /** Phase 5: 当 agent 不支持 checkpoint 时的 fallback */
+    checkpointManager?: CheckpointManager;
 }
 
 // ─── AgentRouter ──────────────────────────────────────────────────────────────
 
 export class AgentRouter implements IAgent {
-    private readonly opts: Required<Omit<AgentRouterOptions, 'claudeFactory'>> & { claudeFactory?: AgentFactory };
+    private readonly opts: Required<Omit<AgentRouterOptions, 'claudeFactory' | 'checkpointManager'>> & { claudeFactory?: AgentFactory; checkpointManager?: CheckpointManager };
     private readonly legacyAgent: IAgent;
     private claudeAgent?: IAgent;
 
@@ -56,6 +60,7 @@ export class AgentRouter implements IAgent {
             claudeFactory: options.claudeFactory,
             featureFlags: options.featureFlags ?? new EnvFeatureFlagService(),
             logger: options.logger,
+            checkpointManager: options.checkpointManager,
         };
         this.legacyAgent = options.legacyFactory();
         if (options.claudeFactory) {
@@ -94,14 +99,27 @@ export class AgentRouter implements IAgent {
     }
 
     async fork(sessionId: string): Promise<string> {
-        return this.legacyAgent.fork(sessionId);
+        // Phase 5: 优先走 ClaudeManagedAgent（SDK forkSession），fallback legacy
+        const agent = this.claudeAgent ?? this.legacyAgent;
+        return agent.fork(sessionId);
     }
 
-    async checkpoint(sessionId: string): Promise<string> {
-        return this.legacyAgent.checkpoint(sessionId);
+    async checkpoint(sessionId: string, label?: string): Promise<string> {
+        // Phase 5: 优先走 ClaudeManagedAgent，fallback legacy
+        const agent = this.claudeAgent ?? this.legacyAgent;
+        return agent.checkpoint(sessionId, label);
     }
 
     capabilities(): AgentCapabilities {
-        return this.legacyAgent.capabilities();
+        // Phase 5: 合并两个 agent 的能力声明（取最大值）
+        const legacy = this.legacyAgent.capabilities();
+        const managed = this.claudeAgent?.capabilities();
+        if (!managed) return legacy;
+        return {
+            supportsStreaming: legacy.supportsStreaming || managed.supportsStreaming,
+            supportsFork: legacy.supportsFork || managed.supportsFork,
+            supportsCheckpoint: legacy.supportsCheckpoint || managed.supportsCheckpoint,
+            maxContextTokens: Math.max(legacy.maxContextTokens, managed.maxContextTokens),
+        };
     }
 }

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -37,6 +37,7 @@ export interface IAgent {
     execute(input: AgentInput): AsyncGenerator<AgentEvent>;
     resume(sessionId: string): AsyncGenerator<AgentEvent>;
     fork(sessionId: string): Promise<string>;
-    checkpoint(sessionId: string): Promise<string>;
+    /** label 为可选标注，用于区分不同检查点 */
+    checkpoint(sessionId: string, label?: string): Promise<string>;
     capabilities(): AgentCapabilities;
 }

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -358,6 +358,14 @@ export function initDatabase(): DatabaseSync {
         }
     }
 
+    // Auto-migration: Phase 5 — sessions 表新增 parent_session_id（fork 溯源）
+    {
+        const sessionColumns = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>;
+        if (!sessionColumns.some(c => c.name === 'parent_session_id')) {
+            db.prepare('ALTER TABLE sessions ADD COLUMN parent_session_id TEXT REFERENCES sessions(id)').run();
+        }
+    }
+
     // Auto-migration: messages 表新增 metadata 列（存储 workflow_generated 等步骤数据）
     {
         const msgColumns = db.prepare('PRAGMA table_info(messages)').all() as Array<{ name: string }>;

--- a/src/core/repository.ts
+++ b/src/core/repository.ts
@@ -249,6 +249,33 @@ export class HistoryRepository {
     }
 
     /**
+     * Phase 5: 记录 fork 关系
+     * 在 sessions 表中为新会话写入 parent_session_id。
+     * 若 newSessionId 行不存在则先插入。
+     */
+    recordFork(parentSessionId: string, newSessionId: string, title?: string): void {
+        const existing = db.prepare('SELECT id FROM sessions WHERE id = ?').get(newSessionId);
+        if (!existing) {
+            db.prepare(
+                'INSERT INTO sessions (id, parent_session_id, title) VALUES (?, ?, ?)'
+            ).run(newSessionId, parentSessionId, title ?? `Fork of ${parentSessionId.slice(0, 8)}`);
+        } else {
+            db.prepare(
+                'UPDATE sessions SET parent_session_id = ? WHERE id = ?'
+            ).run(parentSessionId, newSessionId);
+        }
+    }
+
+    /**
+     * Phase 5: 获取会话的所有 fork 子会话。
+     */
+    getForks(sessionId: string): Array<{ id: string; title: string; createdAt: string }> {
+        return db.prepare(
+            'SELECT id, title, created_at as createdAt FROM sessions WHERE parent_session_id = ? ORDER BY created_at DESC'
+        ).all(sessionId) as Array<{ id: string; title: string; createdAt: string }>;
+    }
+
+    /**
      * 保存消息反馈（点赞/点踩）
      */
     saveFeedback(messageId: string, sessionId: string, rating: 'positive' | 'negative'): string {

--- a/src/core/repository.ts
+++ b/src/core/repository.ts
@@ -254,16 +254,14 @@ export class HistoryRepository {
      * 若 newSessionId 行不存在则先插入。
      */
     recordFork(parentSessionId: string, newSessionId: string, title?: string): void {
-        const existing = db.prepare('SELECT id FROM sessions WHERE id = ?').get(newSessionId);
-        if (!existing) {
-            db.prepare(
-                'INSERT INTO sessions (id, parent_session_id, title) VALUES (?, ?, ?)'
-            ).run(newSessionId, parentSessionId, title ?? `Fork of ${parentSessionId.slice(0, 8)}`);
-        } else {
-            db.prepare(
-                'UPDATE sessions SET parent_session_id = ? WHERE id = ?'
-            ).run(parentSessionId, newSessionId);
-        }
+        const defaultTitle = title ?? `Fork of ${parentSessionId.slice(0, 8)}`;
+        // INSERT OR IGNORE + UPDATE 为原子 upsert，避免并发 fork 时的 SELECT→INSERT 竞争
+        db.prepare(
+            'INSERT OR IGNORE INTO sessions (id, parent_session_id, title) VALUES (?, ?, ?)'
+        ).run(newSessionId, parentSessionId, defaultTitle);
+        db.prepare(
+            'UPDATE sessions SET parent_session_id = ? WHERE id = ? AND parent_session_id IS NULL'
+        ).run(parentSessionId, newSessionId);
     }
 
     /**

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -622,6 +622,7 @@ export class GatewayServer {
                     createdAt: s.created_at,
                     is_pinned: Boolean(s.is_pinned),
                     preview: preview || undefined,
+                    parentSessionId: s.parent_session_id ?? undefined,
                 };
             });
         });
@@ -685,6 +686,36 @@ export class GatewayServer {
                 return { success: true };
             } catch (error: any) {
                 this.logger.error(`Update title error: ${error.message}`);
+                reply.status(500);
+                return { error: error.message };
+            }
+        });
+
+        // Phase 5: Fork session — 创建对话分支
+        this.app.post<{ Params: { id: string }; Body: { title?: string } }>('/api/sessions/:id/fork', async (request, reply) => {
+            const { id } = request.params;
+            const { title } = request.body ?? {};
+            try {
+                if (!this.agentRouter) { reply.status(503); return { error: 'AgentRouter not available' }; }
+                const newSessionId = await this.agentRouter.fork(id);
+                // 若提供了自定义标题则更新
+                if (title) {
+                    historyRepository.updateSessionTitle(newSessionId, title);
+                }
+                const forks = historyRepository.getForks(id);
+                return { sessionId: newSessionId, parentSessionId: id, forks };
+            } catch (error: any) {
+                this.logger.error(`Fork session error: ${error.message}`);
+                reply.status(500);
+                return { error: error.message };
+            }
+        });
+
+        // Phase 5: 获取会话的所有 fork 子会话
+        this.app.get<{ Params: { id: string } }>('/api/sessions/:id/forks', async (request, reply) => {
+            try {
+                return { forks: historyRepository.getForks(request.params.id) };
+            } catch (error: any) {
                 reply.status(500);
                 return { error: error.message };
             }
@@ -1538,17 +1569,21 @@ export class GatewayServer {
             const { id: sessionId } = request.params;
             const { label } = request.body ?? {};
             try {
-                // 从 repository 获取当前消息历史
-                const { historyRepository } = await import('../core/repository.js');
-                const msgs = historyRepository.getMessages(sessionId);
+                // Phase 5: 优先使用 agentRouter.checkpoint()（ClaudeManagedAgent 会尝试从 SDK JSONL 读取）
+                if (this.agentRouter) {
+                    const cpId = await this.agentRouter.checkpoint(sessionId, label);
+                    const list = this.checkpointManager.list(sessionId);
+                    const cp = list.find(c => c.id === cpId);
+                    return { id: cpId, messageCount: cp?.messageCount ?? 0 };
+                }
 
-                // 防止超大快照（限 10MB）
+                // Fallback: 从 repository 获取当前消息历史（legacy agent 路径）
+                const msgs = historyRepository.getMessages(sessionId);
                 const json = JSON.stringify(msgs);
                 if (json.length > 10 * 1024 * 1024) {
                     reply.status(413);
                     return { error: `消息历史过大（${(json.length / 1024 / 1024).toFixed(1)} MB），超出检查点 10 MB 限制` };
                 }
-
                 const cpId = this.checkpointManager.save(sessionId, msgs as any[], label);
                 return { id: cpId, messageCount: msgs.length };
             } catch (err: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { initMemoryRouter } from './memory/memory-router.js';
 import { SoulLoader } from './core/soul-loader.js';
 import { AgentPool, SessionEventStore, CredentialVault } from './core/harness/agent-pool.js';
 import { CheckpointManager } from './core/checkpoint-manager.js';
+import { historyRepository } from './core/repository.js';
 
 async function main() {
     console.log(`
@@ -189,6 +190,10 @@ async function main() {
         agentPool,
     });
 
+    // Phase 5: 检查点管理器（先于 agentRouter 初始化，供 ClaudeManagedAgent 使用）
+    const checkpointManagerForAgent = new CheckpointManager(db, logger);
+    checkpointManagerForAgent.initialize();
+
     // Phase 3: 构建 AgentRouter（ClaudeManagedAgent + LegacySelfHostedAgent 双引擎）
     const featureFlags = createDefaultFeatureFlagService();
     const agentRouter = new AgentRouter({
@@ -218,6 +223,10 @@ async function main() {
             memoryFactory: (sessionId) => sessionManager.getSession(sessionId),
             defaultModel: config.models.providers['anthropic']?.model ?? 'claude-sonnet-4-6',
             maxTurns: 50,
+            // Phase 5: fork/checkpoint 支持
+            checkpointManager: checkpointManagerForAgent,
+            historyRepository,
+            onFork: (parentId, newId) => historyRepository.recordFork(parentId, newId),
         }),
         featureFlags,
         logger,
@@ -251,9 +260,8 @@ async function main() {
         }
     }
 
-    // T2-4: 初始化检查点管理器
-    const checkpointManager = new CheckpointManager(db, logger);
-    checkpointManager.initialize();
+    // Phase 5: checkpointManager 已在 agentRouter 初始化前创建，此处复用同一实例
+    const checkpointManager = checkpointManagerForAgent;
 
     // Start gateway server
     const server = new GatewayServer({

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Phase 5: Session Fork / Checkpoint / Resume 测试
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AgentRouter, EnvFeatureFlagService } from '../src/core/agent/router.js';
+import { CheckpointManager } from '../src/core/checkpoint-manager.js';
+import type { IAgent, AgentInput, AgentEvent, AgentCapabilities } from '../src/core/agent/types.js';
+import type { Logger } from '../src/types.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeLogger(): Logger {
+    return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeInput(overrides: Partial<AgentInput> = {}): AgentInput {
+    return {
+        message: 'hello',
+        sessionId: 'sess-1',
+        userId: 'u1',
+        tenantId: 't1',
+        provider: 'anthropic',
+        ...overrides,
+    };
+}
+
+function makeMockAgent(overrides: Partial<IAgent> = {}): IAgent {
+    return {
+        async *execute(_input: AgentInput): AsyncGenerator<AgentEvent> { yield { type: 'text', data: 'ok', timestamp: 0 }; },
+        async *resume(_sessionId: string): AsyncGenerator<AgentEvent> { yield { type: 'text', data: 'resumed', timestamp: 0 }; },
+        async fork(sessionId: string): Promise<string> { return `fork-of-${sessionId}`; },
+        async checkpoint(sessionId: string, label?: string): Promise<string> { return `cp-${sessionId}-${label ?? 'default'}`; },
+        capabilities(): AgentCapabilities {
+            return { supportsStreaming: true, supportsFork: true, supportsCheckpoint: true, maxContextTokens: 100_000 };
+        },
+        ...overrides,
+    };
+}
+
+// ─── EnvFeatureFlagService ─────────────────────────────────────────────────────
+
+describe('EnvFeatureFlagService', () => {
+    it('读取 overrides', () => {
+        const svc = new EnvFeatureFlagService({ 'my-flag': true });
+        expect(svc.isEnabled('my-flag')).toBe(true);
+        expect(svc.isEnabled('other-flag')).toBe(false);
+    });
+
+    it('读取环境变量', () => {
+        process.env['FEATURE_TEST_FLAG'] = 'true';
+        const svc = new EnvFeatureFlagService();
+        expect(svc.isEnabled('test-flag')).toBe(true);
+        delete process.env['FEATURE_TEST_FLAG'];
+    });
+});
+
+// ─── AgentRouter ──────────────────────────────────────────────────────────────
+
+describe('AgentRouter', () => {
+    let legacyAgent: IAgent;
+    let claudeAgent: IAgent;
+    let router: AgentRouter;
+    const logger = makeLogger();
+
+    beforeEach(() => {
+        legacyAgent = makeMockAgent({
+            async fork(_sessionId: string) { return `legacy-fork`; },
+            async checkpoint(_sessionId: string, _label?: string) { return `legacy-cp`; },
+            capabilities: () => ({ supportsStreaming: true, supportsFork: false, supportsCheckpoint: false, maxContextTokens: 50_000 }),
+        });
+        claudeAgent = makeMockAgent({
+            async fork(sessionId: string) { return `claude-fork-${sessionId}`; },
+            async checkpoint(sessionId: string, label?: string) { return `claude-cp-${sessionId}-${label ?? 'x'}`; },
+            capabilities: () => ({ supportsStreaming: true, supportsFork: true, supportsCheckpoint: true, maxContextTokens: 200_000 }),
+        });
+        router = new AgentRouter({
+            legacyFactory: () => legacyAgent,
+            claudeFactory: () => claudeAgent,
+            featureFlags: new EnvFeatureFlagService({ 'claude-managed-agent': true }),
+            logger,
+        });
+    });
+
+    describe('fork()', () => {
+        it('有 claudeAgent 时优先使用 claudeAgent.fork()', async () => {
+            const newId = await router.fork('sess-abc');
+            expect(newId).toBe('claude-fork-sess-abc');
+        });
+
+        it('无 claudeAgent 时使用 legacyAgent.fork()', async () => {
+            const r = new AgentRouter({
+                legacyFactory: () => legacyAgent,
+                featureFlags: new EnvFeatureFlagService(),
+                logger,
+            });
+            const newId = await r.fork('sess-abc');
+            expect(newId).toBe('legacy-fork');
+        });
+    });
+
+    describe('checkpoint()', () => {
+        it('有 claudeAgent 时优先使用 claudeAgent.checkpoint()', async () => {
+            const cpId = await router.checkpoint('sess-1', 'before-deploy');
+            expect(cpId).toBe('claude-cp-sess-1-before-deploy');
+        });
+
+        it('label 可选', async () => {
+            const cpId = await router.checkpoint('sess-1');
+            expect(cpId).toBe('claude-cp-sess-1-x');
+        });
+
+        it('无 claudeAgent 时 fallback 到 legacyAgent', async () => {
+            const r = new AgentRouter({
+                legacyFactory: () => legacyAgent,
+                featureFlags: new EnvFeatureFlagService(),
+                logger,
+            });
+            const cpId = await r.checkpoint('sess-1', 'lbl');
+            expect(cpId).toBe('legacy-cp');
+        });
+    });
+
+    describe('capabilities()', () => {
+        it('合并两个 agent 能力（取最大值）', () => {
+            const caps = router.capabilities();
+            expect(caps.supportsFork).toBe(true);
+            expect(caps.supportsCheckpoint).toBe(true);
+            expect(caps.maxContextTokens).toBe(200_000);
+        });
+
+        it('无 claudeAgent 时返回 legacy 能力', () => {
+            const r = new AgentRouter({
+                legacyFactory: () => legacyAgent,
+                featureFlags: new EnvFeatureFlagService(),
+                logger,
+            });
+            const caps = r.capabilities();
+            expect(caps.supportsFork).toBe(false);
+            expect(caps.maxContextTokens).toBe(50_000);
+        });
+    });
+
+    describe('execute() 路由', () => {
+        it('forceLegacy=true 时走 legacyAgent', async () => {
+            const legacySpy = vi.spyOn(legacyAgent, 'execute');
+            const claudeSpy = vi.spyOn(claudeAgent, 'execute');
+            const input = makeInput({ forceLegacy: true });
+            const events: AgentEvent[] = [];
+            for await (const ev of router.execute(input)) events.push(ev);
+            expect(legacySpy).toHaveBeenCalled();
+            expect(claudeSpy).not.toHaveBeenCalled();
+        });
+
+        it('provider=anthropic + flag 启用 → 走 claudeAgent', async () => {
+            const claudeSpy = vi.spyOn(claudeAgent, 'execute');
+            const input = makeInput({ provider: 'anthropic' });
+            const events: AgentEvent[] = [];
+            for await (const ev of router.execute(input)) events.push(ev);
+            expect(claudeSpy).toHaveBeenCalled();
+        });
+
+        it('provider=openai → 走 legacyAgent', async () => {
+            const legacySpy = vi.spyOn(legacyAgent, 'execute');
+            const input = makeInput({ provider: 'openai' });
+            const events: AgentEvent[] = [];
+            for await (const ev of router.execute(input)) events.push(ev);
+            expect(legacySpy).toHaveBeenCalled();
+        });
+    });
+});
+
+// ─── CheckpointManager ────────────────────────────────────────────────────────
+
+describe('CheckpointManager', () => {
+    let mgr: CheckpointManager;
+    const logger = makeLogger();
+
+    beforeEach(() => {
+        const { DatabaseSync } = require('node:sqlite');
+        const db = new DatabaseSync(':memory:');
+        // 建表（production 中由 database.ts 统一创建）
+        db.exec(`CREATE TABLE checkpoints (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            label TEXT,
+            message_count INTEGER DEFAULT 0,
+            messages_json TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )`);
+        mgr = new CheckpointManager(db, logger);
+        mgr.initialize();
+    });
+
+    it('save() 返回 checkpoint id', () => {
+        const messages = [{ id: 'm1', role: 'user' as const, content: 'hello' }];
+        const cpId = mgr.save('sess-1', messages, 'my-label');
+        expect(typeof cpId).toBe('string');
+        expect(cpId.length).toBeGreaterThan(0);
+    });
+
+    it('list() 返回按时间倒序的 checkpoint', () => {
+        const msgs = [{ id: 'm1', role: 'user' as const, content: 'hi' }];
+        mgr.save('sess-1', msgs, 'cp-1');
+        mgr.save('sess-1', msgs, 'cp-2');
+        const list = mgr.list('sess-1');
+        expect(list.length).toBe(2);
+    });
+
+    it('restore() 还原消息', () => {
+        const msgs = [
+            { id: 'm1', role: 'user' as const, content: 'hello' },
+            { id: 'm2', role: 'assistant' as const, content: 'world' },
+        ];
+        const cpId = mgr.save('sess-1', msgs);
+        const loaded = mgr.restore(cpId, 'sess-1');
+        expect(loaded).toHaveLength(2);
+        expect(loaded![0].content).toBe('hello');
+        expect(loaded![1].content).toBe('world');
+    });
+
+    it('restore() 跨 session 访问返回 null', () => {
+        const msgs = [{ id: 'm1', role: 'user' as const, content: 'hi' }];
+        const cpId = mgr.save('sess-A', msgs);
+        expect(mgr.restore(cpId, 'sess-B')).toBeNull();
+    });
+
+    it('restore() 不存在时返回 null', () => {
+        expect(mgr.restore('nonexistent-id', 'sess-1')).toBeNull();
+    });
+
+    it('不同 session 的 list() 互相隔离', () => {
+        const msgs = [{ id: 'm1', role: 'user' as const, content: 'hi' }];
+        mgr.save('sess-A', msgs);
+        mgr.save('sess-B', msgs);
+        expect(mgr.list('sess-A').length).toBe(1);
+        expect(mgr.list('sess-B').length).toBe(1);
+    });
+});

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -21,6 +21,7 @@ import "@assistant-ui/react-ui/styles/markdown.css";
 import { CustomAssistantMessage, CustomUserMessage, CustomUserEditComposer } from "@/components/chat/messages";
 import { ThreadHydrator, PromptAutoSender } from "@/components/chat/thread-utils";
 import { CheckpointPanel } from "@/components/chat/checkpoint-panel";
+import { ForkButton } from "@/components/chat/fork-button";
 
 function ChatContent() {
     const searchParams = useSearchParams();
@@ -55,9 +56,10 @@ function ChatSession({ sessionId }: { sessionId?: string }) {
                     historyLoaded={!sessionId || historyLoaded}
                 />
 
-                {/* 检查点工具栏（仅有 sessionId 时显示） */}
+                {/* 会话工具栏（仅有 sessionId 时显示） */}
                 {sessionId && (
-                    <div className="flex justify-end px-3 py-1 border-b shrink-0">
+                    <div className="flex justify-end gap-1 px-3 py-1 border-b shrink-0">
+                        <ForkButton sessionId={sessionId} />
                         <CheckpointPanel sessionId={sessionId} />
                     </div>
                 )}

--- a/web/src/components/chat/fork-button.tsx
+++ b/web/src/components/chat/fork-button.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { GitFork, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+interface ForkButtonProps {
+    sessionId: string;
+}
+
+export function ForkButton({ sessionId }: ForkButtonProps) {
+    const router = useRouter();
+    const [forking, setForking] = useState(false);
+
+    const handleFork = async () => {
+        setForking(true);
+        try {
+            const res = await fetch(`/api/sessions/${sessionId}/fork`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({}),
+            });
+            if (!res.ok) {
+                const data = await res.json();
+                throw new Error(data.error ?? "Fork 失败");
+            }
+            const { sessionId: newId } = await res.json();
+            toast.success("已创建对话分支，正在跳转...");
+            router.push(`/chat?sessionId=${newId}`);
+        } catch (err: any) {
+            toast.error(`Fork 失败：${err.message}`);
+        } finally {
+            setForking(false);
+        }
+    };
+
+    return (
+        <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 gap-1.5 text-muted-foreground hover:text-foreground"
+            onClick={handleFork}
+            disabled={forking}
+            title="创建对话分支（Fork）"
+        >
+            {forking
+                ? <Loader2 className="h-4 w-4 animate-spin" />
+                : <GitFork className="h-4 w-4" />}
+            <span className="text-xs hidden sm:inline">分支</span>
+        </Button>
+    );
+}


### PR DESCRIPTION
## Summary

- **fork()**: 调用 Claude Agent SDK `forkSession()` 创建对话分支，写入 `sessions.parent_session_id`，前端 ForkButton 触发后跳转到新 session
- **checkpoint()**: 优先从 SDK JSONL 获取消息快照，fallback 到 `historyRepository`，存入 SQLite `checkpoints` 表；CheckpointPanel 支持保存/恢复/删除
- **resume()**: AgentRouter 通过 `legacyAgent.resume()` 转发（legacy 路径），ClaudeManagedAgent 可通过 `resumeFrom` 参数指定 checkpoint 恢复

## Changes

### Backend
| 文件 | 变更 |
|---|---|
| `src/core/agent/types.ts` | `checkpoint(sessionId, label?)` 可选 label |
| `src/core/agent/claude-managed.ts` | `fork()` + `checkpoint()` + `capabilities()` 实现 |
| `src/core/agent/legacy.ts` | 签名补 `label?`，保持接口兼容 |
| `src/core/agent/router.ts` | `fork/checkpoint` 优先 ClaudeManagedAgent；合并 capabilities |
| `src/core/database.ts` | 自动迁移 `sessions.parent_session_id` 列 |
| `src/core/repository.ts` | `recordFork()` + `getForks()` |
| `src/gateway/server.ts` | `POST /fork`, `GET /forks`, checkpoint CRUD + restore 端点 |
| `src/index.ts` | CheckpointManager 提前初始化，注入 ClaudeManagedAgent |

### Frontend
| 文件 | 变更 |
|---|---|
| `web/src/components/chat/fork-button.tsx` | 新建 ForkButton 组件（POST fork → 跳转新 session） |
| `web/src/app/chat/page.tsx` | 工具栏加入 ForkButton，与 CheckpointPanel 并排 |

### Tests
- `tests/session.test.ts`: 18 个单元测试（EnvFeatureFlagService / AgentRouter 路由 + fork/checkpoint / CheckpointManager CRUD）

## Test plan
- [ ] `npx vitest run tests/session.test.ts` — 18 tests pass
- [ ] 有 sessionId 时工具栏显示「分支」+「检查点」两个按钮
- [ ] 点击「分支」→ POST /api/sessions/:id/fork → 跳转新 session URL
- [ ] 检查点保存 → GET /checkpoints 列表 → 恢复重置对话视图

🤖 Generated with [Claude Code](https://claude.com/claude-code)