### PR TITLE
fix: 修复大数据流卡死/记录丢失 + Agent实例治理 + 子Agent交互（P0-P2）

### DIFF
--- a/src/core/agent-run-helpers.ts
+++ b/src/core/agent-run-helpers.ts
@@ -205,6 +205,8 @@ export async function* handleBuiltinToolCall(
                     parentInstanceId: context.traceId,
                     parentSessionId: context.sessionId,
                     trigger: 'chat_delegate',
+                    // 透传父级 abort：Chat 断连时级联终止子 Agent，避免孤儿实例
+                    abortSignal: context.abortSignal,
                 });
                 yield {
                     type: 'meta' as any,

--- a/src/core/agent-run-helpers.ts
+++ b/src/core/agent-run-helpers.ts
@@ -18,7 +18,7 @@ import type { ISkillGenerator } from './skill-generator.js';
 import type { IKnowledgeGraph } from '../memory/knowledge-graph.js';
 import { taskRepository } from './task-repository.js';
 import { DAGExecutor } from './dag-executor.js';
-import { waitForApproval } from './interrupt-coordinator.js';
+import { waitForApproval, waitForUserDecision } from './interrupt-coordinator.js';
 import { spanRecorder } from './trace.js';
 import { isDangerousToolCall } from './agent-tools.js';
 
@@ -266,6 +266,41 @@ export async function* handleBuiltinToolCall(
               ).join('\n');
         yield { type: 'observation', content: summary, toolName, timestamp: new Date() };
         messages.push({ role: 'tool', content: summary, toolCallId: toolCall.id });
+
+    } else if (toolName === 'ask_user') {
+        // 向用户提问澄清：挂起等待文本应答（Human-in-the-Loop question interrupt）
+        const { question, options } = params as { question: string; options?: string[] };
+        const interruptId = nanoid();
+        yield {
+            type: 'interrupt',
+            interruptId,
+            interruptKind: 'question',
+            interruptReason: question,
+            toolName,
+            toolInput: params,
+            content: question,
+            // 前端必须用该 sessionId 应答（子 Agent 场景下与 Chat sessionId 不同）
+            sessionId: context.sessionId,
+            timestamp: new Date(),
+        };
+
+        let resultStr: string;
+        try {
+            const decision = await waitForUserDecision(context.sessionId, {
+                interruptId,
+                actionName: toolName,
+                actionParams: JSON.stringify({ question, options }).slice(0, 1000),
+            }, context.abortSignal);
+            resultStr = decision.response?.trim()
+                ? `用户回答: ${decision.response.trim()}`
+                : decision.approved
+                    ? '用户确认了该问题，但未提供文字回答。'
+                    : '用户拒绝回答该问题，请基于已有信息继续或调整方案。';
+        } catch {
+            resultStr = '未能获得用户回答（连接中断），请基于已有信息继续。';
+        }
+        yield { type: 'observation', content: resultStr, toolName, timestamp: new Date() };
+        messages.push({ role: 'tool', content: resultStr, toolCallId: toolCall.id });
     }
 }
 
@@ -323,10 +358,13 @@ export async function* handleExternalToolCalls(
         yield {
             type: 'interrupt',
             interruptId,
+            interruptKind: 'approval',
             interruptReason: firstDangerous.reason!,
             toolName: firstDangerous.toolName,
             toolInput: firstDangerous.params,
             content: `需要确认：${firstDangerous.reason}`,
+            // 前端必须用该 sessionId 应答（子 Agent 场景下与 Chat sessionId 不同）
+            sessionId: context.sessionId,
             timestamp: new Date(),
         };
 
@@ -337,7 +375,7 @@ export async function* handleExternalToolCalls(
                 actionName: firstDangerous.toolName,
                 actionParams: JSON.stringify(firstDangerous.params).slice(0, 1000),
                 dangerReason: firstDangerous.reason ?? undefined,
-            });
+            }, context.abortSignal);
         } catch {
             approved = false;
         }

--- a/src/core/agent-tools.ts
+++ b/src/core/agent-tools.ts
@@ -222,6 +222,27 @@ export const SESSION_RECALL_TOOL: ToolDefinition = {
     },
 };
 
+export const ASK_USER_TOOL: ToolDefinition = {
+    type: 'function',
+    function: {
+        name: 'ask_user',
+        description: 'Ask the user a clarifying question and wait for their answer. ' +
+            'Use this when required information is missing or ambiguous and you cannot proceed reliably without it. ' +
+            'The conversation pauses until the user responds.',
+        parameters: {
+            type: 'object',
+            properties: {
+                question: { type: 'string', description: 'The question to ask the user (clear and specific)' },
+                options: {
+                    type: 'array', items: { type: 'string' },
+                    description: 'Optional suggested answers the user can pick from',
+                },
+            },
+            required: ['question'],
+        },
+    },
+};
+
 /** All built-in tool names for fast lookup */
 export const BUILTIN_TOOL_NAMES = new Set([
     'plan_task',
@@ -235,6 +256,7 @@ export const BUILTIN_TOOL_NAMES = new Set([
     'delegate_to_agent',
     'knowledge_search',
     'session_recall',
+    'ask_user',
 ]);
 
 // ─────────────────────────────────────────────

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -30,6 +30,7 @@ import {
     SKILL_GENERATE_TOOL,
     DELEGATE_AGENT_TOOL,
     KNOWLEDGE_SEARCH_TOOL,
+    ASK_USER_TOOL,
     SESSION_RECALL_TOOL,
     BUILTIN_TOOL_NAMES,
     buildMinimalContext,
@@ -240,7 +241,7 @@ export class Agent {
 
         // 合并内置工具和外部技能工具
         const externalTools = await this.skillRegistry.getToolDefinitions();
-        const builtinTools = [PLAN_TOOL_DEF, DAG_CREATE_TASK_TOOL, DAG_GET_STATUS_TOOL, DAG_EXECUTE_TOOL, SKILL_GENERATE_TOOL, DELEGATE_AGENT_TOOL, KNOWLEDGE_SEARCH_TOOL];
+        const builtinTools = [PLAN_TOOL_DEF, DAG_CREATE_TASK_TOOL, DAG_GET_STATUS_TOOL, DAG_EXECUTE_TOOL, SKILL_GENERATE_TOOL, DELEGATE_AGENT_TOOL, KNOWLEDGE_SEARCH_TOOL, ASK_USER_TOOL];
         if (this.longTermMemory) {
             builtinTools.push(MEMORY_REMEMBER_TOOL, MEMORY_RECALL_TOOL, MEMORY_READ_TOOL);
         }

--- a/src/core/harness/agent-harness.ts
+++ b/src/core/harness/agent-harness.ts
@@ -55,6 +55,8 @@ export class AgentHarness {
     private startedAt: Date = new Date();
     private completedAt?: Date;
     private error?: string;
+    /** cancel() 时中断底层 LLM 流/工具调用，而非等待下一个步骤边界 */
+    private abortController = new AbortController();
 
     /** U16: 执行引擎（native = 现有 Agent.run()；claude-agent-sdk = Claude Code Harness）*/
     private engine: IAgentEngine;
@@ -144,7 +146,10 @@ export class AgentHarness {
     }
 
     cancel(): void {
+        if (this.state === 'completed' || this.state === 'failed' || this.state === 'cancelled') return;
         this.state = 'cancelled';
+        // 立即中断进行中的 LLM 流式调用/工具执行
+        this.abortController.abort();
     }
 
     // ─────────────────────────────────────────────────
@@ -155,6 +160,8 @@ export class AgentHarness {
         task: string,
         context: HarnessExecutionContext
     ): AsyncGenerator<ExecutionStep> {
+        // 已被取消的实例不允许重新进入运行态
+        if (this.state === 'cancelled') return;
         this.state = 'running';
         this.startedAt = new Date();
 
@@ -203,12 +210,16 @@ export class AgentHarness {
                 revision++;
 
                 // ── 执行 Agent（经 IAgentEngine 抽象，U16）──
+                // 合并外部 abortSignal（如父 Chat 断连）与内部 cancel 信号
+                const effectiveSignal = context.abortSignal
+                    ? AbortSignal.any([context.abortSignal, this.abortController.signal])
+                    : this.abortController.signal;
                 for await (const step of this.engine.run(currentTask, {
                     sessionId: context.sessionId,
                     userId: context.userId,
                     memory: context.memory,
                     history: revision === 1 ? (context.history ?? []) : [],
-                    abortSignal: context.abortSignal,
+                    abortSignal: effectiveSignal,
                     traceId: context.traceId,
                 })) {
                     if (this.getState() === 'cancelled') break;
@@ -334,12 +345,25 @@ ${failedCriteria ? `各维度具体问题：\n${failedCriteria}` : ''}`;
                 yield this.makeStep('meta', `🔄 评分 ${graderResult.overallScore}/100（${statusLabel}），正在根据 Grader 建议进行第 ${revision + 1} 次修订...`);
             }
 
-            this.state = 'completed';
+            // cancelled 状态不可被覆写为 completed
+            if (this.getState() !== 'cancelled') {
+                this.state = 'completed';
+            }
             this.completedAt = new Date();
-            this.emit('session_end', { status: 'completed', instanceId: this.instanceId });
+            this.emit('session_end', { status: this.state, instanceId: this.instanceId });
             await this.hookRunner.run(this.spec.hooks.onComplete ?? [], hookCtx);
 
         } catch (err) {
+            // cancel()/外部 abort 触发的 AbortError 属于正常终止，归为 cancelled 而非 failed
+            const isAbort = this.getState() === 'cancelled'
+                || (err as Error).name === 'AbortError'
+                || /abort/i.test((err as Error).message ?? '');
+            if (isAbort) {
+                this.state = 'cancelled';
+                this.completedAt = new Date();
+                this.emit('session_end', { status: 'cancelled', instanceId: this.instanceId });
+                return;
+            }
             this.state = 'failed';
             this.completedAt = new Date();
             this.error = (err as Error).message;

--- a/src/core/harness/agent-pool.ts
+++ b/src/core/harness/agent-pool.ts
@@ -40,6 +40,8 @@ export class AgentPool {
     private steps = new Map<string, ExecutionStep[]>();
     private runningCount = new Map<string, number>();
     private queue: QueueItem[] = [];
+    /** 实例任务描述（供 listInstances 展示，DB 行中同样有存） */
+    private taskById = new Map<string, string>();
 
     constructor(
         private getLLM: (provider?: string) => LLMAdapter,
@@ -241,6 +243,7 @@ export class AgentPool {
 
         this.instances.set(harness.instanceId, harness);
         this.steps.set(harness.instanceId, []);
+        this.taskById.set(harness.instanceId, task);
         this.runningCount.set(spec.id, (this.runningCount.get(spec.id) ?? 0) + 1);
 
         this.logger.info(`[agent-pool] Spawned ${spec.name} instance ${harness.instanceId}`);
@@ -275,6 +278,28 @@ export class AgentPool {
     ): Promise<void> {
         const steps = this.steps.get(harness.instanceId)!;
 
+        // 进度周期性持久化：崩溃/重启后 DB 中不再残留 step_count=0 的 running 行
+        const PERSIST_INTERVAL_MS = 3000;
+        let lastProgressPersist = 0;
+        const persistProgress = () => {
+            const now = Date.now();
+            if (now - lastProgressPersist < PERSIST_INTERVAL_MS) return;
+            lastProgressPersist = now;
+            this.persistInstance({
+                instanceId: harness.instanceId,
+                specId: harness.spec.id,
+                specName: harness.spec.name,
+                state: harness.getState(),
+                task,
+                revision: 0,
+                startedAt: harness.getStartedAt(),
+                completedAt: harness.getCompletedAt(),
+                stepCount: steps.length,
+                lastScore: harness.getLastScore(),
+                error: harness.getError(),
+            });
+        };
+
         // LLM 流式 token 聚合缓冲：将连续的 type='content' chunk 合并为单条步骤，
         // 避免前端展示数百条碎片步骤（每个词一条）。
         let contentBuffer = '';
@@ -291,6 +316,7 @@ export class AgentPool {
             agentBus.publish(`agent.step.${harness.instanceId}`, merged, harness.instanceId);
             contentBuffer = '';
             contentTimestamp = null;
+            persistProgress();
         };
 
         const pushStep = (step: ExecutionStep) => {
@@ -298,6 +324,7 @@ export class AgentPool {
             const safe = sanitizeStepForStream(step);
             steps.push(safe);
             agentBus.publish(`agent.step.${harness.instanceId}`, safe, harness.instanceId);
+            persistProgress();
         };
 
         try {
@@ -445,16 +472,45 @@ export class AgentPool {
     // 生命周期控制
     // ─────────────────────────────────────────────────
 
-    pause(instanceId: string): void {
-        this.instances.get(instanceId)?.pause();
+    /** @returns 是否找到并操作了实例 */
+    pause(instanceId: string): boolean {
+        const harness = this.instances.get(instanceId);
+        if (!harness) return false;
+        harness.pause();
+        return true;
     }
 
-    resume(instanceId: string): void {
-        this.instances.get(instanceId)?.resume();
+    /** @returns 是否找到并操作了实例 */
+    resume(instanceId: string): boolean {
+        const harness = this.instances.get(instanceId);
+        if (!harness) return false;
+        harness.resume();
+        return true;
     }
 
-    cancel(instanceId: string): void {
-        this.instances.get(instanceId)?.cancel();
+    /**
+     * 终止实例。内存实例走 harness.cancel()（abort 底层执行）；
+     * 仅存在于 DB 的残留行（进程重启后）直接更新状态，保证 UI 上可终止。
+     * @returns 是否找到并终止了实例
+     */
+    cancel(instanceId: string): boolean {
+        const harness = this.instances.get(instanceId);
+        if (harness) {
+            harness.cancel();
+            return true;
+        }
+        if (!this.db) return false;
+        try {
+            const result = this.db.prepare(`
+                UPDATE agent_instances
+                SET state = 'cancelled', completed_at = ?, error = COALESCE(error, 'cancelled by user (stale instance)')
+                WHERE id = ? AND state IN ('running', 'queued', 'paused')
+            `).run(Date.now(), instanceId);
+            return Number(result.changes) > 0;
+        } catch (err) {
+            this.logger.warn(`[agent-pool] cancel(${instanceId}) DB update failed: ${(err as Error).message}`);
+            return false;
+        }
     }
 
     // ─────────────────────────────────────────────────
@@ -468,7 +524,7 @@ export class AgentPool {
             specId: h.spec.id,
             specName: h.spec.name,
             state: h.getState(),
-            task: '',
+            task: this.taskById.get(h.instanceId) ?? '',
             revision: 0,
             startedAt: h.getStartedAt(),
             completedAt: h.getCompletedAt(),
@@ -505,6 +561,31 @@ export class AgentPool {
         for (const [id] of done.slice(keepLast)) {
             this.instances.delete(id);
             this.steps.delete(id);
+            this.taskById.delete(id);
+        }
+    }
+
+    /**
+     * 启动时将 DB 中残留的 running/queued/paused 行标记为 failed。
+     * 这些是上次进程退出时未完成的实例（Wake 恢复会创建新实例 ID，
+     * 旧行若不清理会永久显示为"运行中/0 步"且无法终止）。
+     */
+    markOrphanedInstances(): number {
+        if (!this.db) return 0;
+        try {
+            const liveIds = Array.from(this.instances.keys());
+            const placeholders = liveIds.length > 0 ? liveIds.map(() => '?').join(',') : "'__none__'";
+            const result = this.db.prepare(`
+                UPDATE agent_instances
+                SET state = 'failed', completed_at = ?, error = COALESCE(error, 'interrupted by process restart')
+                WHERE state IN ('running', 'queued', 'paused') AND id NOT IN (${placeholders})
+            `).run(Date.now(), ...(liveIds as import('node:sqlite').SQLInputValue[]));
+            const n = Number(result.changes);
+            if (n > 0) this.logger.info(`[agent-pool] Marked ${n} orphaned instance(s) as failed`);
+            return n;
+        } catch (err) {
+            this.logger.warn(`[agent-pool] markOrphanedInstances failed: ${(err as Error).message}`);
+            return 0;
         }
     }
 
@@ -569,6 +650,9 @@ export class AgentPool {
      * 由 index.ts 在服务启动后调用。
      */
     async scanAndWake(): Promise<void> {
+        // 无论是否有 sessionStore，先清理上次进程遗留的孤儿实例行
+        this.markOrphanedInstances();
+
         if (!this.sessionStore) return;
 
         const unfinished = this.sessionStore.getUnfinished();

--- a/src/core/harness/agent-pool.ts
+++ b/src/core/harness/agent-pool.ts
@@ -333,6 +333,8 @@ export class AgentPool {
                     // 累积流式 token，不逐 token 写入
                     if (!contentTimestamp) contentTimestamp = step.timestamp;
                     contentBuffer += step.content ?? '';
+                    // 定时 flush：长文本生成过程中订阅方（Chat 子任务面板等）可中途看到进展
+                    if (Date.now() - contentTimestamp.getTime() > 500) flushContent();
                 } else {
                     // 非 content 步骤：先刷出已缓冲的内容，再推送当前步骤
                     flushContent();

--- a/src/core/harness/agent-pool.ts
+++ b/src/core/harness/agent-pool.ts
@@ -16,6 +16,7 @@ import { defaultAgentSpec, type AgentSpec, type AgentInstanceInfo, type AgentLif
 import { agentBus } from './agent-bus.js';
 import { SessionEventStore } from './session-store.js';
 import { CredentialVault } from './credential-vault.js';
+import { sanitizeStepForStream } from '../step-sanitizer.js';
 import type { LLMAdapter, Logger, ExecutionStep } from '../../types.js';
 import type { SkillRegistry } from '../../skills/registry.js';
 import type { LongTermMemory } from '../../memory/long-term.js';
@@ -293,8 +294,10 @@ export class AgentPool {
         };
 
         const pushStep = (step: ExecutionStep) => {
-            steps.push(step);
-            agentBus.publish(`agent.step.${harness.instanceId}`, step, harness.instanceId);
+            // 传输层截断：防止大 observation 撑爆步骤缓存与前端渲染
+            const safe = sanitizeStepForStream(step);
+            steps.push(safe);
+            agentBus.publish(`agent.step.${harness.instanceId}`, safe, harness.instanceId);
         };
 
         try {

--- a/src/core/interrupt-coordinator.ts
+++ b/src/core/interrupt-coordinator.ts
@@ -23,10 +23,18 @@ export interface InterruptMeta {
 export interface ResolveOptions extends InterruptMeta {
     operator?: string;
     operatorChannel?: string;
+    /** 文本应答内容（ask_user 类 question interrupt） */
+    response?: string;
+}
+
+/** 用户对 interrupt 的应答：布尔决定 + 可选文本回答 */
+export interface UserDecision {
+    approved: boolean;
+    response?: string;
 }
 
 interface PendingInterrupt {
-    resolve: (approved: boolean) => void;
+    resolve: (decision: UserDecision) => void;
     reject: (err: Error) => void;
     meta?: InterruptMeta;
 }
@@ -34,13 +42,32 @@ interface PendingInterrupt {
 const pendingInterrupts = new Map<string, PendingInterrupt>();
 
 /**
+ * Called by the agent — suspends until the user responds (or abortSignal fires).
+ * Returns the full decision including optional text response.
+ */
+export function waitForUserDecision(
+    sessionId: string,
+    meta?: InterruptMeta,
+    abortSignal?: AbortSignal
+): Promise<UserDecision> {
+    return new Promise<UserDecision>((resolve, reject) => {
+        pendingInterrupts.set(sessionId, { resolve, reject, meta });
+        // 父级 abort（如 Chat 断连）时释放挂起的 Promise，避免子 Agent 永久悬挂
+        abortSignal?.addEventListener('abort', () => {
+            if (pendingInterrupts.get(sessionId)?.reject === reject) {
+                pendingInterrupts.delete(sessionId);
+                reject(new Error('Aborted while waiting for user response'));
+            }
+        }, { once: true });
+    });
+}
+
+/**
  * Called by the agent — suspends until the user responds.
  * Returns `true` if approved, `false` if rejected.
  */
-export function waitForApproval(sessionId: string, meta?: InterruptMeta): Promise<boolean> {
-    return new Promise<boolean>((resolve, reject) => {
-        pendingInterrupts.set(sessionId, { resolve, reject, meta });
-    });
+export function waitForApproval(sessionId: string, meta?: InterruptMeta, abortSignal?: AbortSignal): Promise<boolean> {
+    return waitForUserDecision(sessionId, meta, abortSignal).then(d => d.approved);
 }
 
 /**
@@ -51,8 +78,8 @@ export function resolveInterrupt(sessionId: string, approved: boolean, opts?: Re
     const pending = pendingInterrupts.get(sessionId);
     if (!pending) return false;
 
-    // Record approval decision in audit log
-    const meta = opts ?? pending.meta;
+    // Record approval decision in audit log（opts 逐字段覆盖挂起时登记的 meta）
+    const meta = { ...pending.meta, ...opts };
     try {
         auditRepository.recordApproval({
             executionId: meta?.executionId,
@@ -69,7 +96,7 @@ export function resolveInterrupt(sessionId: string, approved: boolean, opts?: Re
         // Non-fatal: audit failure should not block HitL resolution
     }
 
-    pending.resolve(approved);
+    pending.resolve({ approved, response: opts?.response });
     pendingInterrupts.delete(sessionId);
     return true;
 }

--- a/src/core/step-sanitizer.ts
+++ b/src/core/step-sanitizer.ts
@@ -1,0 +1,57 @@
+/**
+ * step-sanitizer.ts — ExecutionStep 传输层瘦身
+ *
+ * observation 等步骤的 content/toolOutput 可能携带 MB 级数据（MCP 响应、
+ * 文件读取、skill 输出），直接下发会导致前端渲染卡死。本模块在传输边界
+ * （SSE/WS 写出、AgentPool 步骤缓存）统一截断展示内容。
+ *
+ * 注意：只影响 UI 展示层；LLM 上下文中的 tool result 不经过此处，保持完整。
+ */
+
+import type { ExecutionStep } from '../types.js';
+
+/** 单步 content 最大下发字符数（可用 STREAM_MAX_STEP_CHARS 环境变量覆盖） */
+export const MAX_STEP_CONTENT_CHARS = Number(process.env.STREAM_MAX_STEP_CHARS) > 0
+    ? Number(process.env.STREAM_MAX_STEP_CHARS)
+    : 4000;
+
+/** toolOutput 序列化后最大下发字符数 */
+export const MAX_TOOL_OUTPUT_CHARS = Number(process.env.STREAM_MAX_TOOL_OUTPUT_CHARS) > 0
+    ? Number(process.env.STREAM_MAX_TOOL_OUTPUT_CHARS)
+    : 2000;
+
+/** 流式正文与最终回答必须保持完整，不参与截断 */
+const FULL_CONTENT_TYPES = new Set(['content', 'answer']);
+
+/**
+ * 截断单个步骤用于传输/缓存。未超限时原样返回（保持引用相等，便于前端 memo）。
+ */
+export function sanitizeStepForStream(step: ExecutionStep): ExecutionStep {
+    if (FULL_CONTENT_TYPES.has(step.type)) return step;
+
+    let changed = false;
+    let content = step.content;
+    if (typeof content === 'string' && content.length > MAX_STEP_CONTENT_CHARS) {
+        content = content.slice(0, MAX_STEP_CONTENT_CHARS)
+            + `\n\n…[输出已截断，完整内容共 ${step.content.length} 字符，模型已收到完整结果]`;
+        changed = true;
+    }
+
+    let toolOutput = (step as { toolOutput?: unknown }).toolOutput;
+    if (toolOutput !== undefined) {
+        try {
+            const serialized = JSON.stringify(toolOutput);
+            if (serialized === undefined || serialized.length > MAX_TOOL_OUTPUT_CHARS) {
+                toolOutput = { _truncated: true, originalChars: serialized?.length ?? -1 };
+                changed = true;
+            }
+        } catch {
+            // 循环引用等不可序列化对象：直接丢弃，避免 JSON.stringify(step) 在写出时抛错
+            toolOutput = { _truncated: true, originalChars: -1 };
+            changed = true;
+        }
+    }
+
+    if (!changed) return step;
+    return { ...step, content, toolOutput } as ExecutionStep;
+}

--- a/src/gateway/routes/agents.ts
+++ b/src/gateway/routes/agents.ts
@@ -76,11 +76,16 @@ export async function registerAgentPoolRoutes(app: FastifyInstance, deps: Gatewa
     app.patch<{ Params: { id: string }; Body: { action: string } }>('/api/agents/instances/:id', async (request, reply) => {
         const { id } = request.params;
         const { action } = request.body;
+        let found: boolean;
         switch (action) {
-            case 'pause': pool.pause(id); break;
-            case 'resume': pool.resume(id); break;
-            case 'cancel': pool.cancel(id); break;
+            case 'pause': found = pool.pause(id); break;
+            case 'resume': found = pool.resume(id); break;
+            case 'cancel': found = pool.cancel(id); break;
             default: reply.status(400); return { error: `Unknown action: ${action}` };
+        }
+        if (!found) {
+            reply.status(404);
+            return { error: `Instance not found or not ${action}able: ${id}` };
         }
         return { success: true, action, instanceId: id };
     });

--- a/src/gateway/routes/chat.ts
+++ b/src/gateway/routes/chat.ts
@@ -1,9 +1,106 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 import { nanoid } from 'nanoid';
-import type { ChatRequest } from '../../types.js';
+import type { ChatRequest, ExecutionStep } from '../../types.js';
 import { cancelInterrupt } from '../../core/interrupt-coordinator.js';
 import { historyRepository } from '../../core/repository.js';
+import { sanitizeStepForStream } from '../../core/step-sanitizer.js';
 import type { GatewayDeps } from '../route-deps.js';
+
+/**
+ * 带背压的 SSE 写出：write 返回 false 时等待 drain（或连接关闭），
+ * 防止大流量下数据无限堆积在 Node 内存。
+ */
+function writeSse(reply: FastifyReply, payload: string): Promise<void> {
+    if (!reply.raw.writable) return Promise.resolve();
+    const ok = reply.raw.write(payload);
+    if (ok) return Promise.resolve();
+    return new Promise<void>(resolve => {
+        const onDone = () => {
+            reply.raw.off('drain', onDone);
+            reply.raw.off('close', onDone);
+            resolve();
+        };
+        reply.raw.once('drain', onDone);
+        reply.raw.once('close', onDone);
+    });
+}
+
+/**
+ * 将后端 ExecutionStep 流归约为前端 ChatThinking 使用的 UI step 形状
+ * （与 assistant-runtime.ts 的归约逻辑保持一致），用于持久化到
+ * assistant 消息 metadata.custom.steps，刷新后可恢复执行过程。
+ */
+function reduceUiStep(uiSteps: any[], step: ExecutionStep): void {
+    const s = step as any;
+    // 子 Agent 步骤：聚合到 subTask 分组（必须先于 type 判断，否则被父级分支吞掉）
+    if (s.delegatedFrom && s.harnessInstanceId) {
+        const existing = uiSteps.find(u => u.subTask?.instanceId === s.harnessInstanceId);
+        if (existing) {
+            existing.subTask.steps.push(step);
+            if (step.type === 'answer') existing.subTask.status = 'completed';
+        } else {
+            uiSteps.push({
+                subTask: {
+                    delegatedFrom: s.delegatedFrom,
+                    instanceId: s.harnessInstanceId,
+                    steps: [step],
+                    status: 'running',
+                    startTime: new Date(),
+                },
+            });
+        }
+        return;
+    }
+    switch (step.type) {
+        case 'thought':
+            uiSteps.push({ thought: step.content });
+            break;
+        case 'plan':
+            try {
+                uiSteps.push({ plan: typeof step.content === 'string' ? JSON.parse(step.content) : step.content });
+            } catch {
+                uiSteps.push({ plan: [String(step.content)] });
+            }
+            break;
+        case 'action':
+            uiSteps.push({ action: s.toolName || step.content || 'tool' });
+            break;
+        case 'observation': {
+            const last = uiSteps[uiSteps.length - 1];
+            if (last) {
+                last.observation = step.content ?? '';
+                if (s.duration !== undefined) last.duration = s.duration;
+            }
+            break;
+        }
+        case 'task_created':
+        case 'task_completed':
+        case 'task_failed':
+            uiSteps.push({ task: { type: step.type, taskId: s.taskId, content: step.content } });
+            break;
+        case 'context_compressed':
+            uiSteps.push({ contextCompressed: { droppedCount: s.droppedCount ?? 0, summary: step.content ?? '对话历史已压缩' } });
+            break;
+        case 'grading':
+        case 'grade_result':
+            uiSteps.push({ grading: { type: step.type, content: step.content } });
+            break;
+        case 'workflow_generated':
+            uiSteps.push({
+                workflow_generated: {
+                    workflow: s.workflow,
+                    subWorkflows: s.subWorkflows,
+                    validation: s.validation,
+                    allValid: s.allValid,
+                    explanation: s.explanation,
+                },
+            });
+            break;
+        default:
+            // content/answer/meta/suggestions/interrupt 不参与持久化步骤
+            break;
+    }
+}
 
 /**
  * Chat 路由：非流式 /api/chat、SSE 流式 /api/chat/stream、WebSocket /ws。
@@ -87,10 +184,53 @@ export async function registerChatRoutes(app: FastifyInstance, deps: GatewayDeps
         });
 
         let assistantAnswer = '';
-        const workflowSteps: any[] = [];
+        let partialContent = '';
+        const uiSteps: any[] = [];
 
         // Use multimodal content if provided, otherwise fall back to plain string
         const userInput = (messageContent && messageContent.length > 0 ? messageContent : message) as string;
+        const userMsgContent = messageContent && messageContent.length > 0 ? messageContent : message;
+
+        // 用户消息在请求开始时即落库（saveMessage 自带同内容幂等去重），
+        // 中途断连/卡死/崩溃不再丢失整轮对话。
+        try {
+            historyRepository.saveMessage(sessionId, { role: 'user', content: userMsgContent, attachments } as any);
+        } catch (err: any) {
+            deps.logger.error(`Failed to persist user message: ${err.message}`);
+        }
+
+        const maybeGenerateTitle = () => {
+            if ((history?.length || 0) <= 2) {
+                deps.agent.generateTitle(message).then(title => {
+                    deps.logger.info(`Generated title for session ${sessionId}: ${title}`);
+                    historyRepository.updateSessionTitle(sessionId, title);
+                }).catch(err => {
+                    deps.logger.error(`Title generation failed: ${err.message}`);
+                });
+            }
+        };
+
+        /** 保存 assistant 消息（完整或部分），返回消息 ID；无可保存内容时返回 null */
+        const persistAssistant = (interrupted: boolean): string | null => {
+            const content = assistantAnswer
+                || (partialContent ? `${partialContent}\n\n> ⚠️ 回答在生成过程中被中断` : '')
+                || (uiSteps.length > 0 ? '(执行被中断，未生成最终回答)' : '');
+            if (!content) return null;
+            try {
+                const metadata = uiSteps.length > 0 ? { custom: { steps: uiSteps } } : undefined;
+                const id = historyRepository.saveMessage(sessionId, {
+                    role: 'assistant', content, metadata,
+                } as any);
+                if (interrupted) {
+                    deps.logger.info(`Persisted partial assistant message on interruption: session=${sessionId}`);
+                }
+                maybeGenerateTitle();
+                return id;
+            } catch (err: any) {
+                deps.logger.error(`Failed to persist assistant message: ${err.message}`);
+                return null;
+            }
+        };
 
         try {
             for await (const step of deps.agent.run(userInput, {
@@ -103,55 +243,34 @@ export async function registerChatRoutes(app: FastifyInstance, deps: GatewayDeps
             })) {
                 if (step.type === 'answer') {
                     assistantAnswer = step.content;
+                } else if (step.type === 'content' && !(step as any).delegatedFrom) {
+                    partialContent += step.content ?? '';
                 }
-                // Collect workflow_generated steps for persistence
-                if ((step as any).type === 'workflow_generated') {
-                    const wf = step as any;
-                    workflowSteps.push({
-                        workflow_generated: {
-                            workflow: wf.workflow,
-                            subWorkflows: wf.subWorkflows,
-                            validation: wf.validation,
-                            allValid: wf.allValid,
-                            explanation: wf.explanation,
-                        },
-                    });
-                }
+
+                // 传输层截断（不影响 LLM 上下文），同时用于持久化步骤归约
+                const safeStep = sanitizeStepForStream(step);
+                reduceUiStep(uiSteps, safeStep);
+
                 if (reply.raw.writable) {
-                    reply.raw.write(`data: ${JSON.stringify(step)}\n\n`);
+                    await writeSse(reply, `data: ${JSON.stringify(safeStep)}\n\n`);
                 } else {
                     abortController.abort(); // 连接已断开，中止 agent
                     break;
                 }
             }
 
-            // Persist history after success — 用事务原子保存，并跳过空答案（客户端中途断连场景）
             if (!abortController.signal.aborted && assistantAnswer) {
-                const assistantMsgMetadata = workflowSteps.length > 0
-                    ? { custom: { steps: workflowSteps } }
-                    : undefined;
-                const { assistantMsgId } = historyRepository.saveConversationTurn(
-                    sessionId,
-                    { role: 'user', content: messageContent && messageContent.length > 0 ? messageContent : message, attachments },
-                    { role: 'assistant', content: assistantAnswer, metadata: assistantMsgMetadata } as any
-                );
+                const assistantMsgId = persistAssistant(false);
 
                 // Send meta chunk with assistant message ID for feedback correlation
-                if (reply.raw.writable) {
-                    reply.raw.write(`data: ${JSON.stringify({ type: 'meta', assistantMessageId: assistantMsgId })}\n\n`);
+                if (assistantMsgId && reply.raw.writable) {
+                    await writeSse(reply, `data: ${JSON.stringify({ type: 'meta', assistantMessageId: assistantMsgId })}\n\n`);
                 }
 
-                // Auto-generate title for new sessions (async)
-                if ((history?.length || 0) <= 2) {
-                    deps.agent.generateTitle(message).then(title => {
-                        deps.logger.info(`Generated title for session ${sessionId}: ${title}`);
-                        historyRepository.updateSessionTitle(sessionId, title);
-                    }).catch(err => {
-                        deps.logger.error(`Title generation failed: ${err.message}`);
-                    });
-                }
-
-                reply.raw.write('data: [DONE]\n\n');
+                await writeSse(reply, 'data: [DONE]\n\n');
+            } else {
+                // 中断场景：保存已产生的部分回答与执行步骤
+                persistAssistant(true);
             }
         } catch (error: any) {
             if (error.name === 'AbortError' || error.message?.includes('aborted')) {
@@ -159,9 +278,11 @@ export async function registerChatRoutes(app: FastifyInstance, deps: GatewayDeps
             } else {
                 deps.logger.error(`Stream error: ${error.message}`);
                 if (reply.raw.writable) {
-                    reply.raw.write(`data: ${JSON.stringify({ type: 'error', content: error.message })}\n\n`);
+                    await writeSse(reply, `data: ${JSON.stringify({ type: 'error', content: error.message })}\n\n`);
                 }
             }
+            // 异常场景同样保存部分结果，避免整轮对话丢失
+            persistAssistant(true);
         }
 
         if (!reply.raw.writableFinished) {
@@ -184,7 +305,7 @@ export async function registerChatRoutes(app: FastifyInstance, deps: GatewayDeps
                     const history = historyRepository.getMessages(sessionId);
 
                     for await (const step of deps.agent.run(userMessage, { sessionId, memory, history })) {
-                        socket.send(JSON.stringify(step));
+                        socket.send(JSON.stringify(sanitizeStepForStream(step)));
                     }
 
                     socket.send(JSON.stringify({ type: 'done' }));

--- a/src/gateway/routes/sessions.ts
+++ b/src/gateway/routes/sessions.ts
@@ -64,18 +64,19 @@ export async function registerSessionsRoutes(app: FastifyInstance, deps: Gateway
         }
     });
 
-    // Human-in-the-Loop: user approves or rejects a pending interrupt
-    app.post<{ Params: { id: string }; Body: { approved: boolean } }>(
+    // Human-in-the-Loop: user approves/rejects a pending interrupt,
+    // or answers an ask_user question via the optional `response` text
+    app.post<{ Params: { id: string }; Body: { approved: boolean; response?: string } }>(
         '/api/sessions/:id/interrupt-response',
         async (request, reply) => {
             const { id: sessionId } = request.params;
-            const { approved } = request.body;
-            const resolved = resolveInterrupt(sessionId, approved === true);
+            const { approved, response } = request.body;
+            const resolved = resolveInterrupt(sessionId, approved === true, response ? { response } : undefined);
             if (!resolved) {
                 reply.status(404);
                 return { error: 'No pending interrupt for this session' };
             }
-            deps.logger.info(`Interrupt resolved for session ${sessionId}: approved=${approved}`);
+            deps.logger.info(`Interrupt resolved for session ${sessionId}: approved=${approved}${response ? ' (with text response)' : ''}`);
             return { ok: true };
         }
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,6 +200,10 @@ export interface ExecutionStep {
     // interrupt fields
     interruptId?: string;
     interruptReason?: string;
+    /** interrupt 类型：approval=危险操作确认（布尔应答），question=向用户提问（文本应答） */
+    interruptKind?: 'approval' | 'question';
+    /** interrupt 实际挂起的 sessionId（子 Agent 场景下与 Chat sessionId 不同，前端应答必须用它） */
+    sessionId?: string;
     // Phase 21: multi-agent delegation
     delegatedFrom?: string;  // workerId — 标记来自哪个 Worker 的步骤
     traceId?: string;

--- a/tests/agent-lifecycle.test.ts
+++ b/tests/agent-lifecycle.test.ts
@@ -1,0 +1,160 @@
+/**
+ * P1: Agent 实例治理测试
+ * 覆盖：cancel 状态保持 / AbortError 归为 cancelled / DB-only 实例 cancel /
+ *       孤儿实例启动清理 / 进度周期性持久化
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { AgentPool } from '../src/core/harness/agent-pool.js';
+import { AgentHarness } from '../src/core/harness/agent-harness.js';
+import { defaultAgentSpec } from '../src/core/harness/agent-spec.js';
+import { SkillRegistry } from '../src/skills/registry.js';
+import type { Logger, MemoryAccess } from '../src/types.js';
+
+function makeLogger(): Logger {
+    return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeLLM() {
+    return {
+        provider: 'mock',
+        chat: vi.fn().mockResolvedValue({ role: 'assistant', content: 'mock answer' }),
+        chatStream: vi.fn(),
+        embeddings: vi.fn().mockResolvedValue([[]]),
+    };
+}
+
+function makeMemory(): MemoryAccess {
+    return { get: async () => undefined, set: async () => {}, search: async () => [] };
+}
+
+function makeDb(): DatabaseSync {
+    const db = new DatabaseSync(':memory:');
+    db.exec(`
+        CREATE TABLE agent_instances (
+            id TEXT PRIMARY KEY,
+            spec_id TEXT NOT NULL,
+            spec_name TEXT NOT NULL,
+            state TEXT NOT NULL,
+            task TEXT,
+            started_at INTEGER,
+            completed_at INTEGER,
+            step_count INTEGER DEFAULT 0,
+            last_score REAL,
+            error TEXT
+        )
+    `);
+    return db;
+}
+
+function makeHarness(logger = makeLogger()): AgentHarness {
+    const spec = defaultAgentSpec({ id: 'w1', name: 'Worker', description: 'test', systemPrompt: 'x' });
+    return new AgentHarness(spec, () => makeLLM() as any, new SkillRegistry(logger), logger);
+}
+
+const ctx = { sessionId: 's1', memory: makeMemory() };
+
+describe('AgentHarness cancel 状态', () => {
+    it('执行中 cancel 后最终状态保持 cancelled（不被覆写为 completed）', async () => {
+        const harness = makeHarness();
+        (harness as any).engine = {
+            run: async function* () {
+                yield { type: 'thought', content: 't1', timestamp: new Date() };
+                harness.cancel();
+                yield { type: 'answer', content: 'a', timestamp: new Date() };
+            },
+        };
+        const steps: any[] = [];
+        for await (const s of harness.execute('task', ctx)) steps.push(s);
+        expect(harness.getState()).toBe('cancelled');
+    });
+
+    it('引擎抛出 AbortError 归为 cancelled 而非 failed，且不向上抛', async () => {
+        const harness = makeHarness();
+        (harness as any).engine = {
+            run: async function* () {
+                const err = new Error('This operation was aborted');
+                err.name = 'AbortError';
+                throw err;
+                yield undefined as never; // 使函数成为 generator
+            },
+        };
+        const steps: any[] = [];
+        for await (const s of harness.execute('task', ctx)) steps.push(s);
+        expect(harness.getState()).toBe('cancelled');
+        expect(harness.getError()).toBeUndefined();
+    });
+
+    it('cancel 后不允许重新进入运行态', async () => {
+        const harness = makeHarness();
+        harness.cancel();
+        const steps: any[] = [];
+        for await (const s of harness.execute('task', ctx)) steps.push(s);
+        expect(steps).toHaveLength(0);
+        expect(harness.getState()).toBe('cancelled');
+    });
+
+    it('cancel 触发内部 AbortController', () => {
+        const harness = makeHarness();
+        const signal = (harness as any).abortController.signal as AbortSignal;
+        expect(signal.aborted).toBe(false);
+        harness.cancel();
+        expect(signal.aborted).toBe(true);
+    });
+});
+
+describe('AgentPool 实例治理', () => {
+    it('cancel 不存在的实例返回 false', () => {
+        const pool = new AgentPool(() => makeLLM() as any, new SkillRegistry(makeLogger()), makeLogger());
+        expect(pool.cancel('nonexistent')).toBe(false);
+        expect(pool.pause('nonexistent')).toBe(false);
+        expect(pool.resume('nonexistent')).toBe(false);
+    });
+
+    it('cancel 仅存在于 DB 的残留 running 行：直接更新状态', () => {
+        const db = makeDb();
+        db.prepare(`INSERT INTO agent_instances (id, spec_id, spec_name, state, task, started_at, step_count)
+                    VALUES ('stale-1', 'w1', 'Worker', 'running', 't', ?, 0)`).run(Date.now());
+        const pool = new AgentPool(
+            () => makeLLM() as any, new SkillRegistry(makeLogger()), makeLogger(),
+            undefined, undefined, undefined, undefined, undefined, db
+        );
+        expect(pool.cancel('stale-1')).toBe(true);
+        const row = db.prepare(`SELECT state FROM agent_instances WHERE id = 'stale-1'`).get() as any;
+        expect(row.state).toBe('cancelled');
+        // 已终止的行再次 cancel 返回 false
+        expect(pool.cancel('stale-1')).toBe(false);
+    });
+
+    it('markOrphanedInstances 将残留 running/queued 行标记为 failed', () => {
+        const db = makeDb();
+        db.prepare(`INSERT INTO agent_instances (id, spec_id, spec_name, state, task, started_at, step_count)
+                    VALUES ('orphan-1', 'w1', 'Worker', 'running', 't', ?, 0)`).run(Date.now());
+        db.prepare(`INSERT INTO agent_instances (id, spec_id, spec_name, state, task, started_at, step_count)
+                    VALUES ('orphan-2', 'w1', 'Worker', 'queued', 't', ?, 0)`).run(Date.now());
+        db.prepare(`INSERT INTO agent_instances (id, spec_id, spec_name, state, task, started_at, step_count, completed_at)
+                    VALUES ('done-1', 'w1', 'Worker', 'completed', 't', ?, 5, ?)`).run(Date.now(), Date.now());
+        const pool = new AgentPool(
+            () => makeLLM() as any, new SkillRegistry(makeLogger()), makeLogger(),
+            undefined, undefined, undefined, undefined, undefined, db
+        );
+        expect(pool.markOrphanedInstances()).toBe(2);
+        const states = db.prepare(`SELECT id, state, error FROM agent_instances ORDER BY id`).all() as any[];
+        expect(states.find(r => r.id === 'orphan-1').state).toBe('failed');
+        expect(states.find(r => r.id === 'orphan-1').error).toContain('restart');
+        expect(states.find(r => r.id === 'orphan-2').state).toBe('failed');
+        expect(states.find(r => r.id === 'done-1').state).toBe('completed');
+    });
+
+    it('spawn 后 listInstances 显示 task 内容', async () => {
+        const logger = makeLogger();
+        const pool = new AgentPool(() => makeLLM() as any, new SkillRegistry(logger), logger);
+        const spec = defaultAgentSpec({ id: 'w1', name: 'Worker', description: 'test', systemPrompt: 'x' });
+        pool.registerSpec(spec);
+        const instanceId = await pool.spawn('w1', '分析日志文件', { sessionId: 's1', memory: makeMemory() });
+        const info = pool.listInstances().find(i => i.instanceId === instanceId);
+        expect(info?.task).toBe('分析日志文件');
+        pool.cancel(instanceId);
+    });
+});

--- a/tests/interrupt-coordinator.test.ts
+++ b/tests/interrupt-coordinator.test.ts
@@ -1,0 +1,48 @@
+/**
+ * P2: Human-in-the-Loop interrupt 协调器测试
+ * 覆盖：布尔审批 / 文本应答（ask_user）/ abortSignal 释放 / 断连取消
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    waitForApproval,
+    waitForUserDecision,
+    resolveInterrupt,
+    cancelInterrupt,
+    hasPendingInterrupt,
+} from '../src/core/interrupt-coordinator.js';
+
+describe('interrupt-coordinator', () => {
+    it('waitForApproval 由 resolveInterrupt(approved=true) 释放', async () => {
+        const p = waitForApproval('sess-a');
+        expect(hasPendingInterrupt('sess-a')).toBe(true);
+        expect(resolveInterrupt('sess-a', true)).toBe(true);
+        await expect(p).resolves.toBe(true);
+        expect(hasPendingInterrupt('sess-a')).toBe(false);
+    });
+
+    it('waitForUserDecision 携带文本应答（ask_user 场景）', async () => {
+        const p = waitForUserDecision('sess-b', { actionName: 'ask_user' });
+        expect(resolveInterrupt('sess-b', true, { response: '用 PostgreSQL' })).toBe(true);
+        await expect(p).resolves.toEqual({ approved: true, response: '用 PostgreSQL' });
+    });
+
+    it('resolveInterrupt 对无挂起的 session 返回 false', () => {
+        expect(resolveInterrupt('sess-none', true)).toBe(false);
+    });
+
+    it('abortSignal 触发时挂起的等待被 reject 并清理', async () => {
+        const controller = new AbortController();
+        const p = waitForUserDecision('sess-c', undefined, controller.signal);
+        controller.abort();
+        await expect(p).rejects.toThrow(/Aborted/);
+        expect(hasPendingInterrupt('sess-c')).toBe(false);
+    });
+
+    it('cancelInterrupt（断连）reject 挂起的等待', async () => {
+        const p = waitForApproval('sess-d');
+        cancelInterrupt('sess-d');
+        await expect(p).rejects.toThrow(/disconnected/i);
+        expect(hasPendingInterrupt('sess-d')).toBe(false);
+    });
+});

--- a/tests/step-sanitizer.test.ts
+++ b/tests/step-sanitizer.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeStepForStream, MAX_STEP_CONTENT_CHARS, MAX_TOOL_OUTPUT_CHARS } from '../src/core/step-sanitizer.js';
+import type { ExecutionStep } from '../src/types.js';
+
+const bigText = 'x'.repeat(MAX_STEP_CONTENT_CHARS * 3);
+
+describe('sanitizeStepForStream', () => {
+    it('小步骤原样返回（引用相等）', () => {
+        const step: ExecutionStep = { type: 'observation', content: 'ok', toolName: 't', timestamp: new Date() };
+        expect(sanitizeStepForStream(step)).toBe(step);
+    });
+
+    it('截断超长 observation content 并标注原始长度', () => {
+        const step: ExecutionStep = { type: 'observation', content: bigText, timestamp: new Date() };
+        const out = sanitizeStepForStream(step);
+        expect(out).not.toBe(step);
+        expect(out.content.length).toBeLessThan(bigText.length);
+        expect(out.content).toContain(`${bigText.length} 字符`);
+    });
+
+    it('content / answer 类型永不截断', () => {
+        for (const type of ['content', 'answer'] as const) {
+            const step: ExecutionStep = { type, content: bigText, timestamp: new Date() };
+            expect(sanitizeStepForStream(step)).toBe(step);
+        }
+    });
+
+    it('超大 toolOutput 被替换为占位对象', () => {
+        const step = {
+            type: 'observation',
+            content: 'ok',
+            toolOutput: { data: 'y'.repeat(MAX_TOOL_OUTPUT_CHARS * 2) },
+            timestamp: new Date(),
+        } as ExecutionStep;
+        const out = sanitizeStepForStream(step) as any;
+        expect(out.toolOutput._truncated).toBe(true);
+        expect(out.toolOutput.originalChars).toBeGreaterThan(MAX_TOOL_OUTPUT_CHARS);
+        expect(out.content).toBe('ok');
+    });
+
+    it('循环引用 toolOutput 不抛错', () => {
+        const circular: any = { a: 1 };
+        circular.self = circular;
+        const step = { type: 'observation', content: 'ok', toolOutput: circular, timestamp: new Date() } as ExecutionStep;
+        const out = sanitizeStepForStream(step) as any;
+        expect(out.toolOutput._truncated).toBe(true);
+        expect(() => JSON.stringify(out)).not.toThrow();
+    });
+
+    it('小 toolOutput 保持不变', () => {
+        const step = { type: 'observation', content: 'ok', toolOutput: { id: 1 }, timestamp: new Date() } as ExecutionStep;
+        expect(sanitizeStepForStream(step)).toBe(step);
+    });
+});

--- a/web/src/components/chat-thinking.tsx
+++ b/web/src/components/chat-thinking.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Sparkles, ChevronRight, ListTodo, CheckCircle2, XCircle, Clock, Loader2, BrainCircuit, ChevronDown, Bot, ExternalLink, BarChart2 } from "lucide-react";
 import { Card } from "@/components/ui/card";
@@ -40,9 +40,16 @@ export interface ChatStep {
     grading?: { type: string; content: string };
 }
 
-function ThoughtCard({ thought }: { thought: string }) {
+/**
+ * 超过该长度的步骤文本不再走 ReactMarkdown（remark 解析大文本会阻塞主线程），
+ * 降级为纯文本渲染。
+ */
+const MARKDOWN_RENDER_LIMIT = 2000;
+
+const ThoughtCard = memo(function ThoughtCard({ thought }: { thought: string }) {
     const [expanded, setExpanded] = useState(false);
     const isLong = thought.length > 200;
+    const useMarkdown = thought.length <= MARKDOWN_RENDER_LIMIT;
 
     return (
         <Card className="p-3 text-xs bg-muted/30 border-none shadow-sm">
@@ -51,9 +58,15 @@ function ThoughtCard({ thought }: { thought: string }) {
                 <div className="flex-1 min-w-0">
                     <div className="relative">
                         <div className={`overflow-hidden transition-all ${isLong && !expanded ? 'max-h-[120px]' : ''}`}>
-                            <div className="prose prose-xs dark:prose-invert max-w-none text-muted-foreground/90 leading-relaxed [&_p]:italic [&_p]:my-0.5">
-                                <ReactMarkdown remarkPlugins={[remarkGfm]}>{thought}</ReactMarkdown>
-                            </div>
+                            {useMarkdown ? (
+                                <div className="prose prose-xs dark:prose-invert max-w-none text-muted-foreground/90 leading-relaxed [&_p]:italic [&_p]:my-0.5">
+                                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{thought}</ReactMarkdown>
+                                </div>
+                            ) : (
+                                <div className="text-muted-foreground/90 leading-relaxed italic whitespace-pre-wrap break-words">
+                                    {expanded ? thought : thought.slice(0, MARKDOWN_RENDER_LIMIT)}
+                                </div>
+                            )}
                         </div>
                         {isLong && !expanded && (
                             <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-muted/60 to-transparent pointer-events-none" />
@@ -71,11 +84,42 @@ function ThoughtCard({ thought }: { thought: string }) {
             </div>
         </Card>
     );
-}
+});
+
+/**
+ * Observation 渲染：小文本走 Markdown；大文本降级为纯文本 + 折叠预览，
+ * 避免流式过程中反复解析超大 Markdown 导致页面卡死。
+ */
+const ObservationContent = memo(function ObservationContent({ observation }: { observation: string }) {
+    const [expanded, setExpanded] = useState(false);
+    const useMarkdown = observation.length <= MARKDOWN_RENDER_LIMIT;
+
+    if (useMarkdown) {
+        return (
+            <div className="prose prose-xs dark:prose-invert max-w-none [&_*]:text-inherit [&_pre]:bg-transparent [&_pre]:p-0 [&_code]:bg-transparent [&_p]:my-0.5">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{observation}</ReactMarkdown>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] m-0">
+                {expanded ? observation : observation.slice(0, MARKDOWN_RENDER_LIMIT)}
+            </pre>
+            <button
+                onClick={() => setExpanded(v => !v)}
+                className="text-[10px] text-muted-foreground/60 hover:text-muted-foreground mt-1 transition-colors"
+            >
+                {expanded ? '↑ 收起' : `↓ 展开全部（共 ${observation.length} 字符）`}
+            </button>
+        </div>
+    );
+});
 
 // ─── SubTaskPanel: 子 Agent 执行面板（Phase 26）──────────────────────────────
 
-function SubTaskPanel({ subTask }: { subTask: SubTaskInfo }) {
+const SubTaskPanel = memo(function SubTaskPanel({ subTask }: { subTask: SubTaskInfo }) {
     const [collapsed, setCollapsed] = useState(true);
 
     const actionSteps = subTask.steps.filter((s: any) => s.type === 'action' || s.type === 'observation');
@@ -162,7 +206,105 @@ function SubTaskPanel({ subTask }: { subTask: SubTaskInfo }) {
             </AnimatePresence>
         </Card>
     );
-}
+});
+
+// ─── StepBlock: 单个步骤渲染（memo 化，流式追加新步骤时旧步骤不再重渲染）────
+
+const StepBlock = memo(function StepBlock({ step }: { step: ChatStep }) {
+    return (
+        <div className="space-y-2">
+            {/* Thought Bubble */}
+            {step.thought && (
+                <ThoughtCard thought={step.thought} />
+            )}
+
+            {/* Plan Checklist */}
+            {step.plan && step.plan.length > 0 && (
+                <Card className="p-4 text-xs bg-blue-50/50 dark:bg-blue-950/10 border border-blue-100 dark:border-blue-900/30">
+                    <div className="flex items-center gap-2 mb-2 text-blue-600 dark:text-blue-400 font-semibold">
+                        <ListTodo className="w-4 h-4" />
+                        <span>Execution Plan</span>
+                    </div>
+                    <div className="space-y-1.5 pl-1">
+                        {step.plan.map((planStep, pIdx) => (
+                            <div key={pIdx} className="flex gap-2 items-start">
+                                <div className="w-4 h-4 rounded-full bg-blue-100 dark:bg-blue-900/40 text-[10px] flex items-center justify-center text-blue-600 dark:text-blue-400 font-mono shrink-0 mt-0.5">
+                                    {pIdx + 1}
+                                </div>
+                                <span className="text-muted-foreground">{planStep}</span>
+                            </div>
+                        ))}
+                    </div>
+                </Card>
+            )}
+
+            {/* Phase 26: 子 Agent 托管任务面板 */}
+            {step.subTask && (
+                <SubTaskPanel subTask={step.subTask} />
+            )}
+
+            {/* Grader 评分步骤 */}
+            {step.grading && (
+                <Card className="p-2 text-xs bg-amber-50/30 dark:bg-amber-950/10 border border-amber-200 dark:border-amber-800/30">
+                    <div className="flex items-center gap-1.5 text-amber-600 dark:text-amber-400">
+                        <BarChart2 className="w-3.5 h-3.5" />
+                        <span>
+                            {step.grading.type === 'grading'
+                                ? step.grading.content
+                                : (() => {
+                                    try {
+                                        const r = JSON.parse(step.grading.content);
+                                        return `质量评分: ${r.overallScore}/100 — ${r.status}`;
+                                    } catch {
+                                        return step.grading.content;
+                                    }
+                                })()
+                            }
+                        </span>
+                    </div>
+                </Card>
+            )}
+
+            {/* Action & Observation */}
+            {step.action && (
+                <div className="ml-4 pl-4 border-l-2 border-muted space-y-2 py-1">
+                    <div className="flex items-center gap-2 text-xs">
+                        <div className="bg-primary/10 text-primary px-2 py-1 rounded-md font-mono text-[10px] flex items-center gap-1.5">
+                            <ChevronRight className="w-3 h-3" />
+                            {step.action}
+                        </div>
+                        {step.duration !== undefined && (
+                            <span className="text-[10px] text-muted-foreground">
+                                {step.duration >= 1000
+                                    ? `${(step.duration / 1000).toFixed(1)}s`
+                                    : `${step.duration}ms`}
+                            </span>
+                        )}
+                    </div>
+                    {step.observation && (() => {
+                        const isError = isErrorObservation(step.observation);
+                        return (
+                            <div className={cn(
+                                "text-xs p-2 rounded-md overflow-x-auto max-h-[120px] overflow-y-auto",
+                                isError
+                                    ? "text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-900/40"
+                                    : "text-muted-foreground bg-muted/20"
+                            )}>
+                                <div className="flex items-center gap-1.5 mb-1 opacity-80">
+                                    {isError
+                                        ? <><XCircle className="w-3 h-3 text-red-500" /><span>执行失败:</span></>
+                                        : <><CheckCircle2 className="w-3 h-3 text-green-500" /><span>Result:</span></>
+                                    }
+                                </div>
+                                <ObservationContent observation={step.observation} />
+                            </div>
+                        );
+                    })()}
+                </div>
+            )}
+        </div>
+    );
+});
 
 export function ChatThinking({ steps }: { steps: ChatStep[] }) {
     const [collapsed, setCollapsed] = useState(false);
@@ -223,99 +365,7 @@ export function ChatThinking({ steps }: { steps: ChatStep[] }) {
                     >
                         <div className="space-y-3 mt-2">
                             {steps.map((step, idx) => (
-                                <div key={idx} className="space-y-2">
-                                    {/* Thought Bubble */}
-                                    {step.thought && (
-                                        <ThoughtCard thought={step.thought} />
-                                    )}
-
-                                    {/* Plan Checklist */}
-                                    {step.plan && step.plan.length > 0 && (
-                                        <Card className="p-4 text-xs bg-blue-50/50 dark:bg-blue-950/10 border border-blue-100 dark:border-blue-900/30">
-                                            <div className="flex items-center gap-2 mb-2 text-blue-600 dark:text-blue-400 font-semibold">
-                                                <ListTodo className="w-4 h-4" />
-                                                <span>Execution Plan</span>
-                                            </div>
-                                            <div className="space-y-1.5 pl-1">
-                                                {step.plan.map((planStep, pIdx) => (
-                                                    <div key={pIdx} className="flex gap-2 items-start">
-                                                        <div className="w-4 h-4 rounded-full bg-blue-100 dark:bg-blue-900/40 text-[10px] flex items-center justify-center text-blue-600 dark:text-blue-400 font-mono shrink-0 mt-0.5">
-                                                            {pIdx + 1}
-                                                        </div>
-                                                        <span className="text-muted-foreground">{planStep}</span>
-                                                    </div>
-                                                ))}
-                                            </div>
-                                        </Card>
-                                    )}
-
-                                    {/* Phase 26: 子 Agent 托管任务面板 */}
-                                    {step.subTask && (
-                                        <SubTaskPanel subTask={step.subTask} />
-                                    )}
-
-                                    {/* Grader 评分步骤 */}
-                                    {step.grading && (
-                                        <Card className="p-2 text-xs bg-amber-50/30 dark:bg-amber-950/10 border border-amber-200 dark:border-amber-800/30">
-                                            <div className="flex items-center gap-1.5 text-amber-600 dark:text-amber-400">
-                                                <BarChart2 className="w-3.5 h-3.5" />
-                                                <span>
-                                                    {step.grading.type === 'grading'
-                                                        ? step.grading.content
-                                                        : (() => {
-                                                            try {
-                                                                const r = JSON.parse(step.grading.content);
-                                                                return `质量评分: ${r.overallScore}/100 — ${r.status}`;
-                                                            } catch {
-                                                                return step.grading.content;
-                                                            }
-                                                        })()
-                                                    }
-                                                </span>
-                                            </div>
-                                        </Card>
-                                    )}
-
-                                    {/* Action & Observation */}
-                                    {step.action && (
-                                        <div className="ml-4 pl-4 border-l-2 border-muted space-y-2 py-1">
-                                            <div className="flex items-center gap-2 text-xs">
-                                                <div className="bg-primary/10 text-primary px-2 py-1 rounded-md font-mono text-[10px] flex items-center gap-1.5">
-                                                    <ChevronRight className="w-3 h-3" />
-                                                    {step.action}
-                                                </div>
-                                                {step.duration !== undefined && (
-                                                    <span className="text-[10px] text-muted-foreground">
-                                                        {step.duration >= 1000
-                                                            ? `${(step.duration / 1000).toFixed(1)}s`
-                                                            : `${step.duration}ms`}
-                                                    </span>
-                                                )}
-                                            </div>
-                                            {step.observation && (() => {
-                                                const isError = isErrorObservation(step.observation);
-                                                return (
-                                                    <div className={cn(
-                                                        "text-xs p-2 rounded-md overflow-x-auto max-h-[120px] overflow-y-auto",
-                                                        isError
-                                                            ? "text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-900/40"
-                                                            : "text-muted-foreground bg-muted/20"
-                                                    )}>
-                                                        <div className="flex items-center gap-1.5 mb-1 opacity-80">
-                                                            {isError
-                                                                ? <><XCircle className="w-3 h-3 text-red-500" /><span>执行失败:</span></>
-                                                                : <><CheckCircle2 className="w-3 h-3 text-green-500" /><span>Result:</span></>
-                                                            }
-                                                        </div>
-                                                        <div className="prose prose-xs dark:prose-invert max-w-none [&_*]:text-inherit [&_pre]:bg-transparent [&_pre]:p-0 [&_code]:bg-transparent [&_p]:my-0.5">
-                                                            <ReactMarkdown remarkPlugins={[remarkGfm]}>{step.observation}</ReactMarkdown>
-                                                        </div>
-                                                    </div>
-                                                );
-                                            })()}
-                                        </div>
-                                    )}
-                                </div>
+                                <StepBlock key={idx} step={step} />
                             ))}
                         </div>
                     </motion.div>

--- a/web/src/components/chat/interrupt-card.tsx
+++ b/web/src/components/chat/interrupt-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { ShieldAlert, ShieldCheck, ShieldX } from "lucide-react";
+import { ShieldAlert, ShieldCheck, ShieldX, MessageCircleQuestion, Send } from "lucide-react";
 import { fetchApi } from "@/lib/api";
 
 export interface InterruptInfo {
@@ -10,6 +10,12 @@ export interface InterruptInfo {
     args: Record<string, unknown>;
     reason: string;
     resolved: boolean | null;
+    /** interrupt 实际挂起的 sessionId（子 Agent 场景下与 Chat sessionId 不同） */
+    sessionId?: string;
+    /** approval=危险操作确认；question=ask_user 提问（文本应答） */
+    kind?: 'approval' | 'question';
+    /** ask_user 提供的候选答案 */
+    options?: string[];
 }
 
 export const InterruptCard = ({
@@ -22,50 +28,109 @@ export const InterruptCard = ({
     const [status, setStatus] = useState<'pending' | 'loading' | 'approved' | 'rejected'>(
         interrupt.resolved === true ? 'approved' : interrupt.resolved === false ? 'rejected' : 'pending'
     );
+    const [answer, setAnswer] = useState('');
 
-    const respond = useCallback(async (approved: boolean) => {
+    // 应答必须发往 interrupt 实际挂起的 session：
+    // 子 Agent 的 interrupt 挂起在 harness 子 session 上；
+    // 新会话（URL 无 sessionId）时 chunk 内的 sessionId 也是唯一可靠来源。
+    const targetSessionId = interrupt.sessionId || sessionId;
+    const isQuestion = interrupt.kind === 'question';
+
+    const respond = useCallback(async (approved: boolean, response?: string) => {
         setStatus('loading');
         try {
-            await fetchApi(`/api/sessions/${sessionId}/interrupt-response`, {
+            await fetchApi(`/api/sessions/${targetSessionId}/interrupt-response`, {
                 method: 'POST',
-                body: JSON.stringify({ approved }),
+                body: JSON.stringify(response ? { approved, response } : { approved }),
             });
             setStatus(approved ? 'approved' : 'rejected');
         } catch {
             setStatus('pending');
         }
-    }, [sessionId]);
+    }, [targetSessionId]);
 
     const cmdPreview = interrupt.args?.command
         ? String(interrupt.args.command).slice(0, 120)
         : interrupt.args?.query
             ? String(interrupt.args.query).slice(0, 120)
-            : JSON.stringify(interrupt.args).slice(0, 120);
+            : !isQuestion
+                ? JSON.stringify(interrupt.args).slice(0, 120)
+                : '';
 
     return (
         <div className="my-3 rounded-xl border border-amber-300/60 dark:border-amber-700/60 bg-amber-50/80 dark:bg-amber-950/30 overflow-hidden">
             <div className="flex items-center gap-2 px-4 py-2.5 bg-amber-100/80 dark:bg-amber-900/30 border-b border-amber-300/40 dark:border-amber-700/40">
-                <ShieldAlert className="w-4 h-4 text-amber-600 dark:text-amber-400 shrink-0" />
-                <span className="text-sm font-semibold text-amber-800 dark:text-amber-300">高危操作确认</span>
+                {isQuestion
+                    ? <MessageCircleQuestion className="w-4 h-4 text-amber-600 dark:text-amber-400 shrink-0" />
+                    : <ShieldAlert className="w-4 h-4 text-amber-600 dark:text-amber-400 shrink-0" />}
+                <span className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                    {isQuestion ? 'Agent 提问' : '高危操作确认'}
+                </span>
                 <span className="ml-auto text-[11px] text-amber-600/70 dark:text-amber-400/70 font-mono">{interrupt.tool}</span>
             </div>
 
             <div className="px-4 py-3 space-y-2">
-                <p className="text-sm text-amber-900 dark:text-amber-200">
-                    Agent 即将执行以下操作，请确认是否继续：
-                </p>
-                <div className="text-xs text-amber-800/80 dark:text-amber-300/80 font-medium">
-                    ⚠️ {interrupt.reason}
-                </div>
+                {isQuestion ? (
+                    <p className="text-sm text-amber-900 dark:text-amber-200 whitespace-pre-wrap">
+                        {interrupt.reason}
+                    </p>
+                ) : (
+                    <>
+                        <p className="text-sm text-amber-900 dark:text-amber-200">
+                            Agent 即将执行以下操作，请确认是否继续：
+                        </p>
+                        <div className="text-xs text-amber-800/80 dark:text-amber-300/80 font-medium">
+                            ⚠️ {interrupt.reason}
+                        </div>
+                    </>
+                )}
                 {cmdPreview && (
                     <pre className="text-xs bg-black/10 dark:bg-white/5 rounded-md px-3 py-2 text-amber-900 dark:text-amber-200 overflow-x-auto whitespace-pre-wrap break-all">
                         {cmdPreview}
                     </pre>
                 )}
+                {isQuestion && status === 'pending' && (interrupt.options?.length ?? 0) > 0 && (
+                    <div className="flex flex-wrap gap-1.5">
+                        {interrupt.options!.map((opt, i) => (
+                            <button
+                                key={i}
+                                onClick={() => respond(true, opt)}
+                                className="px-2.5 py-1 rounded-full border border-amber-400/60 hover:bg-amber-100 dark:hover:bg-amber-900/40 text-amber-800 dark:text-amber-300 text-xs transition-colors"
+                            >
+                                {opt}
+                            </button>
+                        ))}
+                    </div>
+                )}
+                {isQuestion && status === 'pending' && (
+                    <div className="flex gap-2 items-start">
+                        <textarea
+                            value={answer}
+                            onChange={e => setAnswer(e.target.value)}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter' && !e.shiftKey && answer.trim()) {
+                                    e.preventDefault();
+                                    respond(true, answer.trim());
+                                }
+                            }}
+                            placeholder="输入你的回答…（Enter 发送）"
+                            rows={2}
+                            className="flex-1 text-sm rounded-md border border-amber-300/60 dark:border-amber-700/60 bg-background/60 px-3 py-2 resize-y focus:outline-none focus:ring-1 focus:ring-amber-500"
+                        />
+                        <button
+                            onClick={() => answer.trim() && respond(true, answer.trim())}
+                            disabled={!answer.trim()}
+                            className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-amber-600 hover:bg-amber-700 disabled:opacity-40 text-white text-xs font-medium transition-colors"
+                        >
+                            <Send className="w-3.5 h-3.5" />
+                            回答
+                        </button>
+                    </div>
+                )}
             </div>
 
             <div className="px-4 py-2.5 border-t border-amber-300/40 dark:border-amber-700/40 flex items-center gap-2">
-                {status === 'pending' && (
+                {status === 'pending' && !isQuestion && (
                     <>
                         <button
                             onClick={() => respond(true)}
@@ -84,17 +149,29 @@ export const InterruptCard = ({
                         <span className="ml-auto text-[10px] text-amber-600/60">等待您的确认…</span>
                     </>
                 )}
+                {status === 'pending' && isQuestion && (
+                    <>
+                        <button
+                            onClick={() => respond(false)}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-400/60 hover:bg-amber-100 dark:hover:bg-amber-900/40 text-amber-800 dark:text-amber-300 text-xs font-medium transition-colors"
+                        >
+                            <ShieldX className="w-3.5 h-3.5" />
+                            跳过此问题
+                        </button>
+                        <span className="ml-auto text-[10px] text-amber-600/60">Agent 等待您的回答…</span>
+                    </>
+                )}
                 {status === 'loading' && (
                     <span className="text-xs text-amber-600 animate-pulse">处理中…</span>
                 )}
                 {status === 'approved' && (
                     <span className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400 font-medium">
-                        <ShieldCheck className="w-3.5 h-3.5" /> 已确认，Agent 继续执行
+                        <ShieldCheck className="w-3.5 h-3.5" /> {isQuestion ? '已回答，Agent 继续执行' : '已确认，Agent 继续执行'}
                     </span>
                 )}
                 {status === 'rejected' && (
                     <span className="flex items-center gap-1.5 text-xs text-muted-foreground font-medium">
-                        <ShieldX className="w-3.5 h-3.5" /> 已取消操作
+                        <ShieldX className="w-3.5 h-3.5" /> {isQuestion ? '已跳过该问题' : '已取消操作'}
                     </span>
                 )}
             </div>

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -85,7 +85,62 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
             }
 
             for await (const chunk of streamApi("/api/chat/stream", requestBody, abortSignal)) {
-                if (chunk.type === "content") {
+                if (chunk.type === "interrupt") {
+                    // Human-in-the-Loop: agent 挂起等待用户应答（危险操作确认 / ask_user 提问）。
+                    // 必须排在 delegatedFrom 之前：子 Agent 的 interrupt 也要弹出顶层应答卡片。
+                    currentSteps.push({
+                        interrupt: {
+                            id: chunk.interruptId,
+                            tool: chunk.toolName,
+                            args: chunk.toolInput ?? {},
+                            reason: chunk.interruptReason ?? chunk.content ?? '操作需要确认',
+                            // 应答必须发往 interrupt 实际挂起的 session（子 Agent 与 Chat session 不同）
+                            sessionId: chunk.sessionId,
+                            kind: chunk.interruptKind ?? 'approval',
+                            options: chunk.toolInput?.options,
+                            resolved: null, // null = pending user response
+                        }
+                    });
+                    yield buildYield();
+
+                } else if (chunk.delegatedFrom && chunk.harnessInstanceId) {
+                    // 子 Agent 步骤：聚合到子任务分组。
+                    // 必须排在 content/thought/action 等类型分支之前，
+                    // 否则子 Agent 步骤会被父级分支拦截（content 混入父回答正文、
+                    // thought/action/observation 混入父步骤列表），子任务面板只剩 answer。
+                    const instanceId = chunk.harnessInstanceId;
+                    const subTaskIdx = currentSteps.findIndex(
+                        (s: any) => s.subTask?.instanceId === instanceId
+                    );
+                    if (subTaskIdx >= 0) {
+                        // 不可变更新，保证下游 memo 组件能感知变化
+                        const prev = currentSteps[subTaskIdx].subTask;
+                        const nextSubTask = { ...prev, steps: [...prev.steps, chunk] };
+                        if (chunk.type === 'answer') {
+                            nextSubTask.status = 'completed';
+                            nextSubTask.endTime = new Date();
+                        }
+                        if (chunk.type === 'grade_result') {
+                            try {
+                                const graderResult = JSON.parse(chunk.content ?? '{}');
+                                nextSubTask.graderScore = graderResult.overallScore;
+                            } catch { /* ignore */ }
+                        }
+                        currentSteps[subTaskIdx] = { subTask: nextSubTask };
+                    } else {
+                        currentSteps.push({
+                            subTask: {
+                                delegatedFrom: chunk.delegatedFrom,
+                                instanceId,
+                                steps: [chunk],
+                                status: 'running',
+                                startTime: new Date(),
+                            }
+                        });
+                    }
+                    yield buildYield();
+
+                } else if (chunk.type === "content") {
                     currentContent += chunk.content;
                     const now = Date.now();
                     if (now - lastYieldTime >= YIELD_MIN_INTERVAL_MS) {
@@ -149,19 +204,6 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
                     });
                     yield buildYield();
 
-                } else if (chunk.type === "interrupt") {
-                    // Human-in-the-Loop: agent is paused waiting for user approval
-                    currentSteps.push({
-                        interrupt: {
-                            id: chunk.interruptId,
-                            tool: chunk.toolName,
-                            args: chunk.toolInput ?? {},
-                            reason: chunk.interruptReason ?? chunk.content ?? '操作需要确认',
-                            resolved: null, // null = pending user response
-                        }
-                    });
-                    yield buildYield();
-
                 } else if (chunk.type === "workflow_generated") {
                     currentSteps.push({
                         workflow_generated: {
@@ -182,41 +224,6 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
                             content: chunk.content,
                         }
                     });
-                    yield buildYield();
-
-                } else if (chunk.delegatedFrom && chunk.harnessInstanceId) {
-                    // Phase 26: 带 delegatedFrom 标记的子 Agent 步骤
-                    // 聚合到子任务分组中
-                    const instanceId = chunk.harnessInstanceId;
-                    const subTaskIdx = currentSteps.findIndex(
-                        (s: any) => s.subTask?.instanceId === instanceId
-                    );
-                    if (subTaskIdx >= 0) {
-                        // 不可变更新，保证下游 memo 组件能感知变化
-                        const prev = currentSteps[subTaskIdx].subTask;
-                        const nextSubTask = { ...prev, steps: [...prev.steps, chunk] };
-                        if (chunk.type === 'answer') {
-                            nextSubTask.status = 'completed';
-                            nextSubTask.endTime = new Date();
-                        }
-                        if (chunk.type === 'grade_result') {
-                            try {
-                                const graderResult = JSON.parse(chunk.content ?? '{}');
-                                nextSubTask.graderScore = graderResult.overallScore;
-                            } catch { /* ignore */ }
-                        }
-                        currentSteps[subTaskIdx] = { subTask: nextSubTask };
-                    } else {
-                        currentSteps.push({
-                            subTask: {
-                                delegatedFrom: chunk.delegatedFrom,
-                                instanceId,
-                                steps: [chunk],
-                                status: 'running',
-                                startTime: new Date(),
-                            }
-                        });
-                    }
                     yield buildYield();
 
                 } else if (chunk.type === "answer") {

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -62,6 +62,12 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
             metadata: { custom: { steps: [...currentSteps], assistantMessageId, suggestions } },
         });
 
+        // 渲染节流：content token 高频到达时按最小间隔合并 yield，
+        // 避免每个 token 触发一次全量 re-render 导致大输出场景页面卡死。
+        // 非 content 的结构性步骤（thought/action/observation 等）立即 yield。
+        const YIELD_MIN_INTERVAL_MS = 50;
+        let lastYieldTime = 0;
+
         try {
             const requestBody: Record<string, unknown> = {
                 message: userContent,
@@ -81,7 +87,11 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
             for await (const chunk of streamApi("/api/chat/stream", requestBody, abortSignal)) {
                 if (chunk.type === "content") {
                     currentContent += chunk.content;
-                    yield buildYield();
+                    const now = Date.now();
+                    if (now - lastYieldTime >= YIELD_MIN_INTERVAL_MS) {
+                        lastYieldTime = now;
+                        yield buildYield();
+                    }
 
                 } else if (chunk.type === "thought") {
                     currentSteps.push({ thought: chunk.content });
@@ -104,12 +114,14 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
 
                 } else if (chunk.type === "observation") {
                     if (currentSteps.length > 0) {
-                        // Prefer chunk.content (always set by backend), fall back to chunk.result
-                        currentSteps[currentSteps.length - 1].observation =
-                            chunk.content ?? chunk.result ?? chunk.toolOutput ?? "";
-                        if (chunk.duration !== undefined) {
-                            currentSteps[currentSteps.length - 1].duration = chunk.duration;
-                        }
+                        // 用新对象替换而非原地修改，保证下游 memo 组件能感知变化
+                        const last = currentSteps[currentSteps.length - 1];
+                        currentSteps[currentSteps.length - 1] = {
+                            ...last,
+                            // Prefer chunk.content (always set by backend), fall back to chunk.result
+                            observation: chunk.content ?? chunk.result ?? chunk.toolOutput ?? "",
+                            ...(chunk.duration !== undefined ? { duration: chunk.duration } : {}),
+                        };
                     }
                     yield buildYield();
 
@@ -176,21 +188,24 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
                     // Phase 26: 带 delegatedFrom 标记的子 Agent 步骤
                     // 聚合到子任务分组中
                     const instanceId = chunk.harnessInstanceId;
-                    const existingSubTask = currentSteps.find(
+                    const subTaskIdx = currentSteps.findIndex(
                         (s: any) => s.subTask?.instanceId === instanceId
                     );
-                    if (existingSubTask) {
-                        existingSubTask.subTask.steps.push(chunk);
+                    if (subTaskIdx >= 0) {
+                        // 不可变更新，保证下游 memo 组件能感知变化
+                        const prev = currentSteps[subTaskIdx].subTask;
+                        const nextSubTask = { ...prev, steps: [...prev.steps, chunk] };
                         if (chunk.type === 'answer') {
-                            existingSubTask.subTask.status = 'completed';
-                            existingSubTask.subTask.endTime = new Date();
+                            nextSubTask.status = 'completed';
+                            nextSubTask.endTime = new Date();
                         }
                         if (chunk.type === 'grade_result') {
                             try {
                                 const graderResult = JSON.parse(chunk.content ?? '{}');
-                                existingSubTask.subTask.graderScore = graderResult.overallScore;
+                                nextSubTask.graderScore = graderResult.overallScore;
                             } catch { /* ignore */ }
                         }
+                        currentSteps[subTaskIdx] = { subTask: nextSubTask };
                     } else {
                         currentSteps.push({
                             subTask: {
@@ -210,6 +225,8 @@ export class MyRuntimeAdapter implements ChatModelAdapter {
                     yield buildYield();
                 }
             }
+            // 流结束：flush 节流期间可能被跳过的最后一批 content
+            yield buildYield();
         } catch (error: any) {
             if (error.name === 'AbortError') {
                 console.log('Fetch aborted');


### PR DESCRIPTION
## 背景

用户反馈四个问题：
1. 对话调起 Agent 且轮次多/输出大时页面卡死，内容不显示，对话记录丢失
2. Agent 执行记录出现 0 轮次且无法终止
3. Agent 执行步骤在对话中不完整；Agent 追问澄清时对话无法应答
4. 所有大数据场景（MCP 响应/文件读取/skill 输出）均会卡死

## 根因与修复（三批提交）

### P0 — 卡死与数据丢失（问题 1、4）
**根因**：observation 步骤无截断且双份携带 content + toolOutput（单条 SSE 事件可达 MB）；前端每个 token 全量 re-render，大 observation 每次都全量 ReactMarkdown 解析 → 主线程阻塞。用户+助手消息只在整轮成功后落库，中断即全丢。

- 新增 `step-sanitizer.ts`：传输边界统一截断（content 4KB / toolOutput 2KB），LLM 上下文不受影响；SSE/WS/AgentPool 缓存均接入
- `routes/chat.ts`：用户消息请求开始即落库；abort/error 时保存部分回答；执行步骤持久化到 `metadata.custom.steps`（刷新可恢复）；SSE 背压（drain 等待）
- 前端：content token 50ms 节流；步骤组件 memo 化；>2000 字符文本降级纯文本渲染

### P1 — Agent 实例治理（问题 2）
**根因**：agent_instances 只在 spawn（step_count=0）和正常结束时持久化，重启后残留僵尸 running 行；cancel 只查内存 Map 对 DB 残留行 no-op 却返回 success；harness.cancel 不中断底层 LLM 调用且状态被覆写为 completed。

- Harness 内建 AbortController，cancel 立即中断底层执行；cancelled 状态不再被覆写；AbortError 归为 cancelled
- driveInstance 每 3s 持久化进度；启动时 `markOrphanedInstances()` 清理遗留行
- `pool.cancel` 对 DB-only 残留行直接更新状态；PATCH 接口 404 语义
- delegate spawn 透传父 abortSignal，Chat 断连级联终止子 Agent

### P2 — 子 Agent 步骤透传 + 用户澄清（问题 3）
**根因**：runtime 分发链中 delegatedFrom 分支排在最后，子 Agent 步骤被父级分支拦截；interrupt 按 harness 子 sessionId 挂起而前端用 URL 的 Chat sessionId 应答，永远无法送达；无向用户提问机制。

- interrupt / delegatedFrom 分支提到分发链最前，子 Agent 步骤完整进入 SubTaskPanel
- interrupt chunk 携带实际挂起的 sessionId，前端应答优先使用
- 新增 `ask_user` 内置工具 + question 类型 interrupt：Agent 可提问挂起等待，前端问答卡片（候选项/文本框）应答注入继续执行；abortSignal 释放防悬挂

## 验证

- 后端 `tsc --noEmit` 0 错误
- `vitest run` 261 tests 全绿（新增 19 个：sanitizer 6 / 生命周期 8 / coordinator 5）
- web `tsc --noEmit` 0 错误，`npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)