### PR TITLE
feat(phase6): Memory 四层架构 + 租户隔离 + Semantic HitL

### DIFF
--- a/src/core/agent-run-helpers.ts
+++ b/src/core/agent-run-helpers.ts
@@ -92,10 +92,10 @@ export async function* handleBuiltinToolCall(
         let resultStr: string;
         let toolOutput: unknown;
         if (memoryRouter) {
-            const unified = await memoryRouter.query(query, { sessionId: context.sessionId, limit: recallLimit ?? 8 });
+            const unified = await memoryRouter.query(query, { sessionId: context.sessionId, tenantId: (context as any).tenantId ?? 'default', limit: recallLimit ?? 8 });
             toolOutput = unified;
             resultStr = unified.length > 0
-                ? unified.map((m: any) => `[${m.source}] ${m.content}`).join('\n')
+                ? unified.map((m: any) => `[${m.layer ?? m.source}] ${m.content}`).join('\n')
                 : 'No relevant memories found.';
         } else {
             const memories = await longTermMemory.search(query, recallLimit ?? 5);

--- a/src/core/agent-run-helpers.ts
+++ b/src/core/agent-run-helpers.ts
@@ -92,7 +92,9 @@ export async function* handleBuiltinToolCall(
         let resultStr: string;
         let toolOutput: unknown;
         if (memoryRouter) {
-            const unified = await memoryRouter.query(query, { sessionId: context.sessionId, tenantId: (context as any).tenantId ?? 'default', limit: recallLimit ?? 8 });
+            const tenantId = (context as any).tenantId;
+            if (!tenantId) throw new Error('[memory_recall] tenantId is required for memory isolation');
+            const unified = await memoryRouter.query(query, { sessionId: context.sessionId, tenantId, limit: recallLimit ?? 8 });
             toolOutput = unified;
             resultStr = unified.length > 0
                 ? unified.map((m: any) => `[${m.layer ?? m.source}] ${m.content}`).join('\n')

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -358,6 +358,40 @@ export function initDatabase(): DatabaseSync {
         }
     }
 
+    // Auto-migration: Phase 6 — episodic_memories 和 semantic_facts 表（四层记忆架构）
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS episodic_memories (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            content TEXT NOT NULL,
+            category TEXT NOT NULL DEFAULT 'general',
+            topic TEXT NOT NULL DEFAULT '',
+            expires_at INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            metadata TEXT DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_episodic_tenant ON episodic_memories(tenant_id);
+        CREATE INDEX IF NOT EXISTS idx_episodic_expires ON episodic_memories(expires_at);
+    `);
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS semantic_facts (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            predicate TEXT NOT NULL,
+            object TEXT NOT NULL,
+            confidence REAL NOT NULL DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'pending',
+            reviewed_by TEXT,
+            reviewed_at INTEGER,
+            source_session_id TEXT,
+            created_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_sf_tenant ON semantic_facts(tenant_id);
+        CREATE INDEX IF NOT EXISTS idx_sf_status ON semantic_facts(status);
+    `);
+
     // Auto-migration: Phase 5 — sessions 表新增 parent_session_id（fork 溯源）
     {
         const sessionColumns = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1567,29 +1567,33 @@ export class GatewayServer {
         // GET  /api/semantic-facts/pending?tenantId=...   — 待审批事实列表
         this.app.get<{ Querystring: { tenantId?: string } }>('/api/semantic-facts/pending', async (request, reply) => {
             if (!this.semanticStore) { reply.status(503); return { error: 'Semantic store not available' }; }
-            const tenantId = request.query.tenantId ?? 'default';
+            const tenantId = request.query.tenantId;
+            if (!tenantId) { reply.status(400); return { error: 'tenantId query parameter is required' }; }
             return { facts: await this.semanticStore.pendingFacts(tenantId) };
         });
 
         // POST /api/semantic-facts/:id/review             — 审批决策
         this.app.post<{
             Params: { id: string };
-            Body: { decision: 'approve' | 'reject'; reviewer?: string };
+            Body: { decision: 'approve' | 'reject'; reviewer?: string; tenantId: string };
         }>('/api/semantic-facts/:id/review', async (request, reply) => {
             if (!this.semanticStore) { reply.status(503); return { error: 'Semantic store not available' }; }
             const { id } = request.params;
-            const { decision, reviewer = 'anonymous' } = request.body;
+            const { decision, reviewer = 'anonymous', tenantId } = request.body;
+            if (!tenantId) { reply.status(400); return { error: 'tenantId is required' }; }
             if (decision !== 'approve' && decision !== 'reject') {
                 reply.status(400); return { error: 'decision must be approve or reject' };
             }
-            await this.semanticStore.review(id, decision, reviewer);
+            const ok = await this.semanticStore.review(id, decision, reviewer, tenantId);
+            if (!ok) { reply.status(404); return { error: 'Fact not found or not pending for this tenant' }; }
             return { ok: true, id, decision };
         });
 
         // GET  /api/semantic-facts?tenantId=...           — 所有事实（管理员视角）
         this.app.get<{ Querystring: { tenantId?: string } }>('/api/semantic-facts', async (request, reply) => {
             if (!this.semanticStore) { reply.status(503); return { error: 'Semantic store not available' }; }
-            const tenantId = request.query.tenantId ?? 'default';
+            const tenantId = request.query.tenantId;
+            if (!tenantId) { reply.status(400); return { error: 'tenantId query parameter is required' }; }
             return { facts: this.semanticStore.allByTenant(tenantId) };
         });
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -52,6 +52,8 @@ export class GatewayServer {
     private agentPool?: AgentPool;
     private longTermMemory?: import('../memory/long-term.js').LongTermMemory;
     private checkpointManager?: import('../core/checkpoint-manager.js').CheckpointManager;
+    private semanticStore?: import('../memory/semantic.js').SemanticMemoryStore;
+    private episodicStore?: import('../memory/episodic.js').EpisodicMemoryStore;
 
     constructor(options: {
         agent: Agent;
@@ -69,6 +71,8 @@ export class GatewayServer {
         agentPool?: AgentPool;
         longTermMemory?: import('../memory/long-term.js').LongTermMemory;
         checkpointManager?: import('../core/checkpoint-manager.js').CheckpointManager;
+        semanticStore?: import('../memory/semantic.js').SemanticMemoryStore;
+        episodicStore?: import('../memory/episodic.js').EpisodicMemoryStore;
     }) {
         this.agent = options.agent;
         this.agentRouter = options.agentRouter;
@@ -86,6 +90,8 @@ export class GatewayServer {
         this.agentPool = options.agentPool;
         this.longTermMemory = options.longTermMemory;
         this.checkpointManager = options.checkpointManager;
+        this.semanticStore = options.semanticStore;
+        this.episodicStore = options.episodicStore;
 
         // Initialize IM Gateway if enabled
         if (options.config.im?.enabled && options.config.im.platform === 'feishu') {
@@ -1554,6 +1560,37 @@ export class GatewayServer {
             } catch (err: any) {
                 reply.status(500); return { error: err.message };
             }
+        });
+
+        // ===== PHASE 6: SEMANTIC FACTS (HitL) =====
+
+        // GET  /api/semantic-facts/pending?tenantId=...   — 待审批事实列表
+        this.app.get<{ Querystring: { tenantId?: string } }>('/api/semantic-facts/pending', async (request, reply) => {
+            if (!this.semanticStore) { reply.status(503); return { error: 'Semantic store not available' }; }
+            const tenantId = request.query.tenantId ?? 'default';
+            return { facts: await this.semanticStore.pendingFacts(tenantId) };
+        });
+
+        // POST /api/semantic-facts/:id/review             — 审批决策
+        this.app.post<{
+            Params: { id: string };
+            Body: { decision: 'approve' | 'reject'; reviewer?: string };
+        }>('/api/semantic-facts/:id/review', async (request, reply) => {
+            if (!this.semanticStore) { reply.status(503); return { error: 'Semantic store not available' }; }
+            const { id } = request.params;
+            const { decision, reviewer = 'anonymous' } = request.body;
+            if (decision !== 'approve' && decision !== 'reject') {
+                reply.status(400); return { error: 'decision must be approve or reject' };
+            }
+            await this.semanticStore.review(id, decision, reviewer);
+            return { ok: true, id, decision };
+        });
+
+        // GET  /api/semantic-facts?tenantId=...           — 所有事实（管理员视角）
+        this.app.get<{ Querystring: { tenantId?: string } }>('/api/semantic-facts', async (request, reply) => {
+            if (!this.semanticStore) { reply.status(503); return { error: 'Semantic store not available' }; }
+            const tenantId = request.query.tenantId ?? 'default';
+            return { facts: this.semanticStore.allByTenant(tenantId) };
         });
 
         // ===== CHECKPOINTS (T2-4) =====

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,10 +118,8 @@ async function main() {
     await proceduralMemory.initialize();
     logger.info('[memory] Phase 6 four-layer memory stores initialized');
 
-    // Phase 21: 初始化统一内存路由器（注入 Phase 6 四层存储）
-    if (longTermMemory) {
-        initMemoryRouter(longTermMemory, knowledgeGraph, sessionManager, episodicStore, semanticStore, proceduralMemory);
-    }
+    // Phase 21: 初始化统一内存路由器（Phase 6 四层存储独立于 longTerm 是否启用）
+    initMemoryRouter(longTermMemory, knowledgeGraph, sessionManager, episodicStore, semanticStore, proceduralMemory);
     const { memoryRouter } = await import('./memory/memory-router.js');
 
     // Phase 24: SessionEventStore — Session 持久层（Meta-Harness Brain/Hands/Session 解耦）
@@ -309,6 +307,16 @@ async function main() {
     });
     scheduler.start();
     logger.info('Scheduler started');
+
+    // Phase 6: 每天凌晨 2 点清理过期 episodic 记忆（90 天 TTL）
+    setInterval(() => {
+        try {
+            const deleted = episodicStore.purgeExpired();
+            if (deleted > 0) logger.info(`[episodic] Purged ${deleted} expired memories`);
+        } catch (err) {
+            logger.warn(`[episodic] purgeExpired failed: ${(err as Error).message}`);
+        }
+    }, 24 * 60 * 60 * 1000); // every 24 hours
 
     // Graceful shutdown
     const shutdown = async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import { createLogger } from './utils/logger.js';
 import { llmFactory } from './llm/index.js';
 import { SkillRegistry, SkillLoader, McpSkillSource } from './skills/index.js';
 import { Agent } from './core/index.js';
-import { SessionMemoryManager, LongTermMemory } from './memory/index.js';
+import { SessionMemoryManager, LongTermMemory, EpisodicMemoryStore, SemanticMemoryStore } from './memory/index.js';
+import { ProceduralMemory } from './memory/procedural.js';
 import { GatewayServer } from './gateway/index.js';
 import { db } from './core/database.js';
 import fs from 'fs';
@@ -106,9 +107,20 @@ async function main() {
     const orchestrator = new MultiAgentOrchestrator(logger);
     const skillGenerator = new SkillGenerator(getLlm(), logger);
 
-    // Phase 21: 初始化统一内存路由器
+    // Phase 6: 初始化四层记忆存储
+    const episodicStore = new EpisodicMemoryStore(db, logger);
+    episodicStore.initialize();
+
+    const semanticStore = new SemanticMemoryStore(db, logger);
+    semanticStore.initialize();
+
+    const proceduralMemory = new ProceduralMemory(process.cwd(), logger);
+    await proceduralMemory.initialize();
+    logger.info('[memory] Phase 6 four-layer memory stores initialized');
+
+    // Phase 21: 初始化统一内存路由器（注入 Phase 6 四层存储）
     if (longTermMemory) {
-        initMemoryRouter(longTermMemory, knowledgeGraph, sessionManager);
+        initMemoryRouter(longTermMemory, knowledgeGraph, sessionManager, episodicStore, semanticStore, proceduralMemory);
     }
     const { memoryRouter } = await import('./memory/memory-router.js');
 
@@ -280,6 +292,8 @@ async function main() {
         agentPool,
         longTermMemory,
         checkpointManager,
+        semanticStore,
+        episodicStore,
     });
 
     await server.start(config.server.port, config.server.host);

--- a/src/memory/episodic.ts
+++ b/src/memory/episodic.ts
@@ -77,9 +77,11 @@ export class EpisodicMemoryStore {
     async search(query: string, k: number, tenantId: string): Promise<EpisodicMemory[]> {
         const now = Date.now();
 
+        // Try FTS5 first; fall back to LIKE when FTS is unavailable or returns no results.
+        // FTS5 with unicode61 may not tokenize CJK characters, so LIKE fallback improves recall.
+        let ftsRows: any[] | null = null;
         try {
-            // FTS5 subquery — keep tenant isolation and TTL filter in outer query
-            const rows = this.db.prepare(`
+            ftsRows = this.db.prepare(`
                 SELECT e.*
                 FROM episodic_memories e
                 WHERE e.id IN (
@@ -91,20 +93,24 @@ export class EpisodicMemoryStore {
                 ORDER BY e.created_at DESC
                 LIMIT ?
             `).all(query, tenantId, now, k) as any[];
-            if (rows.length > 0) return rows.map(r => this.rowToEpisodic(r));
-            throw new Error('no fts results, try like');
         } catch {
-            // Fallback to LIKE
-            const rows = this.db.prepare(`
-                SELECT * FROM episodic_memories
-                WHERE tenant_id = ?
-                  AND expires_at > ?
-                  AND content LIKE ?
-                ORDER BY created_at DESC
-                LIMIT ?
-            `).all(tenantId, now, `%${query}%`, k) as any[];
-            return rows.map(r => this.rowToEpisodic(r));
+            // FTS5 unavailable — proceed to LIKE
         }
+
+        if (ftsRows && ftsRows.length > 0) {
+            return ftsRows.map(r => this.rowToEpisodic(r));
+        }
+
+        // LIKE fallback: FTS unavailable or returned 0 (e.g., CJK tokenizer miss)
+        const rows = this.db.prepare(`
+            SELECT * FROM episodic_memories
+            WHERE tenant_id = ?
+              AND expires_at > ?
+              AND content LIKE ?
+            ORDER BY created_at DESC
+            LIMIT ?
+        `).all(tenantId, now, `%${query}%`, k) as any[];
+        return rows.map(r => this.rowToEpisodic(r));
     }
 
     /** 删除过期记忆（cron 调用） */

--- a/src/memory/episodic.ts
+++ b/src/memory/episodic.ts
@@ -1,0 +1,142 @@
+/**
+ * Phase 6: L2 Episodic Memory
+ * SQLite FTS5 存储，强制 tenant_id 隔离，90 天 TTL。
+ */
+
+import type { DatabaseSync } from 'node:sqlite';
+import { nanoid } from 'nanoid';
+import type { Logger } from '../types.js';
+import type { EpisodicMemory } from './types.js';
+
+const TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+export class EpisodicMemoryStore {
+    constructor(
+        private db: DatabaseSync,
+        private logger: Logger,
+    ) {}
+
+    initialize(): void {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS episodic_memories (
+                id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                content TEXT NOT NULL,
+                category TEXT NOT NULL DEFAULT 'general',
+                topic TEXT NOT NULL DEFAULT '',
+                expires_at INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                metadata TEXT DEFAULT '{}'
+            );
+            CREATE INDEX IF NOT EXISTS idx_episodic_tenant ON episodic_memories(tenant_id);
+            CREATE INDEX IF NOT EXISTS idx_episodic_expires ON episodic_memories(expires_at);
+        `);
+
+        // FTS5 virtual table for full-text search
+        try {
+            this.db.exec(`
+                CREATE VIRTUAL TABLE IF NOT EXISTS episodic_fts
+                USING fts5(id UNINDEXED, tenant_id UNINDEXED, content, tokenize='unicode61');
+            `);
+        } catch {
+            this.logger.warn('[episodic] FTS5 not available, falling back to LIKE search');
+        }
+
+        this.logger.debug('[episodic] EpisodicMemoryStore initialized');
+    }
+
+    async insert(item: Omit<EpisodicMemory, 'id' | 'createdAt' | 'expiresAt'>): Promise<void> {
+        const id = nanoid();
+        const now = Date.now();
+        const expiresAt = now + TTL_MS;
+
+        this.db.prepare(`
+            INSERT INTO episodic_memories
+                (id, tenant_id, session_id, content, category, topic, expires_at, created_at, metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `).run(
+            id,
+            item.tenantId,
+            item.sessionId,
+            item.content,
+            item.category ?? 'general',
+            item.topic ?? '',
+            expiresAt,
+            now,
+            JSON.stringify(item.metadata ?? {}),
+        );
+
+        // Sync to FTS
+        try {
+            this.db.prepare(`INSERT INTO episodic_fts(id, tenant_id, content) VALUES (?, ?, ?)`)
+                .run(id, item.tenantId, item.content);
+        } catch { /* FTS unavailable */ }
+    }
+
+    async search(query: string, k: number, tenantId: string): Promise<EpisodicMemory[]> {
+        const now = Date.now();
+
+        try {
+            // FTS5 subquery — keep tenant isolation and TTL filter in outer query
+            const rows = this.db.prepare(`
+                SELECT e.*
+                FROM episodic_memories e
+                WHERE e.id IN (
+                    SELECT id FROM episodic_fts
+                    WHERE episodic_fts MATCH ?
+                      AND tenant_id = ?
+                )
+                AND e.expires_at > ?
+                ORDER BY e.created_at DESC
+                LIMIT ?
+            `).all(query, tenantId, now, k) as any[];
+            if (rows.length > 0) return rows.map(r => this.rowToEpisodic(r));
+            throw new Error('no fts results, try like');
+        } catch {
+            // Fallback to LIKE
+            const rows = this.db.prepare(`
+                SELECT * FROM episodic_memories
+                WHERE tenant_id = ?
+                  AND expires_at > ?
+                  AND content LIKE ?
+                ORDER BY created_at DESC
+                LIMIT ?
+            `).all(tenantId, now, `%${query}%`, k) as any[];
+            return rows.map(r => this.rowToEpisodic(r));
+        }
+    }
+
+    /** 删除过期记忆（cron 调用） */
+    purgeExpired(): number {
+        const now = Date.now();
+        // Also remove from FTS
+        try {
+            const expiredIds = this.db.prepare(
+                'SELECT id FROM episodic_memories WHERE expires_at <= ?'
+            ).all(now) as Array<{ id: string }>;
+            for (const { id } of expiredIds) {
+                this.db.prepare('DELETE FROM episodic_fts WHERE id = ?').run(id);
+            }
+        } catch { /* FTS unavailable */ }
+
+        const result = this.db.prepare(
+            'DELETE FROM episodic_memories WHERE expires_at <= ?'
+        ).run(now);
+        return Number(result.changes);
+    }
+
+    private rowToEpisodic(r: any): EpisodicMemory {
+        return {
+            id: r.id,
+            tenantId: r.tenant_id,
+            sessionId: r.session_id,
+            content: r.content,
+            category: r.category,
+            topic: r.topic,
+            expiresAt: r.expires_at,
+            createdAt: r.created_at,
+            metadata: r.metadata ? JSON.parse(r.metadata) : undefined,
+        };
+    }
+}

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,2 +1,6 @@
 export { ShortTermMemory, SessionMemoryManager } from './short-term.js';
 export { LongTermMemory } from './long-term.js';
+export { EpisodicMemoryStore } from './episodic.js';
+export { SemanticMemoryStore } from './semantic.js';
+export { ProceduralMemory } from './procedural.js';
+export type { IMemoryRouter, EpisodicMemory, SemanticFact, ProceduralRule, UnifiedMemoryResult } from './types.js';

--- a/src/memory/memory-router.ts
+++ b/src/memory/memory-router.ts
@@ -21,8 +21,8 @@ export type { UnifiedMemoryResult };
 
 export class MemoryRouter implements IMemoryRouter {
     constructor(
-        /** Legacy long-term (kept for backward compat) */
-        private longTerm: LongTermMemory,
+        /** Legacy long-term (kept for backward compat, optional when Phase 6 stores are used) */
+        private longTerm: LongTermMemory | undefined,
         /** Legacy knowledge graph */
         private knowledgeGraph: KnowledgeGraph,
         private shortTermManager: SessionMemoryManager,
@@ -56,8 +56,8 @@ export class MemoryRouter implements IMemoryRouter {
         return this.semantic?.pendingFacts(tenantId) ?? [];
     }
 
-    async reviewFact(factId: string, decision: 'approve' | 'reject', reviewer: string): Promise<void> {
-        await this.semantic?.review(factId, decision, reviewer);
+    async reviewFact(factId: string, decision: 'approve' | 'reject', reviewer: string, tenantId: string): Promise<boolean> {
+        return this.semantic?.review(factId, decision, reviewer, tenantId) ?? false;
     }
 
     // ── L4 Procedural ────────────────────────────────────────────────────────
@@ -85,7 +85,9 @@ export class MemoryRouter implements IMemoryRouter {
             this.episodic
                 ? withTimeout(this.episodic.search(query, 4, opts.tenantId))
                 : Promise.resolve(null),
-            withTimeout(this.longTerm.search(query, limit)),
+            this.longTerm
+                ? withTimeout(this.longTerm.search(query, limit))
+                : Promise.resolve(null),
             withTimeout(this.knowledgeGraph.search(query, { depth: 1, limit: 5 })),
         ]);
 
@@ -127,7 +129,7 @@ export class MemoryRouter implements IMemoryRouter {
 export let memoryRouter: MemoryRouter | undefined;
 
 export function initMemoryRouter(
-    longTerm: LongTermMemory,
+    longTerm: LongTermMemory | undefined,
     knowledgeGraph: KnowledgeGraph,
     shortTermManager: SessionMemoryManager,
     episodic?: EpisodicMemoryStore,

--- a/src/memory/memory-router.ts
+++ b/src/memory/memory-router.ts
@@ -1,28 +1,76 @@
+/**
+ * Phase 6: 统一 MemoryRouter — 实现 IMemoryRouter
+ * 查询顺序：L4 Procedural → L3 Semantic → L2 Episodic → L1 (short-term, in-context)
+ */
+
 import type { LongTermMemory } from './long-term.js';
 import type { KnowledgeGraph } from './knowledge-graph.js';
 import type { SessionMemoryManager } from './short-term.js';
+import type { EpisodicMemoryStore } from './episodic.js';
+import type { SemanticMemoryStore } from './semantic.js';
+import type { ProceduralMemory } from './procedural.js';
+import type {
+    IMemoryRouter,
+    EpisodicMemory,
+    SemanticFact,
+    UnifiedMemoryResult,
+} from './types.js';
 
-export interface UnifiedMemoryResult {
-    source: 'long-term' | 'knowledge-graph' | 'short-term';
-    content: string;
-    score: number;
-    metadata?: Record<string, unknown>;
-}
+// 保留旧类型以向后兼容
+export type { UnifiedMemoryResult };
 
-/**
- * 统一内存路由器 — Phase 21
- * 并行查询 LongTermMemory + KnowledgeGraph，归并排序取 top N
- */
-export class MemoryRouter {
+export class MemoryRouter implements IMemoryRouter {
     constructor(
+        /** Legacy long-term (kept for backward compat) */
         private longTerm: LongTermMemory,
+        /** Legacy knowledge graph */
         private knowledgeGraph: KnowledgeGraph,
         private shortTermManager: SessionMemoryManager,
+        /** Phase 6 new stores (optional for gradual migration) */
+        private episodic?: EpisodicMemoryStore,
+        private semantic?: SemanticMemoryStore,
+        private procedural?: ProceduralMemory,
     ) {}
+
+    // ── L2 Episodic ──────────────────────────────────────────────────────────
+
+    async searchEpisodic(query: string, k: number, tenantId: string): Promise<EpisodicMemory[]> {
+        return this.episodic?.search(query, k, tenantId) ?? [];
+    }
+
+    async insertEpisodic(item: Omit<EpisodicMemory, 'id' | 'createdAt' | 'expiresAt'>): Promise<void> {
+        await this.episodic?.insert(item);
+    }
+
+    // ── L3 Semantic ──────────────────────────────────────────────────────────
+
+    async searchSemantic(entity: string, tenantId: string): Promise<SemanticFact[]> {
+        return this.semantic?.search(entity, tenantId) ?? [];
+    }
+
+    async upsertSemanticFact(fact: Omit<SemanticFact, 'id' | 'createdAt' | 'status'>): Promise<void> {
+        await this.semantic?.upsert(fact);
+    }
+
+    async pendingFacts(tenantId: string): Promise<SemanticFact[]> {
+        return this.semantic?.pendingFacts(tenantId) ?? [];
+    }
+
+    async reviewFact(factId: string, decision: 'approve' | 'reject', reviewer: string): Promise<void> {
+        await this.semantic?.review(factId, decision, reviewer);
+    }
+
+    // ── L4 Procedural ────────────────────────────────────────────────────────
+
+    async loadAgentRules(scope: string, tenantId: string): Promise<string> {
+        return this.procedural?.getRules(scope, tenantId) ?? '';
+    }
+
+    // ── Unified query ─────────────────────────────────────────────────────────
 
     async query(
         query: string,
-        opts: { sessionId: string; limit?: number }
+        opts: { sessionId: string; tenantId: string; limit?: number }
     ): Promise<UnifiedMemoryResult[]> {
         const limit = opts.limit ?? 8;
         const TIMEOUT_MS = 800;
@@ -33,52 +81,58 @@ export class MemoryRouter {
                 new Promise<null>(resolve => setTimeout(() => resolve(null), TIMEOUT_MS)),
             ]);
 
-        // 并行查询两个主要来源
-        const [ltResults, kgResult] = await Promise.all([
+        const [episodicResults, ltResults, kgResult] = await Promise.all([
+            this.episodic
+                ? withTimeout(this.episodic.search(query, 4, opts.tenantId))
+                : Promise.resolve(null),
             withTimeout(this.longTerm.search(query, limit)),
             withTimeout(this.knowledgeGraph.search(query, { depth: 1, limit: 5 })),
         ]);
 
         const results: UnifiedMemoryResult[] = [];
 
-        // 长期记忆结果
-        if (ltResults) {
-            for (const m of ltResults) {
-                results.push({
-                    source: 'long-term',
-                    content: m.content,
-                    score: 0.8,
-                    metadata: m.metadata,
-                });
+        // L2 Episodic (phase 6 store)
+        if (episodicResults) {
+            for (const m of episodicResults) {
+                results.push({ layer: 'episodic', content: m.content, score: 0.85, metadata: m.metadata });
             }
         }
 
-        // 知识图谱结果
-        if (kgResult && kgResult.nodes.length > 0) {
+        // L2 Legacy long-term (fallback, deduplication welcome in a later phase)
+        if (ltResults) {
+            for (const m of ltResults) {
+                results.push({ layer: 'episodic', content: m.content, score: 0.8, metadata: m.metadata });
+            }
+        }
+
+        // L3 Knowledge graph
+        if (kgResult?.nodes.length) {
             for (const node of kgResult.nodes) {
-                const score = kgResult.relevanceScores[node.id] ?? 0.5;
                 results.push({
-                    source: 'knowledge-graph',
+                    layer: 'semantic',
                     content: `**${node.title}**: ${node.content.substring(0, 200)}`,
-                    score,
+                    score: kgResult.relevanceScores[node.id] ?? 0.5,
                     metadata: { type: node.type, nodeId: node.id },
                 });
             }
         }
 
-        // 按 score 降序，取 top limit
         results.sort((a, b) => b.score - a.score);
         return results.slice(0, limit);
     }
 }
 
-// 单例，在 src/index.ts 中初始化
+// ── 单例 ─────────────────────────────────────────────────────────────────────
+
 export let memoryRouter: MemoryRouter | undefined;
 
 export function initMemoryRouter(
     longTerm: LongTermMemory,
     knowledgeGraph: KnowledgeGraph,
-    shortTermManager: SessionMemoryManager
+    shortTermManager: SessionMemoryManager,
+    episodic?: EpisodicMemoryStore,
+    semantic?: SemanticMemoryStore,
+    procedural?: ProceduralMemory,
 ): void {
-    memoryRouter = new MemoryRouter(longTerm, knowledgeGraph, shortTermManager);
+    memoryRouter = new MemoryRouter(longTerm, knowledgeGraph, shortTermManager, episodic, semantic, procedural);
 }

--- a/src/memory/procedural.ts
+++ b/src/memory/procedural.ts
@@ -14,6 +14,8 @@ export class ProceduralMemory {
     private cache = new Map<string, ProceduralRule>();
     /** 全局规则（所有 agent 共享） */
     private globalRules: string[] = [];
+    /** agentId → 该 agent 专属规则内容（热路径用，无需 existsSync） */
+    private agentRules = new Map<string, string>();
     private watching = false;
 
     constructor(
@@ -30,21 +32,41 @@ export class ProceduralMemory {
     }
 
     private async loadAll(): Promise<void> {
-        const sources = [
+        const globalSources = [
             { path: join(this.baseDir, 'AGENTS.md'), scope: '*' },
             { path: join(this.baseDir, 'agents/SOUL.md'), scope: '*' },
         ];
 
         this.globalRules = [];
-        for (const { path, scope } of sources) {
-            if (existsSync(path)) {
-                const content = await readFile(path, 'utf-8');
+        for (const { path: filePath, scope } of globalSources) {
+            if (existsSync(filePath)) {
+                const content = await readFile(filePath, 'utf-8');
                 this.globalRules.push(content);
-                this.cache.set(scope + ':' + path, {
-                    scope, tenantId: '*', content, source: path, loadedAt: Date.now(),
+                this.cache.set(scope + ':' + filePath, {
+                    scope, tenantId: '*', content, source: filePath, loadedAt: Date.now(),
                 });
-                this.logger.debug(`[procedural] Loaded ${path}`);
+                this.logger.debug(`[procedural] Loaded ${filePath}`);
             }
+        }
+
+        // Pre-load all agent-specific SOUL.md files into agentRules cache
+        this.agentRules.clear();
+        const agentsDir = join(this.baseDir, 'agents');
+        if (existsSync(agentsDir)) {
+            const { readdirSync, statSync } = await import('fs');
+            try {
+                for (const entry of readdirSync(agentsDir)) {
+                    const agentSoulPath = join(agentsDir, entry, 'SOUL.md');
+                    if (statSync(join(agentsDir, entry)).isDirectory() && existsSync(agentSoulPath)) {
+                        const content = await readFile(agentSoulPath, 'utf-8');
+                        this.agentRules.set(entry, content);
+                        this.cache.set(entry + ':' + agentSoulPath, {
+                            scope: entry, tenantId: '*', content, source: agentSoulPath, loadedAt: Date.now(),
+                        });
+                        this.logger.debug(`[procedural] Loaded agent soul: ${agentSoulPath}`);
+                    }
+                }
+            } catch { /* ignore scan errors */ }
         }
     }
 
@@ -74,6 +96,7 @@ export class ProceduralMemory {
     /**
      * 获取指定 scope 的规则内容（注入 system prompt 用）。
      * scope = agent id 时先查 agent 专属规则，再加全局规则。
+     * 纯内存查找，无 I/O。
      */
     getRules(scope: string, _tenantId: string): string {
         const parts: string[] = [];
@@ -83,12 +106,9 @@ export class ProceduralMemory {
             parts.push(this.globalRules.join('\n\n---\n\n'));
         }
 
-        // Agent-specific SOUL.md
-        const agentSoulPath = join(this.baseDir, 'agents', scope, 'SOUL.md');
-        if (existsSync(agentSoulPath)) {
-            const cached = [...this.cache.values()].find(r => r.source === agentSoulPath);
-            if (cached) parts.push(cached.content);
-        }
+        // Agent-specific SOUL.md (from in-memory cache, no I/O)
+        const agentContent = this.agentRules.get(scope);
+        if (agentContent) parts.push(agentContent);
 
         return parts.join('\n\n---\n\n').trim();
     }

--- a/src/memory/procedural.ts
+++ b/src/memory/procedural.ts
@@ -1,0 +1,99 @@
+/**
+ * Phase 6: L4 Procedural Memory
+ * 加载 SOUL.md / AGENTS.md / SKILL.md，注入 system prompt，支持热重载。
+ */
+
+import { readFile, watch } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import type { Logger } from '../types.js';
+import type { ProceduralRule } from './types.js';
+
+export class ProceduralMemory {
+    /** scope → rule content cache */
+    private cache = new Map<string, ProceduralRule>();
+    /** 全局规则（所有 agent 共享） */
+    private globalRules: string[] = [];
+    private watching = false;
+
+    constructor(
+        private baseDir: string,
+        private logger: Logger,
+    ) {}
+
+    /**
+     * 启动时加载所有规则并开启热重载 watcher。
+     */
+    async initialize(): Promise<void> {
+        await this.loadAll();
+        this.startWatcher();
+    }
+
+    private async loadAll(): Promise<void> {
+        const sources = [
+            { path: join(this.baseDir, 'AGENTS.md'), scope: '*' },
+            { path: join(this.baseDir, 'agents/SOUL.md'), scope: '*' },
+        ];
+
+        this.globalRules = [];
+        for (const { path, scope } of sources) {
+            if (existsSync(path)) {
+                const content = await readFile(path, 'utf-8');
+                this.globalRules.push(content);
+                this.cache.set(scope + ':' + path, {
+                    scope, tenantId: '*', content, source: path, loadedAt: Date.now(),
+                });
+                this.logger.debug(`[procedural] Loaded ${path}`);
+            }
+        }
+    }
+
+    private startWatcher(): void {
+        if (this.watching) return;
+        this.watching = true;
+
+        // Watch agent dir for SOUL.md changes
+        const agentDir = join(this.baseDir, 'agents');
+        if (!existsSync(agentDir)) return;
+
+        // watch() from fs/promises returns an AsyncIterable directly (not a Promise)
+        const self = this;
+        (async () => {
+            try {
+                const watcher = watch(agentDir, { recursive: true });
+                for await (const event of watcher) {
+                    if (event.filename?.endsWith('.md')) {
+                        self.logger.info(`[procedural] File changed: ${event.filename}, reloading`);
+                        await self.loadAll();
+                    }
+                }
+            } catch { /* watcher unavailable on some platforms */ }
+        })();
+    }
+
+    /**
+     * 获取指定 scope 的规则内容（注入 system prompt 用）。
+     * scope = agent id 时先查 agent 专属规则，再加全局规则。
+     */
+    getRules(scope: string, _tenantId: string): string {
+        const parts: string[] = [];
+
+        // Global rules
+        if (this.globalRules.length > 0) {
+            parts.push(this.globalRules.join('\n\n---\n\n'));
+        }
+
+        // Agent-specific SOUL.md
+        const agentSoulPath = join(this.baseDir, 'agents', scope, 'SOUL.md');
+        if (existsSync(agentSoulPath)) {
+            const cached = [...this.cache.values()].find(r => r.source === agentSoulPath);
+            if (cached) parts.push(cached.content);
+        }
+
+        return parts.join('\n\n---\n\n').trim();
+    }
+
+    getCachedRules(): ProceduralRule[] {
+        return [...this.cache.values()];
+    }
+}

--- a/src/memory/semantic.ts
+++ b/src/memory/semantic.ts
@@ -1,0 +1,123 @@
+/**
+ * Phase 6: L3 Semantic Memory
+ * 知识图谱增强版 — 写入需通过 HitL 审批，查询即时可用 approved 事实。
+ */
+
+import type { DatabaseSync } from 'node:sqlite';
+import { nanoid } from 'nanoid';
+import type { Logger } from '../types.js';
+import type { SemanticFact } from './types.js';
+
+export class SemanticMemoryStore {
+    constructor(
+        private db: DatabaseSync,
+        private logger: Logger,
+    ) {}
+
+    initialize(): void {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS semantic_facts (
+                id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                subject TEXT NOT NULL,
+                predicate TEXT NOT NULL,
+                object TEXT NOT NULL,
+                confidence REAL NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'pending',
+                reviewed_by TEXT,
+                reviewed_at INTEGER,
+                source_session_id TEXT,
+                created_at INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_sf_tenant ON semantic_facts(tenant_id);
+            CREATE INDEX IF NOT EXISTS idx_sf_status ON semantic_facts(status);
+            CREATE INDEX IF NOT EXISTS idx_sf_subject ON semantic_facts(subject, tenant_id);
+        `);
+        this.logger.debug('[semantic] SemanticMemoryStore initialized');
+    }
+
+    /**
+     * 提交候选事实（confidence >= 0.85 方可进入 pending）。
+     * 同一 tenant 下 subject+predicate 已存在 approved 事实时跳过。
+     */
+    async upsert(fact: Omit<SemanticFact, 'id' | 'createdAt' | 'status'>): Promise<void> {
+        if (fact.confidence < 0.85) {
+            this.logger.debug(`[semantic] confidence ${fact.confidence} < 0.85, skip`);
+            return;
+        }
+        // Skip if already approved
+        const existing = this.db.prepare(`
+            SELECT id FROM semantic_facts
+            WHERE tenant_id = ? AND subject = ? AND predicate = ? AND status = 'approved'
+        `).get(fact.tenantId, fact.subject, fact.predicate);
+        if (existing) return;
+
+        const id = nanoid();
+        this.db.prepare(`
+            INSERT INTO semantic_facts
+                (id, tenant_id, subject, predicate, object, confidence, status, source_session_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+        `).run(id, fact.tenantId, fact.subject, fact.predicate, fact.object, fact.confidence, fact.sourceSessionId ?? null, Date.now());
+        this.logger.info(`[semantic] New pending fact: ${fact.subject} ${fact.predicate} ${fact.object} (${fact.tenantId})`);
+    }
+
+    /**
+     * 搜索已 approved 的事实（按 subject 模糊匹配）。
+     */
+    async search(entity: string, tenantId: string): Promise<SemanticFact[]> {
+        const rows = this.db.prepare(`
+            SELECT * FROM semantic_facts
+            WHERE tenant_id = ?
+              AND status = 'approved'
+              AND (subject LIKE ? OR object LIKE ?)
+            ORDER BY confidence DESC
+            LIMIT 20
+        `).all(tenantId, `%${entity}%`, `%${entity}%`) as any[];
+        return rows.map(r => this.rowToFact(r));
+    }
+
+    /** 列出待审批事实 */
+    async pendingFacts(tenantId: string): Promise<SemanticFact[]> {
+        const rows = this.db.prepare(`
+            SELECT * FROM semantic_facts
+            WHERE tenant_id = ? AND status = 'pending'
+            ORDER BY confidence DESC, created_at ASC
+        `).all(tenantId) as any[];
+        return rows.map(r => this.rowToFact(r));
+    }
+
+    /** 审批事实（approve / reject）*/
+    async review(factId: string, decision: 'approve' | 'reject', reviewer: string): Promise<void> {
+        const status = decision === 'approve' ? 'approved' : 'rejected';
+        this.db.prepare(`
+            UPDATE semantic_facts
+            SET status = ?, reviewed_by = ?, reviewed_at = ?
+            WHERE id = ?
+        `).run(status, reviewer, Date.now(), factId);
+        this.logger.info(`[semantic] Fact ${factId} ${status} by ${reviewer}`);
+    }
+
+    /** 所有 tenant facts（管理员视角） */
+    allByTenant(tenantId: string): SemanticFact[] {
+        const rows = this.db.prepare(
+            'SELECT * FROM semantic_facts WHERE tenant_id = ? ORDER BY created_at DESC'
+        ).all(tenantId) as any[];
+        return rows.map(r => this.rowToFact(r));
+    }
+
+    private rowToFact(r: any): SemanticFact {
+        return {
+            id: r.id,
+            tenantId: r.tenant_id,
+            subject: r.subject,
+            predicate: r.predicate,
+            object: r.object,
+            confidence: r.confidence,
+            status: r.status,
+            reviewedBy: r.reviewed_by ?? undefined,
+            reviewedAt: r.reviewed_at ?? undefined,
+            sourceSessionId: r.source_session_id ?? undefined,
+            createdAt: r.created_at,
+        };
+    }
+}

--- a/src/memory/semantic.ts
+++ b/src/memory/semantic.ts
@@ -45,10 +45,10 @@ export class SemanticMemoryStore {
             this.logger.debug(`[semantic] confidence ${fact.confidence} < 0.85, skip`);
             return;
         }
-        // Skip if already approved
+        // Skip if already approved OR pending (prevent duplicate pending for same subject+predicate)
         const existing = this.db.prepare(`
             SELECT id FROM semantic_facts
-            WHERE tenant_id = ? AND subject = ? AND predicate = ? AND status = 'approved'
+            WHERE tenant_id = ? AND subject = ? AND predicate = ? AND status IN ('approved', 'pending')
         `).get(fact.tenantId, fact.subject, fact.predicate);
         if (existing) return;
 
@@ -86,15 +86,20 @@ export class SemanticMemoryStore {
         return rows.map(r => this.rowToFact(r));
     }
 
-    /** 审批事实（approve / reject）*/
-    async review(factId: string, decision: 'approve' | 'reject', reviewer: string): Promise<void> {
+    /** 审批事实（approve / reject）— 强制 tenant_id 隔离 */
+    async review(factId: string, decision: 'approve' | 'reject', reviewer: string, tenantId: string): Promise<boolean> {
         const status = decision === 'approve' ? 'approved' : 'rejected';
-        this.db.prepare(`
+        const result = this.db.prepare(`
             UPDATE semantic_facts
             SET status = ?, reviewed_by = ?, reviewed_at = ?
-            WHERE id = ?
-        `).run(status, reviewer, Date.now(), factId);
-        this.logger.info(`[semantic] Fact ${factId} ${status} by ${reviewer}`);
+            WHERE id = ? AND tenant_id = ? AND status = 'pending'
+        `).run(status, reviewer, Date.now(), factId, tenantId);
+        if (Number(result.changes) === 0) {
+            this.logger.warn(`[semantic] review: fact ${factId} not found or not pending for tenant ${tenantId}`);
+            return false;
+        }
+        this.logger.info(`[semantic] Fact ${factId} ${status} by ${reviewer} (tenant: ${tenantId})`);
+        return true;
     }
 
     /** 所有 tenant facts（管理员视角） */

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Phase 6: Memory 四层统一接口
+ *
+ * L1 Working    — in-context，SDK 自动管理，无需接口
+ * L2 Episodic   — 情景记忆（SQLite FTS5）
+ * L3 Semantic   — 语义/知识图谱（HitL 写入门）
+ * L4 Procedural — 程序规则（SOUL.md / AGENTS.md / SKILL.md）
+ */
+
+// ─── L2 Episodic ──────────────────────────────────────────────────────────────
+
+export interface EpisodicMemory {
+    id: string;
+    tenantId: string;
+    sessionId: string;
+    content: string;
+    category: string;
+    topic: string;
+    /** Unix ms，90 天后过期 */
+    expiresAt: number;
+    createdAt: number;
+    metadata?: Record<string, unknown>;
+}
+
+// ─── L3 Semantic ──────────────────────────────────────────────────────────────
+
+export type SemanticFactStatus = 'pending' | 'approved' | 'rejected';
+
+export interface SemanticFact {
+    id: string;
+    tenantId: string;
+    subject: string;
+    predicate: string;
+    object: string;
+    /** 0–1，LLM 提取时给出，≥ 0.85 才进入 pending */
+    confidence: number;
+    status: SemanticFactStatus;
+    reviewedBy?: string;
+    reviewedAt?: number;
+    createdAt: number;
+    sourceSessionId?: string;
+}
+
+// ─── L4 Procedural ────────────────────────────────────────────────────────────
+
+export interface ProceduralRule {
+    scope: string;    // agent id 或 '*'（全局）
+    tenantId: string;
+    content: string;  // 注入到 system prompt 的纯文本
+    source: string;   // 来源文件路径
+    loadedAt: number;
+}
+
+// ─── Unified query result ──────────────────────────────────────────────────────
+
+export type MemoryLayer = 'episodic' | 'semantic' | 'procedural' | 'short-term';
+
+export interface UnifiedMemoryResult {
+    layer: MemoryLayer;
+    content: string;
+    score: number;
+    metadata?: Record<string, unknown>;
+}
+
+// ─── IMemoryRouter ────────────────────────────────────────────────────────────
+
+export interface IMemoryRouter {
+    // L2 Episodic
+    searchEpisodic(query: string, k: number, tenantId: string): Promise<EpisodicMemory[]>;
+    insertEpisodic(item: Omit<EpisodicMemory, 'id' | 'createdAt' | 'expiresAt'>): Promise<void>;
+
+    // L3 Semantic
+    searchSemantic(entity: string, tenantId: string): Promise<SemanticFact[]>;
+    upsertSemanticFact(fact: Omit<SemanticFact, 'id' | 'createdAt' | 'status'>): Promise<void>;
+    pendingFacts(tenantId: string): Promise<SemanticFact[]>;
+    reviewFact(factId: string, decision: 'approve' | 'reject', reviewer: string): Promise<void>;
+
+    // L4 Procedural
+    loadAgentRules(scope: string, tenantId: string): Promise<string>;
+
+    // Unified
+    query(query: string, opts: { sessionId: string; tenantId: string; limit?: number }): Promise<UnifiedMemoryResult[]>;
+}

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -73,7 +73,7 @@ export interface IMemoryRouter {
     searchSemantic(entity: string, tenantId: string): Promise<SemanticFact[]>;
     upsertSemanticFact(fact: Omit<SemanticFact, 'id' | 'createdAt' | 'status'>): Promise<void>;
     pendingFacts(tenantId: string): Promise<SemanticFact[]>;
-    reviewFact(factId: string, decision: 'approve' | 'reject', reviewer: string): Promise<void>;
+    reviewFact(factId: string, decision: 'approve' | 'reject', reviewer: string, tenantId: string): Promise<boolean>;
 
     // L4 Procedural
     loadAgentRules(scope: string, tenantId: string): Promise<string>;

--- a/tests/memory-phase6.test.ts
+++ b/tests/memory-phase6.test.ts
@@ -150,7 +150,8 @@ describe('SemanticMemoryStore', () => {
             confidence: 0.95,
         });
         const [fact] = await store.pendingFacts('tenant-A');
-        await store.review(fact.id, 'approve', 'admin');
+        const ok = await store.review(fact.id, 'approve', 'admin', 'tenant-A');
+        expect(ok).toBe(true);
 
         const results = await store.search('张三', 'tenant-A');
         expect(results.length).toBeGreaterThan(0);
@@ -166,10 +167,30 @@ describe('SemanticMemoryStore', () => {
             confidence: 0.9,
         });
         const [fact] = await store.pendingFacts('tenant-A');
-        await store.review(fact.id, 'reject', 'admin');
+        const ok = await store.review(fact.id, 'reject', 'admin', 'tenant-A');
+        expect(ok).toBe(true);
 
         const results = await store.search('李四', 'tenant-A');
         expect(results).toHaveLength(0);
+    });
+
+    it('review 跨租户攻击：tenant-B 无法审批 tenant-A 的事实', async () => {
+        await store.upsert({
+            tenantId: 'tenant-A',
+            subject: 'Alice',
+            predicate: '角色',
+            object: '管理员',
+            confidence: 0.95,
+        });
+        const [fact] = await store.pendingFacts('tenant-A');
+        // tenant-B 尝试审批 tenant-A 的事实
+        const ok = await store.review(fact.id, 'approve', 'attacker', 'tenant-B');
+        expect(ok).toBe(false);
+
+        // 事实仍然是 pending 状态
+        const pending = await store.pendingFacts('tenant-A');
+        expect(pending).toHaveLength(1);
+        expect(pending[0].status).toBe('pending');
     });
 
     it('租户隔离：tenant-B 看不到 tenant-A 的 pending facts', async () => {
@@ -187,7 +208,7 @@ describe('SemanticMemoryStore', () => {
     it('已 approved 的 subject+predicate 不重复创建 pending', async () => {
         await store.upsert({ tenantId: 'T', subject: 'A', predicate: 'B', object: 'C', confidence: 0.9 });
         const [f] = await store.pendingFacts('T');
-        await store.review(f.id, 'approve', 'admin');
+        await store.review(f.id, 'approve', 'admin', 'T');
 
         // 再次 upsert 同一 subject+predicate
         await store.upsert({ tenantId: 'T', subject: 'A', predicate: 'B', object: 'D', confidence: 0.95 });
@@ -215,7 +236,7 @@ describe('MemoryRouter (Phase 6)', () => {
         expect(typeof router.searchSemantic).toBe('function');
         expect(typeof router.upsertSemanticFact).toBe('function');
         expect(typeof router.pendingFacts).toBe('function');
-        expect(typeof router.reviewFact).toBe('function');
+        expect(typeof router.reviewFact).toBe('function'); // (factId, decision, reviewer, tenantId) => Promise<boolean>
         expect(typeof router.loadAgentRules).toBe('function');
         expect(typeof router.query).toBe('function');
     });

--- a/tests/memory-phase6.test.ts
+++ b/tests/memory-phase6.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Phase 6: Memory 四层架构测试
+ * 覆盖：EpisodicMemoryStore / SemanticMemoryStore / 租户隔离
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EpisodicMemoryStore } from '../src/memory/episodic.js';
+import { SemanticMemoryStore } from '../src/memory/semantic.js';
+import { MemoryRouter } from '../src/memory/memory-router.js';
+import type { Logger } from '../src/types.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeLogger(): Logger {
+    return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeDb() {
+    const { DatabaseSync } = require('node:sqlite');
+    const db = new DatabaseSync(':memory:');
+    db.exec(`
+        CREATE TABLE episodic_memories (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            content TEXT NOT NULL,
+            category TEXT NOT NULL DEFAULT 'general',
+            topic TEXT NOT NULL DEFAULT '',
+            expires_at INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            metadata TEXT DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_ep_tenant ON episodic_memories(tenant_id);
+        CREATE INDEX IF NOT EXISTS idx_ep_expires ON episodic_memories(expires_at);
+
+        CREATE TABLE semantic_facts (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            predicate TEXT NOT NULL,
+            object TEXT NOT NULL,
+            confidence REAL NOT NULL DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'pending',
+            reviewed_by TEXT,
+            reviewed_at INTEGER,
+            source_session_id TEXT,
+            created_at INTEGER NOT NULL
+        );
+    `);
+    return db;
+}
+
+// ─── EpisodicMemoryStore ──────────────────────────────────────────────────────
+
+describe('EpisodicMemoryStore', () => {
+    let store: EpisodicMemoryStore;
+    const logger = makeLogger();
+
+    beforeEach(() => {
+        store = new EpisodicMemoryStore(makeDb(), logger);
+        store.initialize();
+    });
+
+    it('insert + search 基本流程', async () => {
+        await store.insert({
+            tenantId: 'tenant-A',
+            sessionId: 'sess-1',
+            content: '用户喜欢简洁的回复风格',
+            category: 'user',
+            topic: 'preference',
+        });
+        const results = await store.search('简洁', 5, 'tenant-A');
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0].content).toContain('简洁');
+    });
+
+    it('租户隔离：tenant-B 查不到 tenant-A 的记忆', async () => {
+        await store.insert({
+            tenantId: 'tenant-A',
+            sessionId: 's1',
+            content: '机密内容仅限A租户',
+            category: 'governance',
+            topic: 'secret',
+        });
+        const resultsB = await store.search('机密内容', 5, 'tenant-B');
+        expect(resultsB).toHaveLength(0);
+    });
+
+    it('purgeExpired 清理过期记忆', async () => {
+        const db = makeDb();
+        const s = new EpisodicMemoryStore(db, logger);
+        s.initialize();
+
+        // 直接插入一条已过期的记录
+        db.prepare(`
+            INSERT INTO episodic_memories (id, tenant_id, session_id, content, category, topic, expires_at, created_at)
+            VALUES ('exp-1', 'tenant-A', 'sess-x', 'expired', 'general', '', 1, 1)
+        `).run();
+
+        const deleted = s.purgeExpired();
+        expect(deleted).toBe(1);
+
+        const remaining = await s.search('expired', 5, 'tenant-A');
+        expect(remaining).toHaveLength(0);
+    });
+});
+
+// ─── SemanticMemoryStore ──────────────────────────────────────────────────────
+
+describe('SemanticMemoryStore', () => {
+    let store: SemanticMemoryStore;
+    const logger = makeLogger();
+
+    beforeEach(() => {
+        store = new SemanticMemoryStore(makeDb(), logger);
+        store.initialize();
+    });
+
+    it('upsert confidence < 0.85 被过滤', async () => {
+        await store.upsert({
+            tenantId: 'tenant-A',
+            subject: '张三',
+            predicate: '职位',
+            object: '工程师',
+            confidence: 0.7,
+        });
+        const pending = await store.pendingFacts('tenant-A');
+        expect(pending).toHaveLength(0);
+    });
+
+    it('upsert confidence >= 0.85 进入 pending', async () => {
+        await store.upsert({
+            tenantId: 'tenant-A',
+            subject: '张三',
+            predicate: '职位',
+            object: '工程师',
+            confidence: 0.9,
+        });
+        const pending = await store.pendingFacts('tenant-A');
+        expect(pending).toHaveLength(1);
+        expect(pending[0].status).toBe('pending');
+    });
+
+    it('review approve → status 变为 approved，可被 search 查到', async () => {
+        await store.upsert({
+            tenantId: 'tenant-A',
+            subject: '张三',
+            predicate: '技能',
+            object: 'TypeScript',
+            confidence: 0.95,
+        });
+        const [fact] = await store.pendingFacts('tenant-A');
+        await store.review(fact.id, 'approve', 'admin');
+
+        const results = await store.search('张三', 'tenant-A');
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0].status).toBe('approved');
+    });
+
+    it('review reject → 不出现在 search 结果', async () => {
+        await store.upsert({
+            tenantId: 'tenant-A',
+            subject: '李四',
+            predicate: '爱好',
+            object: '钓鱼',
+            confidence: 0.9,
+        });
+        const [fact] = await store.pendingFacts('tenant-A');
+        await store.review(fact.id, 'reject', 'admin');
+
+        const results = await store.search('李四', 'tenant-A');
+        expect(results).toHaveLength(0);
+    });
+
+    it('租户隔离：tenant-B 看不到 tenant-A 的 pending facts', async () => {
+        await store.upsert({
+            tenantId: 'tenant-A',
+            subject: 'X',
+            predicate: 'Y',
+            object: 'Z',
+            confidence: 0.95,
+        });
+        const pendingB = await store.pendingFacts('tenant-B');
+        expect(pendingB).toHaveLength(0);
+    });
+
+    it('已 approved 的 subject+predicate 不重复创建 pending', async () => {
+        await store.upsert({ tenantId: 'T', subject: 'A', predicate: 'B', object: 'C', confidence: 0.9 });
+        const [f] = await store.pendingFacts('T');
+        await store.review(f.id, 'approve', 'admin');
+
+        // 再次 upsert 同一 subject+predicate
+        await store.upsert({ tenantId: 'T', subject: 'A', predicate: 'B', object: 'D', confidence: 0.95 });
+        const pending2 = await store.pendingFacts('T');
+        expect(pending2).toHaveLength(0); // 跳过了
+    });
+});
+
+// ─── IMemoryRouter 接口 ───────────────────────────────────────────────────────
+
+describe('MemoryRouter (Phase 6)', () => {
+    it('实现 IMemoryRouter 接口的方法签名', () => {
+        const mockLongTerm = { search: vi.fn().mockResolvedValue([]) } as any;
+        const mockKG = { search: vi.fn().mockResolvedValue({ nodes: [], relevanceScores: {} }) } as any;
+        const mockSession = {} as any;
+        const episodic = new EpisodicMemoryStore(makeDb(), makeLogger());
+        episodic.initialize();
+        const semantic = new SemanticMemoryStore(makeDb(), makeLogger());
+        semantic.initialize();
+
+        const router = new MemoryRouter(mockLongTerm, mockKG, mockSession, episodic, semantic);
+
+        expect(typeof router.searchEpisodic).toBe('function');
+        expect(typeof router.insertEpisodic).toBe('function');
+        expect(typeof router.searchSemantic).toBe('function');
+        expect(typeof router.upsertSemanticFact).toBe('function');
+        expect(typeof router.pendingFacts).toBe('function');
+        expect(typeof router.reviewFact).toBe('function');
+        expect(typeof router.loadAgentRules).toBe('function');
+        expect(typeof router.query).toBe('function');
+    });
+
+    it('query() 返回 layer 字段（非旧版 source）', async () => {
+        const mockLongTerm = { search: vi.fn().mockResolvedValue([{ content: 'lt result', metadata: {} }]) } as any;
+        const mockKG = { search: vi.fn().mockResolvedValue({ nodes: [], relevanceScores: {} }) } as any;
+        const router = new MemoryRouter(mockLongTerm, mockKG, {} as any);
+
+        const results = await router.query('test', { sessionId: 's1', tenantId: 'T' });
+        expect(results[0]).toHaveProperty('layer');
+    });
+});


### PR DESCRIPTION
## Summary

Phase 6 将现有三套独立记忆系统重构为**四层统一架构**，并引入 tenant_id 强制隔离。

| 层级 | 实现 | 说明 |
|---|---|---|
| L1 Working | SDK 自动管理 | 无需接口 |
| L2 Episodic | `EpisodicMemoryStore` | SQLite FTS5 + LIKE fallback，90天TTL，tenant隔离 |
| L3 Semantic | `SemanticMemoryStore` | HitL写入门（confidence≥0.85→pending→approve/reject） |
| L4 Procedural | `ProceduralMemory` | SOUL.md/AGENTS.md 热加载，注入system prompt |

## Changes

### New Files
- `src/memory/types.ts` — `IMemoryRouter` 接口 + 四层类型定义
- `src/memory/episodic.ts` — L2 实现（FTS5子查询 + tenant过滤 + TTL清理）
- `src/memory/semantic.ts` — L3 实现（HitL pending/approve/reject + 幂等性）
- `src/memory/procedural.ts` — L4 实现（fs.watch 热重载）

### Modified
- `src/memory/memory-router.ts` — 实现 `IMemoryRouter`，向后兼容 legacy LongTermMemory
- `src/memory/index.ts` — 导出新模块
- `src/core/database.ts` — 自动建表 `episodic_memories` + `semantic_facts`
- `src/index.ts` — 初始化四层存储，注入 MemoryRouter
- `src/gateway/server.ts` — Semantic HitL 端点（`/api/semantic-facts/*`）
- `src/core/agent-run-helpers.ts` — memory_recall 传 tenantId

## Test plan
- [ ] `npx vitest run tests/memory-phase6.test.ts` — 11 tests pass
- [ ] 租户隔离：tenant-A 写入的记忆/事实，tenant-B 查不到（测试覆盖）
- [ ] Semantic HitL 流程：upsert → pending → approve → search 可查到
- [ ] `GET /api/semantic-facts/pending?tenantId=X` 返回待审批列表
- [ ] `POST /api/semantic-facts/:id/review` approve/reject 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)