### PR TITLE
feat(phase7): 企业 IM 一等公民 — IChannel 抽象 + 飞书强化 + 钉钉新增

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -96,6 +96,11 @@ im:
     appSecret:         ${FEISHU_APP_SECRET:}
     verificationToken: ${FEISHU_VERIFY_TOKEN:}
     encryptKey:        ${FEISHU_ENCRYPT_KEY:}
+  dingtalk:
+    appKey:            ${DINGTALK_APP_KEY:}
+    appSecret:         ${DINGTALK_APP_SECRET:}
+    signingSecret:     ${DINGTALK_SIGNING_SECRET:}
+    corpId:            ${DINGTALK_CORP_ID:}
   defaultRole: user
   hitlTimeoutMinutes: 30
 

--- a/src/channels/dingtalk.ts
+++ b/src/channels/dingtalk.ts
@@ -59,7 +59,12 @@ export class DingTalkChannel implements IChannel {
             .update(content)
             .digest('base64');
 
-        return expected === decodeURIComponent(sign);
+        const decoded = decodeURIComponent(sign);
+        try {
+            return crypto.timingSafeEqual(Buffer.from(expected, 'base64'), Buffer.from(decoded, 'base64'));
+        } catch {
+            return false;
+        }
     }
 
     // ─── parseInboundMessage ─────────────────────────────────────────────────
@@ -191,12 +196,15 @@ export class DingTalkChannel implements IChannel {
 
         if (!res.ok) {
             const text = await res.text().catch(() => '');
-            this.logger.error(`[dingtalk] POST ${url} → ${res.status}: ${text.slice(0, 200)}`);
-        } else {
-            const data = await res.json().catch(() => ({})) as any;
-            if (data?.errcode && data.errcode !== 0) {
-                this.logger.warn(`[dingtalk] API error: ${data.errmsg} (${data.errcode})`);
-            }
+            const msg = `[dingtalk] POST ${url} → ${res.status}: ${text.slice(0, 200)}`;
+            this.logger.error(msg);
+            throw new Error(msg);
+        }
+        const data = await res.json().catch(() => ({})) as any;
+        if (data?.errcode && data.errcode !== 0) {
+            const msg = `[dingtalk] API error: ${data.errmsg} (${data.errcode})`;
+            this.logger.error(msg);
+            throw new Error(msg);
         }
     }
 

--- a/src/channels/dingtalk.ts
+++ b/src/channels/dingtalk.ts
@@ -1,0 +1,208 @@
+/**
+ * Phase 7: DingTalkChannel — 钉钉自建应用机器人
+ *
+ * 实现：
+ *  - 签名验证：timestamp + '\n' + secret → HMAC-SHA256 Base64
+ *  - 消息接收：回调事件格式（msgtype=text）
+ *  - ActionCard 交互卡片（HitL 审批）
+ *  - access_token 缓存（7200s 官方 TTL，缓存 1800s）
+ *  - health()：调用 /gettoken 端点
+ */
+
+import crypto from 'crypto';
+import type { IChannel, IncomingMessage, ChannelTarget, ChannelMessage, ApprovalRequest, StatusKind, RiskLevel } from './types.js';
+import type { Logger } from '../types.js';
+
+export interface DingTalkChannelConfig {
+    /** 应用 AppKey */
+    appKey: string;
+    /** 应用 AppSecret */
+    appSecret: string;
+    /** 机器人 outgoing webhook 签名 token */
+    signingSecret: string;
+    /** 企业 CorpId（用于 API 鉴权） */
+    corpId?: string;
+}
+
+const RISK_COLOR: Record<RiskLevel, string> = {
+    low: '#36a64f',
+    medium: '#f0ad4e',
+    high: '#ff7f00',
+    critical: '#d9534f',
+};
+
+export class DingTalkChannel implements IChannel {
+    readonly name = 'dingtalk';
+
+    private cfg: DingTalkChannelConfig;
+    private logger: Logger;
+
+    private tokenCache: { token: string; expiresAt: number } | null = null;
+
+    constructor(cfg: DingTalkChannelConfig, logger: Logger) {
+        this.cfg = cfg;
+        this.logger = logger;
+    }
+
+    // ─── verifyRequest ────────────────────────────────────────────────────────
+
+    verifyRequest(headers: Record<string, string>, rawBody: string): boolean {
+        // 钉钉签名：HmacSHA256(timestamp + '\n' + token) → Base64
+        const ts = headers['timestamp'];
+        const sign = headers['sign'];
+
+        if (!ts || !sign) return false;
+
+        const content = ts + '\n' + this.cfg.signingSecret;
+        const expected = crypto
+            .createHmac('sha256', this.cfg.signingSecret)
+            .update(content)
+            .digest('base64');
+
+        return expected === decodeURIComponent(sign);
+    }
+
+    // ─── parseInboundMessage ─────────────────────────────────────────────────
+
+    parseInboundMessage(body: unknown): IncomingMessage | null {
+        const b = body as any;
+
+        // 只处理文本消息
+        if (b?.msgtype !== 'text') return null;
+
+        let text: string = (b?.text?.content ?? '').trim();
+        // 去掉 @机器人 mention
+        text = text.replace(/@\S+/g, '').trim();
+        if (!text) return null;
+
+        const userId: string = b?.senderStaffId ?? b?.senderId ?? '';
+        const conversationId: string = b?.conversationId ?? b?.chatId ?? '';
+
+        return {
+            channelName: this.name,
+            userId,
+            conversationId,
+            text,
+            raw: b,
+        };
+    }
+
+    // ─── send ─────────────────────────────────────────────────────────────────
+
+    async send(target: ChannelTarget, message: ChannelMessage): Promise<void> {
+        const token = await this.getToken();
+        const chatId = (target.extra?.chatId as string) ?? target.conversationId;
+
+        await this.post(
+            `https://oapi.dingtalk.com/topapi/im/chat/scencegroup/message/send_v2?access_token=${token}`,
+            {
+                chat_id: chatId,
+                msg: { msgtype: 'text', text: { content: message.text } },
+            },
+        );
+    }
+
+    // ─── sendApprovalCard ─────────────────────────────────────────────────────
+
+    async sendApprovalCard(target: ChannelTarget, req: ApprovalRequest): Promise<void> {
+        const token = await this.getToken();
+        const chatId = (target.extra?.chatId as string) ?? target.conversationId;
+        const color = RISK_COLOR[req.riskLevel];
+
+        const baseUrl = req.cardActionUrl;
+        const approveUrl = `${baseUrl}?action=approve&interrupt_id=${encodeURIComponent(req.interruptId)}&session_id=${encodeURIComponent(req.sessionId)}&channel=dingtalk`;
+        const rejectUrl = `${baseUrl}?action=reject&interrupt_id=${encodeURIComponent(req.interruptId)}&session_id=${encodeURIComponent(req.sessionId)}&channel=dingtalk`;
+
+        const btns: unknown[] = [
+            { title: '✅ 确认执行', actionURL: approveUrl },
+            { title: '❌ 拒绝', actionURL: rejectUrl },
+        ];
+
+        if (req.allowModify) {
+            const modifyUrl = `${baseUrl}?action=modify&interrupt_id=${encodeURIComponent(req.interruptId)}&session_id=${encodeURIComponent(req.sessionId)}&channel=dingtalk`;
+            btns.push({ title: '✏️ 带修改批准', actionURL: modifyUrl });
+        }
+
+        const card = {
+            msgtype: 'action_card',
+            action_card: {
+                title: `⚠️ 高危操作确认 [${req.riskLevel.toUpperCase()}]`,
+                markdown: `**工具**：\`${req.toolName}\`\n\n**风险**：${req.reason}\n\n<font color="${color}">▌ 风险等级：${req.riskLevel.toUpperCase()}</font>`,
+                btn_orientation: '1',
+                btns,
+            },
+        };
+
+        await this.post(
+            `https://oapi.dingtalk.com/topapi/im/chat/scencegroup/message/send_v2?access_token=${token}`,
+            { chat_id: chatId, msg: card },
+        );
+    }
+
+    // ─── sendStatus ───────────────────────────────────────────────────────────
+
+    async sendStatus(target: ChannelTarget, kind: StatusKind, detail?: string): Promise<void> {
+        const labels: Record<StatusKind, string> = {
+            processing: '⏳ 正在处理中...',
+            done: '✅ 已完成',
+            error: `❌ 出现错误${detail ? '：' + detail : ''}`,
+        };
+        await this.send(target, { text: labels[kind] });
+    }
+
+    // ─── health ───────────────────────────────────────────────────────────────
+
+    async health(): Promise<{ ok: boolean; latencyMs?: number; details?: string }> {
+        const t0 = Date.now();
+        try {
+            await this.getToken(true);
+            return { ok: true, latencyMs: Date.now() - t0 };
+        } catch (err) {
+            return { ok: false, latencyMs: Date.now() - t0, details: (err as Error).message };
+        }
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private async getToken(forceRefresh = false): Promise<string> {
+        if (!forceRefresh && this.tokenCache && Date.now() < this.tokenCache.expiresAt) {
+            return this.tokenCache.token;
+        }
+
+        const url = `https://oapi.dingtalk.com/gettoken?appkey=${encodeURIComponent(this.cfg.appKey)}&appsecret=${encodeURIComponent(this.cfg.appSecret)}`;
+        const res = await fetch(url);
+        const data = await res.json() as any;
+
+        if (data.errcode !== 0 || !data.access_token) {
+            throw new Error(`[dingtalk] getToken failed: ${JSON.stringify(data)}`);
+        }
+
+        // 官方 7200s，保守缓存 1800s
+        this.tokenCache = { token: data.access_token, expiresAt: Date.now() + 1800_000 };
+        return this.tokenCache.token;
+    }
+
+    private async post(url: string, body: unknown): Promise<void> {
+        const res = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+
+        if (!res.ok) {
+            const text = await res.text().catch(() => '');
+            this.logger.error(`[dingtalk] POST ${url} → ${res.status}: ${text.slice(0, 200)}`);
+        } else {
+            const data = await res.json().catch(() => ({})) as any;
+            if (data?.errcode && data.errcode !== 0) {
+                this.logger.warn(`[dingtalk] API error: ${data.errmsg} (${data.errcode})`);
+            }
+        }
+    }
+
+    /** 从卡片 callback body（GET querystring 已解析为 body）提取 userId */
+    static extractOperatorUserId(body: unknown): string {
+        const b = body as any;
+        return b?.staffId ?? b?.senderStaffId ?? b?.userId ?? 'unknown';
+    }
+}

--- a/src/channels/feishu.ts
+++ b/src/channels/feishu.ts
@@ -57,7 +57,11 @@ export class FeishuChannel implements IChannel {
             .update(ts + nonce + key + rawBody)
             .digest('hex');
 
-        return expected === sig;
+        try {
+            return crypto.timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(sig, 'hex'));
+        } catch {
+            return false;
+        }
     }
 
     // ─── parseInboundMessage ─────────────────────────────────────────────────
@@ -259,7 +263,9 @@ export class FeishuChannel implements IChannel {
 
         if (!res.ok) {
             const text = await res.text().catch(() => '');
-            this.logger.error(`[feishu] POST ${url} → ${res.status}: ${text.slice(0, 200)}`);
+            const msg = `[feishu] POST ${url} → ${res.status}: ${text.slice(0, 200)}`;
+            this.logger.error(msg);
+            throw new Error(msg);
         }
     }
 

--- a/src/channels/feishu.ts
+++ b/src/channels/feishu.ts
@@ -1,0 +1,286 @@
+/**
+ * Phase 7: FeishuChannel — 飞书企业版 OpenAPI v3 完整实现
+ *
+ * 改进项（相对 im-gateway.ts FeishuAdapter）：
+ *  - access_token 30 分钟缓存，避免每次请求都换 token
+ *  - riskLevel → 卡片颜色（green/yellow/orange/red）
+ *  - allowModify → 第三态"带修改批准"按钮
+ *  - AES 消息加密解密支持（encryptKey 非空时自动解密）
+ *  - health() 实现（调用 /auth/v3/app_ticket）
+ */
+
+import crypto from 'crypto';
+import type { IChannel, IncomingMessage, ChannelTarget, ChannelMessage, ApprovalRequest, StatusKind, RiskLevel } from './types.js';
+import type { Logger } from '../types.js';
+
+export interface FeishuChannelConfig {
+    appId: string;
+    appSecret: string;
+    verificationToken: string;
+    /** AES 解密 key（16/24/32 字节）；留空则不做消息加密 */
+    encryptKey?: string;
+}
+
+const RISK_COLOR: Record<RiskLevel, string> = {
+    low: 'green',
+    medium: 'yellow',
+    high: 'orange',
+    critical: 'red',
+};
+
+export class FeishuChannel implements IChannel {
+    readonly name = 'feishu';
+
+    private cfg: FeishuChannelConfig;
+    private logger: Logger;
+
+    /** tenant_access_token 缓存 */
+    private tokenCache: { token: string; expiresAt: number } | null = null;
+
+    constructor(cfg: FeishuChannelConfig, logger: Logger) {
+        this.cfg = cfg;
+        this.logger = logger;
+    }
+
+    // ─── verifyRequest ────────────────────────────────────────────────────────
+
+    verifyRequest(headers: Record<string, string>, rawBody: string): boolean {
+        const sig = headers['x-lark-signature'] ?? headers['X-Lark-Signature'];
+        const ts = headers['x-lark-request-timestamp'] ?? headers['X-Lark-Request-Timestamp'];
+        const nonce = headers['x-lark-request-nonce'] ?? headers['X-Lark-Request-Nonce'];
+
+        if (!sig || !ts || !nonce) return false;
+
+        const key = this.cfg.encryptKey || this.cfg.verificationToken;
+        const expected = crypto
+            .createHmac('sha256', key)
+            .update(ts + nonce + key + rawBody)
+            .digest('hex');
+
+        return expected === sig;
+    }
+
+    // ─── parseInboundMessage ─────────────────────────────────────────────────
+
+    parseInboundMessage(body: unknown): IncomingMessage | null {
+        let b = body as any;
+
+        // AES 加密消息解密
+        if (b?.encrypt && this.cfg.encryptKey) {
+            try {
+                b = this.decryptMessage(b.encrypt);
+            } catch (err) {
+                this.logger.warn(`[feishu] AES decrypt failed: ${(err as Error).message}`);
+                return null;
+            }
+        }
+
+        // URL 验证 challenge
+        if (b?.challenge) return null;
+
+        const event = b?.event;
+        if (b?.header?.event_type !== 'im.message.receive_v1' || !event) return null;
+
+        const msgType = event.message?.message_type;
+        if (msgType !== 'text') return null;
+
+        let text: string;
+        try {
+            text = (JSON.parse(event.message.content).text ?? '').trim();
+        } catch {
+            return null;
+        }
+
+        text = text.replace(/@\S+/g, '').trim();
+        if (!text) return null;
+
+        const userId = event.sender?.sender_id?.open_id ?? event.sender?.sender_id?.user_id ?? '';
+        const chatId = event.message?.chat_id ?? '';
+        const messageId = event.message?.message_id ?? '';
+
+        return {
+            channelName: this.name,
+            userId,
+            conversationId: chatId,
+            text,
+            raw: b,
+            attachments: [],
+        };
+    }
+
+    // ─── send ─────────────────────────────────────────────────────────────────
+
+    async send(target: ChannelTarget, message: ChannelMessage): Promise<void> {
+        const token = await this.getToken();
+        const chatId = (target.extra?.chatId as string) ?? target.conversationId;
+
+        await this.post(
+            'https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id',
+            token,
+            {
+                receive_id: chatId,
+                msg_type: 'text',
+                content: JSON.stringify({ text: message.text }),
+            },
+        );
+    }
+
+    // ─── sendApprovalCard ─────────────────────────────────────────────────────
+
+    async sendApprovalCard(target: ChannelTarget, req: ApprovalRequest): Promise<void> {
+        const token = await this.getToken();
+        const chatId = (target.extra?.chatId as string) ?? target.conversationId;
+        const color = RISK_COLOR[req.riskLevel];
+
+        const actions: unknown[] = [
+            {
+                tag: 'button',
+                text: { tag: 'plain_text', content: '✅ 确认执行' },
+                type: 'primary',
+                value: {
+                    action: 'approve',
+                    interrupt_id: req.interruptId,
+                    session_id: req.sessionId,
+                    channel: this.name,
+                },
+                url: req.cardActionUrl,
+            },
+            {
+                tag: 'button',
+                text: { tag: 'plain_text', content: '❌ 拒绝' },
+                type: 'danger',
+                value: {
+                    action: 'reject',
+                    interrupt_id: req.interruptId,
+                    session_id: req.sessionId,
+                    channel: this.name,
+                },
+                url: req.cardActionUrl,
+            },
+        ];
+
+        if (req.allowModify) {
+            actions.push({
+                tag: 'button',
+                text: { tag: 'plain_text', content: '✏️ 带修改批准' },
+                type: 'default',
+                value: {
+                    action: 'modify',
+                    interrupt_id: req.interruptId,
+                    session_id: req.sessionId,
+                    channel: this.name,
+                },
+                url: req.cardActionUrl,
+            });
+        }
+
+        const card = {
+            msg_type: 'interactive',
+            card: {
+                header: {
+                    title: { tag: 'plain_text', content: `⚠️ 高危操作确认 [${req.riskLevel.toUpperCase()}]` },
+                    template: color,
+                },
+                elements: [
+                    {
+                        tag: 'div',
+                        text: {
+                            tag: 'lark_md',
+                            content: `**工具**：\`${req.toolName}\`\n**风险**：${req.reason}`,
+                        },
+                    },
+                    { tag: 'action', actions },
+                ],
+            },
+        };
+
+        await this.post(
+            'https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id',
+            token,
+            { receive_id: chatId, ...card },
+        );
+    }
+
+    // ─── sendStatus ───────────────────────────────────────────────────────────
+
+    async sendStatus(target: ChannelTarget, kind: StatusKind, detail?: string): Promise<void> {
+        const labels: Record<StatusKind, string> = {
+            processing: '⏳ 正在处理中...',
+            done: '✅ 已完成',
+            error: `❌ 出现错误${detail ? '：' + detail : ''}`,
+        };
+        await this.send(target, { text: labels[kind] });
+    }
+
+    // ─── health ───────────────────────────────────────────────────────────────
+
+    async health(): Promise<{ ok: boolean; latencyMs?: number; details?: string }> {
+        const t0 = Date.now();
+        try {
+            await this.getToken(true);
+            return { ok: true, latencyMs: Date.now() - t0 };
+        } catch (err) {
+            return { ok: false, latencyMs: Date.now() - t0, details: (err as Error).message };
+        }
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private async getToken(forceRefresh = false): Promise<string> {
+        if (!forceRefresh && this.tokenCache && Date.now() < this.tokenCache.expiresAt) {
+            return this.tokenCache.token;
+        }
+
+        const res = await fetch('https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ app_id: this.cfg.appId, app_secret: this.cfg.appSecret }),
+        });
+
+        const data = await res.json() as any;
+        if (!data.tenant_access_token) {
+            throw new Error(`[feishu] getToken failed: ${JSON.stringify(data)}`);
+        }
+
+        // 飞书 token 有效期 7200s，缓存 1800s（30 分钟）保守处理
+        this.tokenCache = { token: data.tenant_access_token, expiresAt: Date.now() + 1800_000 };
+        return this.tokenCache.token;
+    }
+
+    private async post(url: string, token: string, body: unknown): Promise<void> {
+        const res = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(body),
+        });
+
+        if (!res.ok) {
+            const text = await res.text().catch(() => '');
+            this.logger.error(`[feishu] POST ${url} → ${res.status}: ${text.slice(0, 200)}`);
+        }
+    }
+
+    /** AES-256-CBC 解密飞书加密消息 */
+    private decryptMessage(encrypted: string): unknown {
+        if (!this.cfg.encryptKey) throw new Error('encryptKey not configured');
+
+        // 飞书 AES key：SHA256(encryptKey) 取前 32 字节
+        const key = crypto.createHash('sha256').update(this.cfg.encryptKey).digest().subarray(0, 32);
+        const buf = Buffer.from(encrypted, 'base64');
+        const iv = buf.subarray(0, 16);
+        const ciphertext = buf.subarray(16);
+
+        const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+        const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf-8');
+        return JSON.parse(decrypted);
+    }
+
+    /** 从卡片 callback body 提取 userId（兼容飞书 2.0 / 3.0 格式） */
+    static extractOperatorUserId(body: unknown): string {
+        const b = body as any;
+        return b?.operator?.open_id ?? b?.open_id ?? b?.user_id ?? 'unknown';
+    }
+}

--- a/src/channels/hitl-card-renderer.ts
+++ b/src/channels/hitl-card-renderer.ts
@@ -52,6 +52,7 @@ export class HitlCardRenderer {
             onTimeout();
         }, timeoutMs);
 
+        this.clear(req.interruptId); // 防止重复调用导致旧定时器泄漏
         this.pending.set(req.interruptId, {
             interruptId: req.interruptId,
             sessionId: req.sessionId,

--- a/src/channels/hitl-card-renderer.ts
+++ b/src/channels/hitl-card-renderer.ts
@@ -1,0 +1,119 @@
+/**
+ * Phase 7: HitlCardRenderer — HitL 审批卡片统一管理
+ *
+ * 职责：
+ *  - 向目标渠道发送审批卡片
+ *  - 管理超时定时器（默认 5 分钟，超时自动 reject）
+ *  - 解析卡片 callback body 为 CardActionPayload
+ */
+
+import type { IChannel, ChannelTarget, ApprovalRequest, CardActionPayload, ApprovalDecision } from './types.js';
+import type { Logger } from '../types.js';
+import { FeishuChannel } from './feishu.js';
+import { DingTalkChannel } from './dingtalk.js';
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 分钟
+
+interface PendingCard {
+    interruptId: string;
+    sessionId: string;
+    channelName: string;
+    timer: NodeJS.Timeout;
+    onTimeout: () => void;
+}
+
+export class HitlCardRenderer {
+    private pending = new Map<string, PendingCard>();
+    private logger: Logger;
+
+    constructor(logger: Logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * 向指定渠道发送审批卡片，并注册超时定时器。
+     * @param channel 目标渠道实例
+     * @param target  目标用户/会话
+     * @param req     审批请求
+     * @param onTimeout 超时回调（一般是 resolveInterrupt(false)）
+     */
+    async send(
+        channel: IChannel,
+        target: ChannelTarget,
+        req: ApprovalRequest,
+        onTimeout: () => void,
+    ): Promise<void> {
+        await channel.sendApprovalCard(target, req);
+
+        const timeoutMs = (req.timeoutSeconds ?? DEFAULT_TIMEOUT_MS / 1000) * 1000;
+        const timer = setTimeout(() => {
+            this.logger.warn(`[hitl] timeout interruptId=${req.interruptId} sessionId=${req.sessionId}`);
+            this.pending.delete(req.interruptId);
+            onTimeout();
+        }, timeoutMs);
+
+        this.pending.set(req.interruptId, {
+            interruptId: req.interruptId,
+            sessionId: req.sessionId,
+            channelName: channel.name,
+            timer,
+            onTimeout,
+        });
+
+        this.logger.info(`[hitl] card sent interruptId=${req.interruptId} timeout=${timeoutMs}ms`);
+    }
+
+    /** 卡片已被用户点击，清除定时器 */
+    clear(interruptId: string): void {
+        const p = this.pending.get(interruptId);
+        if (p) {
+            clearTimeout(p.timer);
+            this.pending.delete(interruptId);
+        }
+    }
+
+    /**
+     * 解析卡片 callback body 为标准 CardActionPayload。
+     * 兼容飞书（body.action.value）和钉钉（querystring 已解析为 body）两种格式。
+     */
+    static parseCardAction(channelName: string, body: unknown): CardActionPayload | null {
+        const b = body as any;
+
+        // 飞书格式：body.action.value
+        const feishuValue = b?.action?.value;
+        if (feishuValue?.interrupt_id) {
+            return {
+                channelName,
+                interruptId: feishuValue.interrupt_id,
+                sessionId: feishuValue.session_id ?? '',
+                decision: (feishuValue.action as ApprovalDecision) ?? 'reject',
+                operatorUserId: FeishuChannel.extractOperatorUserId(body),
+            };
+        }
+
+        // 钉钉格式：querystring 参数
+        if (b?.interrupt_id) {
+            return {
+                channelName,
+                interruptId: b.interrupt_id,
+                sessionId: b.session_id ?? '',
+                decision: (b.action as ApprovalDecision) ?? 'reject',
+                operatorUserId: DingTalkChannel.extractOperatorUserId(body),
+            };
+        }
+
+        return null;
+    }
+
+    get pendingCount(): number {
+        return this.pending.size;
+    }
+
+    /** 停止所有定时器（graceful shutdown） */
+    destroy(): void {
+        for (const p of this.pending.values()) {
+            clearTimeout(p.timer);
+        }
+        this.pending.clear();
+    }
+}

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -1,0 +1,19 @@
+export { FeishuChannel } from './feishu.js';
+export { DingTalkChannel } from './dingtalk.js';
+export { WeComChannel } from './wecom.js';
+export { TeamsChannel } from './teams.js';
+export { HitlCardRenderer } from './hitl-card-renderer.js';
+export { ChannelRouter } from './router.js';
+export type {
+    IChannel,
+    IncomingMessage,
+    ChannelTarget,
+    ChannelMessage,
+    ApprovalRequest,
+    ApprovalResponse,
+    ApprovalDecision,
+    CardActionPayload,
+    RiskLevel,
+    StatusKind,
+    Attachment,
+} from './types.js';

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1,0 +1,278 @@
+/**
+ * Phase 7: ChannelRouter — 多渠道统一分发器
+ *
+ * 职责：
+ *  - 注册/注销渠道（IChannel）
+ *  - handleInbound：验签 → 解析 → 鉴权 → 会话映射 → 异步执行 Agent
+ *  - handleCardAction：解析 HitL callback → resolveInterrupt
+ *  - health：汇总所有渠道健康状态
+ *
+ * 与旧 ImGateway 的区别：
+ *  - 支持多渠道同时注册，按 channelName 路由
+ *  - HitL 由 HitlCardRenderer 统一管理（超时、解析）
+ *  - 鉴权/会话映射复用 imUserRegistry / imSessionMapper
+ */
+
+import { nanoid } from 'nanoid';
+import { auditRepository } from '../core/audit-repository.js';
+import { resolveInterrupt, hasPendingInterrupt, getPendingInterruptMeta } from '../core/interrupt-coordinator.js';
+import { imUserRegistry, imSessionMapper } from '../gateway/im-gateway.js';
+import { HitlCardRenderer } from './hitl-card-renderer.js';
+import type { IChannel, ChannelTarget, ApprovalRequest } from './types.js';
+import type { Logger } from '../types.js';
+
+export interface ChannelRouterOptions {
+    logger: Logger;
+    /** Agent 执行函数：返回最终答案字符串 */
+    runAgent: (prompt: string, sessionId: string) => Promise<string>;
+    /** 默认角色（新用户自动注册时使用）：'user' = 允许，'blocked' = 拒绝 */
+    defaultRole?: string;
+    /** HitL 审批卡片 callback base URL */
+    cardActionBaseUrl?: string;
+}
+
+export class ChannelRouter {
+    private channels = new Map<string, IChannel>();
+    private hitl: HitlCardRenderer;
+    private logger: Logger;
+    private runAgent: ChannelRouterOptions['runAgent'];
+    private defaultRole: string;
+    private cardActionBaseUrl: string;
+
+    constructor(opts: ChannelRouterOptions) {
+        this.logger = opts.logger;
+        this.runAgent = opts.runAgent;
+        this.defaultRole = opts.defaultRole ?? 'user';
+        this.cardActionBaseUrl = opts.cardActionBaseUrl ?? 'http://localhost:3000';
+        this.hitl = new HitlCardRenderer(opts.logger);
+    }
+
+    // ─── Channel Registry ─────────────────────────────────────────────────────
+
+    register(channel: IChannel): void {
+        this.channels.set(channel.name, channel);
+        this.logger.info(`[channel-router] registered channel: ${channel.name}`);
+    }
+
+    unregister(channelName: string): void {
+        this.channels.delete(channelName);
+    }
+
+    getChannel(name: string): IChannel | undefined {
+        return this.channels.get(name);
+    }
+
+    listChannels(): string[] {
+        return [...this.channels.keys()];
+    }
+
+    // ─── Inbound ──────────────────────────────────────────────────────────────
+
+    /**
+     * 处理入站 IM 事件。
+     * @returns HTTP 响应体（需由调用者作为 JSON response 返回）
+     */
+    async handleInbound(
+        channelName: string,
+        rawBody: string,
+        headers: Record<string, string>,
+    ): Promise<unknown> {
+        const channel = this.channels.get(channelName);
+        if (!channel) {
+            return { error: `Unknown channel: ${channelName}`, code: 404 };
+        }
+
+        // 1. 签名验证
+        if (!channel.verifyRequest(headers, rawBody)) {
+            this.logger.warn(`[channel-router] signature failed channel=${channelName}`);
+            return { error: 'Unauthorized', code: 401 };
+        }
+
+        let body: unknown;
+        try { body = JSON.parse(rawBody); } catch { return { error: 'Invalid JSON', code: 400 }; }
+
+        // 2. URL 验证 challenge（飞书）
+        const b = body as any;
+        if (b?.challenge) return { challenge: b.challenge };
+
+        // 3. 解析消息
+        const msg = channel.parseInboundMessage(body);
+        if (!msg) return { ok: true };
+
+        this.logger.info(`[channel-router] ${channelName}/${msg.userId}: "${msg.text.slice(0, 80)}"`);
+
+        // 4. 鉴权
+        let user = imUserRegistry.getUser(channelName, msg.userId);
+        if (!user) {
+            if (this.defaultRole === 'blocked') {
+                const target = this.makeTarget(channel.name, msg.conversationId, msg.userId, msg.raw);
+                await channel.send(target, { text: '您没有权限使用此机器人，请联系管理员。' });
+                return { ok: true };
+            }
+            imUserRegistry.upsertUser({ platform: channelName, imUserId: msg.userId, role: this.defaultRole });
+            user = imUserRegistry.getUser(channelName, msg.userId);
+        }
+
+        if (!user || !user.enabled || user.role === 'blocked') {
+            const target = this.makeTarget(channel.name, msg.conversationId, msg.userId, msg.raw);
+            await channel.send(target, { text: '您的账号已被禁用，请联系管理员。' });
+            return { ok: true };
+        }
+
+        // 5. IM 会话 → CMaster Session 映射
+        const sessionId = imSessionMapper.getOrCreate(channelName, msg.conversationId, msg.userId);
+
+        // 6. 审计记录
+        const execId = auditRepository.createExecution({
+            type: 'agent',
+            name: `IM[${channelName}]: ${msg.text.slice(0, 50)}`,
+            sessionId,
+            triggerSource: 'im',
+            triggerRef: msg.userId,
+            inputSummary: msg.text.slice(0, 500),
+        });
+
+        // 7. 立即返回 200，异步执行
+        const target = this.makeTarget(channelName, msg.conversationId, msg.userId, msg.raw, sessionId);
+        setImmediate(() => this.runAsync(channel, execId, msg.text, sessionId, target));
+
+        return { ok: true };
+    }
+
+    // ─── Card Action ──────────────────────────────────────────────────────────
+
+    /** 处理 HitL 审批卡片 callback */
+    async handleCardAction(channelName: string, body: unknown): Promise<unknown> {
+        const payload = HitlCardRenderer.parseCardAction(channelName, body);
+        if (!payload) {
+            return { toast: { type: 'error', content: '缺少必要参数' } };
+        }
+
+        this.hitl.clear(payload.interruptId);
+
+        const meta = getPendingInterruptMeta(payload.sessionId);
+        const approved = payload.decision === 'approve' || payload.decision === 'modify';
+
+        const resolved = resolveInterrupt(payload.sessionId, approved, {
+            interruptId: payload.interruptId,
+            actionName: meta?.actionName,
+            dangerReason: meta?.dangerReason,
+            executionId: meta?.executionId,
+            operator: payload.operatorUserId,
+            operatorChannel: channelName,
+        });
+
+        if (!resolved) {
+            return { toast: { type: 'warning', content: '该操作已超时或不存在' } };
+        }
+
+        this.logger.info(
+            `[channel-router] HitL resolved: ${payload.sessionId} decision=${payload.decision} by ${payload.operatorUserId}`,
+        );
+
+        return {
+            toast: {
+                type: approved ? 'success' : 'info',
+                content: approved ? '已确认执行' : '已拒绝操作',
+            },
+        };
+    }
+
+    // ─── Health ───────────────────────────────────────────────────────────────
+
+    async health(): Promise<Record<string, { ok: boolean; latencyMs?: number; details?: string }>> {
+        const results: Record<string, { ok: boolean; latencyMs?: number; details?: string }> = {};
+        await Promise.all(
+            [...this.channels.entries()].map(async ([name, ch]) => {
+                results[name] = await ch.health().catch(err => ({ ok: false, details: err.message }));
+            }),
+        );
+        return results;
+    }
+
+    destroy(): void {
+        this.hitl.destroy();
+    }
+
+    // ─── Private ──────────────────────────────────────────────────────────────
+
+    private makeTarget(
+        channelName: string,
+        conversationId: string,
+        userId: string,
+        raw: unknown,
+        sessionId?: string,
+    ): ChannelTarget {
+        const b = raw as any;
+        return {
+            channelName,
+            conversationId,
+            userId,
+            extra: {
+                chatId: b?.event?.message?.chat_id ?? b?.conversationId ?? conversationId,
+                messageId: b?.event?.message?.message_id,
+                sessionId,
+            },
+        };
+    }
+
+    private async runAsync(
+        channel: IChannel,
+        execId: string,
+        text: string,
+        sessionId: string,
+        replyTarget: ChannelTarget,
+    ): Promise<void> {
+        const t0 = Date.now();
+        await channel.sendStatus(replyTarget, 'processing').catch(() => undefined);
+
+        // HitL 监听：500ms 轮询，检测到 pending interrupt 则发卡片
+        let hitlSent = false;
+        const hitlTimer = setInterval(() => {
+            if (hasPendingInterrupt(sessionId) && !hitlSent) {
+                hitlSent = true;
+                const meta = getPendingInterruptMeta(sessionId);
+                const req: ApprovalRequest = {
+                    interruptId: meta?.interruptId ?? nanoid(),
+                    toolName: meta?.actionName ?? '未知操作',
+                    reason: meta?.dangerReason ?? '高危操作需要确认',
+                    riskLevel: 'high',
+                    sessionId,
+                    cardActionUrl: `${this.cardActionBaseUrl}/api/channels/${channel.name}/card-action`,
+                    timeoutSeconds: 300,
+                };
+                this.hitl.send(channel, replyTarget, req, () => {
+                    resolveInterrupt(sessionId, false, {
+                        interruptId: req.interruptId,
+                        actionName: meta?.actionName,
+                        dangerReason: meta?.dangerReason,
+                        operator: 'system-timeout',
+                        operatorChannel: channel.name,
+                    });
+                }).catch(err => {
+                    this.logger.error(`[channel-router] sendApprovalCard failed: ${err.message}`);
+                });
+            }
+        }, 500);
+
+        try {
+            const answer = await this.runAgent(text, sessionId);
+            clearInterval(hitlTimer);
+            await channel.send(replyTarget, { text: answer || '（无结果）' });
+            auditRepository.updateExecution(execId, {
+                status: 'success',
+                outputSummary: answer?.slice(0, 500),
+                durationMs: Date.now() - t0,
+            });
+        } catch (err: any) {
+            clearInterval(hitlTimer);
+            this.logger.error(`[channel-router] agent error: ${err.message}`);
+            await channel.sendStatus(replyTarget, 'error', err.message?.slice(0, 100)).catch(() => undefined);
+            auditRepository.updateExecution(execId, {
+                status: 'failed',
+                errorMessage: err.message,
+                durationMs: Date.now() - t0,
+            });
+        }
+    }
+}

--- a/src/channels/teams.ts
+++ b/src/channels/teams.ts
@@ -1,0 +1,40 @@
+/**
+ * Phase 7: TeamsChannel — Microsoft Teams（占位实现）
+ *
+ * Phase 7 聚焦飞书 + 钉钉，此文件保留接口签名供后续实现。
+ */
+
+import type { IChannel, IncomingMessage, ChannelTarget, ChannelMessage, ApprovalRequest, StatusKind } from './types.js';
+
+export class TeamsChannel implements IChannel {
+    readonly name = 'teams';
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    verifyRequest(_headers: Record<string, string>, _rawBody: string): boolean {
+        throw new Error('TeamsChannel: not implemented — planned for Phase 7.5');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    parseInboundMessage(_body: unknown): IncomingMessage | null {
+        throw new Error('TeamsChannel: not implemented');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async send(_target: ChannelTarget, _message: ChannelMessage): Promise<void> {
+        throw new Error('TeamsChannel: not implemented');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async sendApprovalCard(_target: ChannelTarget, _req: ApprovalRequest): Promise<void> {
+        throw new Error('TeamsChannel: not implemented');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async sendStatus(_target: ChannelTarget, _kind: StatusKind, _detail?: string): Promise<void> {
+        throw new Error('TeamsChannel: not implemented');
+    }
+
+    async health(): Promise<{ ok: boolean; details?: string }> {
+        return { ok: false, details: 'TeamsChannel: not implemented' };
+    }
+}

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -1,0 +1,115 @@
+/**
+ * Phase 7: IChannel 抽象 — 企业 IM 渠道统一接口
+ *
+ * 设计原则：
+ *  - 每个渠道实现 IChannel，统一入站/出站/HitL
+ *  - ApprovalRequest 含 riskLevel（影响卡片配色）与 allowModify（第三态按钮）
+ *  - ChannelRouter 负责多渠道注册与分发
+ */
+
+// ─── Inbound ─────────────────────────────────────────────────────────────────
+
+export interface IncomingMessage {
+    channelName: string;
+    /** 平台原始用户 ID（如飞书 open_id / 钉钉 dingtalk_id） */
+    userId: string;
+    /** 会话/群 ID */
+    conversationId: string;
+    /** 清洗后的文本（已去掉 @Bot 前缀） */
+    text: string;
+    attachments?: Attachment[];
+    /** 平台原始消息体，供适配器内部使用 */
+    raw: unknown;
+}
+
+export interface Attachment {
+    type: 'image' | 'file' | 'audio';
+    url?: string;
+    name?: string;
+}
+
+// ─── Outbound ─────────────────────────────────────────────────────────────────
+
+export interface ChannelTarget {
+    channelName: string;
+    conversationId: string;
+    userId: string;
+    /** 平台特定的回复上下文（如 message_id、chat_id） */
+    extra?: Record<string, unknown>;
+}
+
+export interface ChannelMessage {
+    text: string;
+    /** 可选：Markdown / 富文本 */
+    markdown?: string;
+}
+
+// ─── HitL Approval ───────────────────────────────────────────────────────────
+
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export interface ApprovalRequest {
+    interruptId: string;
+    toolName: string;
+    toolInput?: Record<string, unknown>;
+    /** 风险原因，显示在卡片正文 */
+    reason: string;
+    riskLevel: RiskLevel;
+    /** 是否显示"带修改批准"第三态按钮 */
+    allowModify?: boolean;
+    /** 超时秒数，默认 300s（5 分钟） */
+    timeoutSeconds?: number;
+    /** 嵌入卡片 value 的 sessionId，用于 callback 定位 */
+    sessionId: string;
+    /** 卡片 callback URL */
+    cardActionUrl: string;
+}
+
+export type ApprovalDecision = 'approve' | 'reject' | 'modify';
+
+export interface ApprovalResponse {
+    decision: ApprovalDecision;
+    /** "带修改批准"时，用户填入的修改内容 */
+    modifiedInput?: Record<string, unknown>;
+    operatorUserId: string;
+}
+
+// ─── Status Update ────────────────────────────────────────────────────────────
+
+export type StatusKind = 'processing' | 'done' | 'error';
+
+// ─── IChannel ────────────────────────────────────────────────────────────────
+
+export interface IChannel {
+    readonly name: string;
+
+    /** 验证入站请求签名，返回 false 则以 401 拒绝 */
+    verifyRequest(headers: Record<string, string>, rawBody: string): boolean;
+
+    /** 解析平台事件为标准 IncomingMessage，无需处理时返回 null */
+    parseInboundMessage(body: unknown): IncomingMessage | null;
+
+    /** 发送纯文本消息 */
+    send(target: ChannelTarget, message: ChannelMessage): Promise<void>;
+
+    /** 发送 HitL 审批卡片 */
+    sendApprovalCard(target: ChannelTarget, req: ApprovalRequest): Promise<void>;
+
+    /** 发送状态更新（处理中 / 完成 / 出错） */
+    sendStatus(target: ChannelTarget, kind: StatusKind, detail?: string): Promise<void>;
+
+    /** 健康检查 */
+    health(): Promise<{ ok: boolean; latencyMs?: number; details?: string }>;
+}
+
+// ─── Card Action Callback ─────────────────────────────────────────────────────
+
+/** ChannelRouter.handleCardAction 解析后的标准回调结构 */
+export interface CardActionPayload {
+    channelName: string;
+    interruptId: string;
+    sessionId: string;
+    decision: ApprovalDecision;
+    operatorUserId: string;
+    modifiedInput?: Record<string, unknown>;
+}

--- a/src/channels/wecom.ts
+++ b/src/channels/wecom.ts
@@ -1,0 +1,41 @@
+/**
+ * Phase 7: WeComChannel — 企业微信（占位实现）
+ *
+ * Phase 7 聚焦飞书 + 钉钉，此文件保留接口签名供后续实现。
+ * 调用任何方法将抛出 NotImplementedError。
+ */
+
+import type { IChannel, IncomingMessage, ChannelTarget, ChannelMessage, ApprovalRequest, StatusKind } from './types.js';
+
+export class WeComChannel implements IChannel {
+    readonly name = 'wecom';
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    verifyRequest(_headers: Record<string, string>, _rawBody: string): boolean {
+        throw new Error('WeComChannel: not implemented — planned for Phase 7.5');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    parseInboundMessage(_body: unknown): IncomingMessage | null {
+        throw new Error('WeComChannel: not implemented');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async send(_target: ChannelTarget, _message: ChannelMessage): Promise<void> {
+        throw new Error('WeComChannel: not implemented');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async sendApprovalCard(_target: ChannelTarget, _req: ApprovalRequest): Promise<void> {
+        throw new Error('WeComChannel: not implemented');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async sendStatus(_target: ChannelTarget, _kind: StatusKind, _detail?: string): Promise<void> {
+        throw new Error('WeComChannel: not implemented');
+    }
+
+    async health(): Promise<{ ok: boolean; details?: string }> {
+        return { ok: false, details: 'WeComChannel: not implemented' };
+    }
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -26,6 +26,7 @@ import { AgentGateway } from '../core/agent-gateway.js';
 import type { AgentPool } from '../core/harness/agent-pool.js';
 import { auditRepository } from '../core/audit-repository.js';
 import { ImGateway, FeishuAdapter, imUserRegistry, imSessionMapper } from './im-gateway.js';
+import { ChannelRouter, FeishuChannel, DingTalkChannel } from '../channels/index.js';
 import type { AgentRouter } from '../core/agent/router.js';
 import { adaptAgentEvents } from '../core/agent/agent-event-adapter.js';
 
@@ -49,6 +50,7 @@ export class GatewayServer {
     private selfImprovementEngine?: SelfImprovementEngine;
     private agentGateway: AgentGateway;
     private imGateway?: ImGateway;
+    private channelRouter?: ChannelRouter;
     private agentPool?: AgentPool;
     private longTermMemory?: import('../memory/long-term.js').LongTermMemory;
     private checkpointManager?: import('../core/checkpoint-manager.js').CheckpointManager;
@@ -112,6 +114,29 @@ export class GatewayServer {
                 });
                 options.logger.info('[im-gateway] Feishu adapter initialized');
             }
+        }
+
+        // Phase 7: ChannelRouter — 多渠道统一分发器
+        const baseUrl = `http://${options.config.server.host}:${options.config.server.port}`;
+        this.channelRouter = new ChannelRouter({
+            logger: options.logger,
+            defaultRole: options.config.im?.defaultRole ?? 'user',
+            cardActionBaseUrl: baseUrl,
+            runAgent: async (prompt, sessionId) => {
+                const memory = options.sessionManager.getSession(sessionId);
+                const { answer } = await options.agent.execute(prompt, { sessionId, memory });
+                return answer ?? '';
+            },
+        });
+
+        if (options.config.im?.feishu?.appId) {
+            this.channelRouter.register(new FeishuChannel(options.config.im.feishu, options.logger));
+            options.logger.info('[channel-router] FeishuChannel registered');
+        }
+
+        if (options.config.im?.dingtalk?.appKey) {
+            this.channelRouter.register(new DingTalkChannel(options.config.im.dingtalk, options.logger));
+            options.logger.info('[channel-router] DingTalkChannel registered');
         }
 
         this.app = Fastify({
@@ -1953,6 +1978,47 @@ export class GatewayServer {
             }
         );
 
+        // ===== CHANNEL ROUTER API (Phase 7) =====
+        // POST /api/channels/:channel/inbound — 各渠道入站事件（统一端点）
+        this.app.post<{ Params: { channel: string }; Body: unknown }>(
+            '/api/channels/:channel/inbound',
+            { config: { rawBody: true } },
+            async (request, reply) => {
+                if (!this.channelRouter) { reply.status(503); return { error: 'ChannelRouter not initialized' }; }
+                const rawBody = (request as any).rawBody ?? JSON.stringify(request.body);
+                const headers: Record<string, string> = {};
+                for (const [k, v] of Object.entries(request.headers)) {
+                    if (typeof v === 'string') headers[k] = v;
+                }
+                const result = await this.channelRouter.handleInbound(request.params.channel, rawBody, headers) as any;
+                if (result?.code === 401) { reply.status(401); return { error: result.error }; }
+                if (result?.code === 400) { reply.status(400); return { error: result.error }; }
+                if (result?.code === 404) { reply.status(404); return { error: result.error }; }
+                return result;
+            },
+        );
+
+        // POST /api/channels/:channel/card-action — HitL 审批卡片 callback
+        this.app.post<{ Params: { channel: string }; Body: unknown }>(
+            '/api/channels/:channel/card-action',
+            async (request) => {
+                if (!this.channelRouter) return { toast: { type: 'error', content: 'ChannelRouter not initialized' } };
+                return this.channelRouter.handleCardAction(request.params.channel, request.body);
+            },
+        );
+
+        // GET /api/channels/health — 所有渠道健康状态
+        this.app.get('/api/channels/health', async () => {
+            if (!this.channelRouter) return {};
+            return this.channelRouter.health();
+        });
+
+        // GET /api/channels — 已注册渠道列表
+        this.app.get('/api/channels', async () => {
+            if (!this.channelRouter) return [];
+            return this.channelRouter.listChannels().map(name => ({ name }));
+        });
+
         // ===== AGENT GATEWAY =====
         this.agentGateway.registerRoutes(this.app);
 
@@ -2084,6 +2150,7 @@ export class GatewayServer {
     }
 
     async stop(): Promise<void> {
+        this.channelRouter?.destroy();
         await this.app.close();
         this.logger.info('Server stopped');
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,6 +348,12 @@ export interface Config {
             verificationToken: string;
             encryptKey: string;
         };
+        dingtalk?: {
+            appKey: string;
+            appSecret: string;
+            signingSecret: string;
+            corpId?: string;
+        };
         defaultRole?: string;
         hitlTimeoutMinutes?: number;
     };

--- a/tests/channels.test.ts
+++ b/tests/channels.test.ts
@@ -1,0 +1,293 @@
+import crypto from 'crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeishuChannel } from '../src/channels/feishu.js';
+import { DingTalkChannel } from '../src/channels/dingtalk.js';
+import { HitlCardRenderer } from '../src/channels/hitl-card-renderer.js';
+import { ChannelRouter } from '../src/channels/router.js';
+import type { Logger } from '../src/types.js';
+
+const mockLogger: Logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+};
+
+// ─── FeishuChannel Tests ──────────────────────────────────────────────────────
+
+describe('FeishuChannel', () => {
+    const cfg = {
+        appId: 'test_app_id',
+        appSecret: 'test_app_secret',
+        verificationToken: 'test_token',
+        encryptKey: 'test_key_1234567', // 16 字节
+    };
+
+    let ch: FeishuChannel;
+    beforeEach(() => { ch = new FeishuChannel(cfg, mockLogger); });
+
+    it('verifyRequest: 缺少 header 时返回 false', () => {
+        expect(ch.verifyRequest({}, '{}')).toBe(false);
+        expect(ch.verifyRequest({ 'x-lark-signature': 'abc' }, '{}')).toBe(false);
+    });
+
+    it('verifyRequest: 签名正确时返回 true', () => {
+        const ts = String(Date.now());
+        const nonce = 'testnonce';
+        const body = '{"test":1}';
+        const key = cfg.encryptKey;
+        const sig = crypto.createHmac('sha256', key).update(ts + nonce + key + body).digest('hex');
+        const headers = {
+            'x-lark-signature': sig,
+            'x-lark-request-timestamp': ts,
+            'x-lark-request-nonce': nonce,
+        };
+        expect(ch.verifyRequest(headers, body)).toBe(true);
+    });
+
+    it('parseInboundMessage: URL challenge 返回 null', () => {
+        expect(ch.parseInboundMessage({ challenge: 'abc' })).toBeNull();
+    });
+
+    it('parseInboundMessage: 非 im.message.receive_v1 返回 null', () => {
+        expect(ch.parseInboundMessage({ header: { event_type: 'bot.added' } })).toBeNull();
+    });
+
+    it('parseInboundMessage: 正常文本消息解析成功', () => {
+        const body = {
+            header: { event_type: 'im.message.receive_v1' },
+            event: {
+                sender: { sender_id: { open_id: 'user123' } },
+                message: {
+                    message_type: 'text',
+                    content: JSON.stringify({ text: 'hello bot' }),
+                    chat_id: 'chat_abc',
+                    message_id: 'msg_001',
+                },
+            },
+        };
+        const msg = ch.parseInboundMessage(body);
+        expect(msg).not.toBeNull();
+        expect(msg?.text).toBe('hello bot');
+        expect(msg?.userId).toBe('user123');
+        expect(msg?.conversationId).toBe('chat_abc');
+        expect(msg?.channelName).toBe('feishu');
+    });
+
+    it('parseInboundMessage: @mention 被清洗', () => {
+        const body = {
+            header: { event_type: 'im.message.receive_v1' },
+            event: {
+                sender: { sender_id: { open_id: 'u1' } },
+                message: {
+                    message_type: 'text',
+                    content: JSON.stringify({ text: '@bot 帮我查下天气' }),
+                    chat_id: 'c1',
+                    message_id: 'm1',
+                },
+            },
+        };
+        const msg = ch.parseInboundMessage(body);
+        expect(msg?.text).toBe('帮我查下天气');
+    });
+
+    it('parseInboundMessage: 空文本返回 null', () => {
+        const body = {
+            header: { event_type: 'im.message.receive_v1' },
+            event: {
+                sender: { sender_id: { open_id: 'u1' } },
+                message: {
+                    message_type: 'text',
+                    content: JSON.stringify({ text: '@bot' }),
+                    chat_id: 'c1',
+                    message_id: 'm1',
+                },
+            },
+        };
+        expect(ch.parseInboundMessage(body)).toBeNull();
+    });
+
+    it('extractOperatorUserId: 飞书 2.0 格式', () => {
+        expect(FeishuChannel.extractOperatorUserId({ operator: { open_id: 'op123' } })).toBe('op123');
+    });
+
+    it('extractOperatorUserId: 飞书 3.0 fallback', () => {
+        expect(FeishuChannel.extractOperatorUserId({ open_id: 'op456' })).toBe('op456');
+    });
+});
+
+// ─── DingTalkChannel Tests ────────────────────────────────────────────────────
+
+describe('DingTalkChannel', () => {
+    const cfg = {
+        appKey: 'test_app_key',
+        appSecret: 'test_app_secret',
+        signingSecret: 'test_signing_secret',
+    };
+
+    let ch: DingTalkChannel;
+    beforeEach(() => { ch = new DingTalkChannel(cfg, mockLogger); });
+
+    it('verifyRequest: 缺少 timestamp/sign 返回 false', () => {
+        expect(ch.verifyRequest({}, '{}')).toBe(false);
+        expect(ch.verifyRequest({ timestamp: '123' }, '{}')).toBe(false);
+    });
+
+    it('verifyRequest: 签名正确时返回 true', () => {
+        const ts = String(Date.now());
+        const content = ts + '\n' + cfg.signingSecret;
+        const sign = encodeURIComponent(
+            crypto.createHmac('sha256', cfg.signingSecret).update(content).digest('base64'),
+        );
+        expect(ch.verifyRequest({ timestamp: ts, sign }, '{}')).toBe(true);
+    });
+
+    it('parseInboundMessage: 非 text 消息返回 null', () => {
+        expect(ch.parseInboundMessage({ msgtype: 'image' })).toBeNull();
+    });
+
+    it('parseInboundMessage: 正常文本消息解析成功', () => {
+        const body = {
+            msgtype: 'text',
+            text: { content: '查询订单状态' },
+            senderStaffId: 'staff001',
+            conversationId: 'conv_001',
+        };
+        const msg = ch.parseInboundMessage(body);
+        expect(msg).not.toBeNull();
+        expect(msg?.text).toBe('查询订单状态');
+        expect(msg?.userId).toBe('staff001');
+        expect(msg?.channelName).toBe('dingtalk');
+    });
+
+    it('parseInboundMessage: @mention 被清洗', () => {
+        const body = {
+            msgtype: 'text',
+            text: { content: '@bot 帮我查天气' },
+            senderStaffId: 's1',
+            conversationId: 'c1',
+        };
+        expect(ch.parseInboundMessage(body)?.text).toBe('帮我查天气');
+    });
+
+    it('extractOperatorUserId: staffId 优先', () => {
+        expect(DingTalkChannel.extractOperatorUserId({ staffId: 's1', userId: 'u1' })).toBe('s1');
+    });
+});
+
+// ─── HitlCardRenderer Tests ───────────────────────────────────────────────────
+
+describe('HitlCardRenderer', () => {
+    it('parseCardAction: 飞书格式', () => {
+        const body = {
+            action: { value: { action: 'approve', interrupt_id: 'int1', session_id: 'sess1', channel: 'feishu' } },
+            operator: { open_id: 'op1' },
+        };
+        const result = HitlCardRenderer.parseCardAction('feishu', body);
+        expect(result).not.toBeNull();
+        expect(result?.decision).toBe('approve');
+        expect(result?.interruptId).toBe('int1');
+        expect(result?.operatorUserId).toBe('op1');
+    });
+
+    it('parseCardAction: 钉钉 querystring 格式', () => {
+        const body = { action: 'reject', interrupt_id: 'int2', session_id: 'sess2', staffId: 'staff1' };
+        const result = HitlCardRenderer.parseCardAction('dingtalk', body);
+        expect(result).not.toBeNull();
+        expect(result?.decision).toBe('reject');
+        expect(result?.interruptId).toBe('int2');
+        expect(result?.operatorUserId).toBe('staff1');
+    });
+
+    it('parseCardAction: 无效 body 返回 null', () => {
+        expect(HitlCardRenderer.parseCardAction('feishu', {})).toBeNull();
+        expect(HitlCardRenderer.parseCardAction('dingtalk', { foo: 'bar' })).toBeNull();
+    });
+
+    it('send 后 pendingCount 增加，clear 后减少', async () => {
+        const renderer = new HitlCardRenderer(mockLogger);
+        const mockChannel = {
+            name: 'feishu',
+            sendApprovalCard: vi.fn().mockResolvedValue(undefined),
+        } as any;
+        const target = { channelName: 'feishu', conversationId: 'c1', userId: 'u1' };
+        const req = {
+            interruptId: 'int_test',
+            toolName: 'rm_rf',
+            reason: '危险操作',
+            riskLevel: 'high' as const,
+            sessionId: 'sess_test',
+            cardActionUrl: 'http://localhost/callback',
+            timeoutSeconds: 3600,
+        };
+        await renderer.send(mockChannel, target, req, vi.fn());
+        expect(renderer.pendingCount).toBe(1);
+        renderer.clear('int_test');
+        expect(renderer.pendingCount).toBe(0);
+        renderer.destroy();
+    });
+});
+
+// ─── ChannelRouter Tests ──────────────────────────────────────────────────────
+
+describe('ChannelRouter', () => {
+    const runAgent = vi.fn().mockResolvedValue('agent answer');
+
+    it('未注册渠道返回 404', async () => {
+        const router = new ChannelRouter({ logger: mockLogger, runAgent });
+        const result = await router.handleInbound('unknown', '{}', {}) as any;
+        expect(result.code).toBe(404);
+        router.destroy();
+    });
+
+    it('注册/注销/listChannels 正常工作', () => {
+        const router = new ChannelRouter({ logger: mockLogger, runAgent });
+        const mockCh = { name: 'feishu', verifyRequest: vi.fn(), parseInboundMessage: vi.fn(), send: vi.fn(), sendApprovalCard: vi.fn(), sendStatus: vi.fn(), health: vi.fn() };
+        router.register(mockCh);
+        expect(router.listChannels()).toContain('feishu');
+        router.unregister('feishu');
+        expect(router.listChannels()).not.toContain('feishu');
+        router.destroy();
+    });
+
+    it('验签失败返回 401', async () => {
+        const router = new ChannelRouter({ logger: mockLogger, runAgent });
+        const mockCh = {
+            name: 'test',
+            verifyRequest: vi.fn().mockReturnValue(false),
+            parseInboundMessage: vi.fn(),
+            send: vi.fn(),
+            sendApprovalCard: vi.fn(),
+            sendStatus: vi.fn(),
+            health: vi.fn(),
+        };
+        router.register(mockCh);
+        const result = await router.handleInbound('test', '{}', {}) as any;
+        expect(result.code).toBe(401);
+        router.destroy();
+    });
+
+    it('handleCardAction: 无效 body 返回 error toast', async () => {
+        const router = new ChannelRouter({ logger: mockLogger, runAgent });
+        const result = await router.handleCardAction('feishu', {}) as any;
+        expect(result.toast.type).toBe('error');
+        router.destroy();
+    });
+
+    it('health: 返回各渠道健康状态 map', async () => {
+        const router = new ChannelRouter({ logger: mockLogger, runAgent });
+        const mockCh = {
+            name: 'feishu',
+            verifyRequest: vi.fn(),
+            parseInboundMessage: vi.fn(),
+            send: vi.fn(),
+            sendApprovalCard: vi.fn(),
+            sendStatus: vi.fn(),
+            health: vi.fn().mockResolvedValue({ ok: true, latencyMs: 10 }),
+        };
+        router.register(mockCh);
+        const h = await router.health();
+        expect(h['feishu']?.ok).toBe(true);
+        router.destroy();
+    });
+});


### PR DESCRIPTION
## Summary

Phase 7 实现：聚焦飞书强化 + 钉钉新增，WeCom/Teams 保留 stub 接口。

### IChannel 抽象（src/channels/types.ts）
统一渠道接口，支持 `riskLevel`（low/medium/high/critical）和 `allowModify`（第三态审批按钮）。

### FeishuChannel 强化
- access_token **30min 缓存**（告别每次请求换 token）
- AES-256-CBC 消息加密解密（encryptKey 非空时自动生效）
- riskLevel → 卡片颜色（green/yellow/orange/red）
- `allowModify` → "✏️ 带修改批准"第三态按钮
- `health()` 实现

### DingTalkChannel（新增）
- HMAC-SHA256 签名验证 + access_token 缓存
- ActionCard 交互卡片（三态：approve/reject/modify）
- `health()` 实现

### HitlCardRenderer（src/channels/hitl-card-renderer.ts）
- 统一管理超时定时器（默认 5 分钟自动 reject）
- 解析飞书/钉钉两种 callback 格式
- `destroy()` 优雅清理

### ChannelRouter（src/channels/router.ts）
- 多渠道注册/注销/路由，替代单一 `ImGateway`
- 新 API 端点：`POST /api/channels/:channel/inbound`、`/card-action`、`GET /api/channels/health`
- 保留旧 `/api/im/*` 端点（向后兼容）

### WeCom/Teams stub
实现 IChannel 接口，方法抛 `NotImplementedError`，预留 Phase 7.5。

## Test plan

- [x] 24 个新测试（FeishuChannel + DingTalkChannel + HitlCardRenderer + ChannelRouter）
- [x] 230/230 total tests 通过
- [x] `tsc --noEmit` 零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)