### PR TITLE
fix(llm): 修复 undici ProxyAgent 与 Node.js 内置 fetch 不兼容导致 OpenAI 连接失败

### DIFF
--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -9,7 +9,7 @@ import type {
     LLMConfig,
     ToolDefinition
 } from '../types.js';
-import { ProxyAgent } from 'undici';
+import { fetch as undiciFetch, ProxyAgent } from 'undici';
 
 function recordTokenUsage(model: string, usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number } | null | undefined) {
     if (!usage) return;
@@ -42,8 +42,12 @@ export class OpenAIAdapter implements LLMAdapter {
         this.client = new OpenAI({
             apiKey: config.apiKey,
             baseURL: config.baseUrl,
-            // undici 与 undici-types 的 FormData 类型声明存在已知不兼容，运行时行为一致
-            ...(dispatcher ? { fetchOptions: { dispatcher: dispatcher as never } } : {}),
+            // ProxyAgent 必须与同一个 undici 包的 fetch 配合使用，否则 Node.js 内置 fetch
+            // 与外部 undici dispatcher 版本不匹配会导致 APIConnectionError
+            ...(dispatcher ? {
+                fetch: undiciFetch as unknown as typeof globalThis.fetch,
+                fetchOptions: { dispatcher: dispatcher as never },
+            } : {}),
         });
     }
 


### PR DESCRIPTION
## 问题

启动服务后测试 OpenAI 连接报错：

```
Connectivity test failed for openai: Connection error. This may be caused by passing an undici
dispatcher, such as ProxyAgent, that is incompatible with the fetch implementation.
```

## 根因

当系统环境变量中配置了代理（`https_proxy` / `HTTPS_PROXY` / `http_proxy` / `HTTP_PROXY`），`OpenAIAdapter` 构造函数会创建 `undici.ProxyAgent` 并通过 `fetchOptions.dispatcher` 注入。

但 OpenAI SDK v5+ 默认使用 **Node.js 内置 fetch**，而 Node.js 内置 fetch 底层虽然也基于 undici，但与项目中安装的独立 `undici` 包版本不同。两者的 `dispatcher` 接口不兼容，导致 `APIConnectionError`。

## 修复

额外从 `undici` 导入 `fetch`，在配置了代理时同时传给 OpenAI 构造函数：

```ts
import { fetch as undiciFetch, ProxyAgent } from 'undici';

...(dispatcher ? {
    fetch: undiciFetch as unknown as typeof globalThis.fetch,
    fetchOptions: { dispatcher: dispatcher as never },
} : {}),
```

这与 OpenAI SDK 错误提示的修复方案完全一致：ProxyAgent 必须和来自同一个 undici 包的 fetch 配合使用。

## 影响范围

- 仅影响配置了代理环境变量的运行环境
- 无代理时代码路径不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)