### PR TITLE
feat(dev-workflow): 数据层 — projects/requirements/requirement_runs + repository + 项目 CRUD

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -306,6 +306,63 @@ export function initDatabase(): DatabaseSync {
         CREATE INDEX IF NOT EXISTS idx_se_type    ON session_events(type);
     `);
 
+    // 研发流程管理模块：projects / requirements / requirement_runs（实施地图 #61 ticket #62）
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS projects (
+            id                  TEXT PRIMARY KEY,
+            name                TEXT NOT NULL UNIQUE,
+            dir                 TEXT NOT NULL,
+            description         TEXT,
+            sync_source         TEXT NOT NULL DEFAULT 'github',
+            sync_config         TEXT,
+            last_synced_at      TEXT,
+            max_concurrent_runs INTEGER NOT NULL DEFAULT 2,
+            skills_installed_at TEXT,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS requirements (
+            id             TEXT PRIMARY KEY,
+            project_id     TEXT NOT NULL,
+            req_key        TEXT NOT NULL,
+            source         TEXT NOT NULL,
+            source_key     TEXT NOT NULL,
+            title          TEXT NOT NULL,
+            description    TEXT,
+            labels         TEXT,
+            status         TEXT NOT NULL DEFAULT 'synced',
+            source_url     TEXT,
+            source_closed  INTEGER NOT NULL DEFAULT 0,
+            created_at     TEXT NOT NULL,
+            updated_at     TEXT NOT NULL,
+            FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_req_key       ON requirements(req_key);
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_req_dedup     ON requirements(project_id, source, source_key);
+        CREATE INDEX IF NOT EXISTS idx_req_project_status  ON requirements(project_id, status);
+
+        CREATE TABLE IF NOT EXISTS requirement_runs (
+            id              TEXT PRIMARY KEY,
+            requirement_id  TEXT NOT NULL,
+            project_id      TEXT NOT NULL,
+            engine          TEXT NOT NULL,
+            worktree_path   TEXT,
+            branch          TEXT,
+            session_id      TEXT NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'running',
+            retry_no        INTEGER NOT NULL DEFAULT 0,
+            pr_url          TEXT,
+            error_message   TEXT,
+            token_cost      TEXT,
+            started_at      TEXT NOT NULL,
+            finished_at     TEXT,
+            FOREIGN KEY (requirement_id) REFERENCES requirements(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_req_runs_requirement ON requirement_runs(requirement_id, started_at);
+        CREATE INDEX IF NOT EXISTS idx_req_runs_project     ON requirement_runs(project_id, started_at);
+    `);
+
     // Phase 25: credential_vault — 凭证隔离存储（Gap 4）
     // 凭证以 AES-256-GCM 加密存储；skill 只持有 sessionToken，proxy 换取真实凭证
     db.exec(`

--- a/src/core/project-repository.ts
+++ b/src/core/project-repository.ts
@@ -1,0 +1,144 @@
+import { nanoid } from 'nanoid';
+import { db } from './database.js';
+
+export interface Project {
+    id: string;
+    name: string;
+    dir: string;
+    description: string | null;
+    syncSource: string;
+    syncConfig: Record<string, unknown> | null;
+    lastSyncedAt: string | null;
+    maxConcurrentRuns: number;
+    skillsInstalledAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+interface ProjectRow {
+    id: string;
+    name: string;
+    dir: string;
+    description: string | null;
+    sync_source: string;
+    sync_config: string | null;
+    last_synced_at: string | null;
+    max_concurrent_runs: number;
+    skills_installed_at: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+function rowToProject(row: ProjectRow): Project {
+    return {
+        id: row.id,
+        name: row.name,
+        dir: row.dir,
+        description: row.description,
+        syncSource: row.sync_source,
+        syncConfig: row.sync_config ? JSON.parse(row.sync_config) : null,
+        lastSyncedAt: row.last_synced_at,
+        maxConcurrentRuns: row.max_concurrent_runs,
+        skillsInstalledAt: row.skills_installed_at,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+export interface CreateProjectInput {
+    name: string;
+    dir: string;
+    description?: string;
+    syncSource?: string;
+    syncConfig?: Record<string, unknown>;
+    maxConcurrentRuns?: number;
+}
+
+export interface UpdateProjectInput {
+    dir?: string;
+    description?: string;
+    syncSource?: string;
+    syncConfig?: Record<string, unknown>;
+    maxConcurrentRuns?: number;
+}
+
+export class ProjectRepository {
+    private db: typeof db;
+
+    constructor(database?: typeof db) {
+        this.db = database ?? db;
+    }
+
+    create(input: CreateProjectInput): Project {
+        const id = nanoid();
+        const now = new Date().toISOString();
+        this.db.prepare(
+            `INSERT INTO projects (id, name, dir, description, sync_source, sync_config, max_concurrent_runs, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).run(
+            id,
+            input.name,
+            input.dir,
+            input.description ?? null,
+            input.syncSource ?? 'github',
+            input.syncConfig ? JSON.stringify(input.syncConfig) : null,
+            input.maxConcurrentRuns ?? 2,
+            now,
+            now
+        );
+        return this.getById(id)!;
+    }
+
+    getById(id: string): Project | null {
+        const row = this.db.prepare('SELECT * FROM projects WHERE id = ?').get(id) as ProjectRow | undefined;
+        return row ? rowToProject(row) : null;
+    }
+
+    getByName(name: string): Project | null {
+        const row = this.db.prepare('SELECT * FROM projects WHERE name = ?').get(name) as ProjectRow | undefined;
+        return row ? rowToProject(row) : null;
+    }
+
+    list(): Project[] {
+        const rows = this.db.prepare('SELECT * FROM projects ORDER BY created_at DESC').all() as unknown as ProjectRow[];
+        return rows.map(rowToProject);
+    }
+
+    update(id: string, input: UpdateProjectInput): Project | null {
+        const existing = this.getById(id);
+        if (!existing) return null;
+
+        const now = new Date().toISOString();
+        this.db.prepare(
+            `UPDATE projects
+             SET dir = ?, description = ?, sync_source = ?, sync_config = ?, max_concurrent_runs = ?, updated_at = ?
+             WHERE id = ?`
+        ).run(
+            input.dir ?? existing.dir,
+            input.description !== undefined ? input.description : existing.description,
+            input.syncSource ?? existing.syncSource,
+            input.syncConfig !== undefined ? JSON.stringify(input.syncConfig) : (existing.syncConfig ? JSON.stringify(existing.syncConfig) : null),
+            input.maxConcurrentRuns ?? existing.maxConcurrentRuns,
+            now,
+            id
+        );
+        return this.getById(id);
+    }
+
+    touchSynced(id: string, syncedAt: string = new Date().toISOString()): void {
+        this.db.prepare('UPDATE projects SET last_synced_at = ?, updated_at = ? WHERE id = ?')
+            .run(syncedAt, new Date().toISOString(), id);
+    }
+
+    markSkillsInstalled(id: string, installedAt: string = new Date().toISOString()): void {
+        this.db.prepare('UPDATE projects SET skills_installed_at = ?, updated_at = ? WHERE id = ?')
+            .run(installedAt, new Date().toISOString(), id);
+    }
+
+    delete(id: string): boolean {
+        const result = this.db.prepare('DELETE FROM projects WHERE id = ?').run(id);
+        return result.changes > 0;
+    }
+}
+
+export const projectRepository = new ProjectRepository();

--- a/src/core/requirement-repository.ts
+++ b/src/core/requirement-repository.ts
@@ -1,0 +1,206 @@
+import { nanoid } from 'nanoid';
+import { db } from './database.js';
+
+export type RequirementStatus =
+    | 'synced'
+    | 'queued'
+    | 'in_progress'
+    | 'waiting_input'
+    | 'implemented'
+    | 'merged'
+    | 'failed'
+    | 'cancelled';
+
+export interface Requirement {
+    id: string;
+    projectId: string;
+    reqKey: string;
+    source: string;
+    sourceKey: string;
+    title: string;
+    description: string | null;
+    labels: string[];
+    status: RequirementStatus;
+    sourceUrl: string | null;
+    sourceClosed: boolean;
+    createdAt: string;
+    updatedAt: string;
+}
+
+interface RequirementRow {
+    id: string;
+    project_id: string;
+    req_key: string;
+    source: string;
+    source_key: string;
+    title: string;
+    description: string | null;
+    labels: string | null;
+    status: string;
+    source_url: string | null;
+    source_closed: number;
+    created_at: string;
+    updated_at: string;
+}
+
+function rowToRequirement(row: RequirementRow): Requirement {
+    return {
+        id: row.id,
+        projectId: row.project_id,
+        reqKey: row.req_key,
+        source: row.source,
+        sourceKey: row.source_key,
+        title: row.title,
+        description: row.description,
+        labels: row.labels ? JSON.parse(row.labels) : [],
+        status: row.status as RequirementStatus,
+        sourceUrl: row.source_url,
+        sourceClosed: Boolean(row.source_closed),
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+export interface CreateRequirementInput {
+    projectId: string;
+    reqKey: string;
+    source: string;
+    sourceKey: string;
+    title: string;
+    description?: string;
+    labels?: string[];
+    sourceUrl?: string;
+}
+
+export interface UpdateRequirementMetadataInput {
+    title?: string;
+    description?: string;
+    labels?: string[];
+    sourceUrl?: string;
+}
+
+/**
+ * 手动需求 req_key 的数字段前缀，用于与同步渠道（如 GitHub issue number）的数字编号区分，
+ * 避免撞车（spec §2.2）。
+ */
+const MANUAL_REQ_KEY_PREFIX = 'M';
+const MANUAL_SEQUENCE_START = 10000;
+
+export class RequirementRepository {
+    private db: typeof db;
+
+    constructor(database?: typeof db) {
+        this.db = database ?? db;
+    }
+
+    create(input: CreateRequirementInput): Requirement {
+        const id = nanoid();
+        const now = new Date().toISOString();
+        this.db.prepare(
+            `INSERT INTO requirements (id, project_id, req_key, source, source_key, title, description, labels, status, source_url, source_closed, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'synced', ?, 0, ?, ?)`
+        ).run(
+            id,
+            input.projectId,
+            input.reqKey,
+            input.source,
+            input.sourceKey,
+            input.title,
+            input.description ?? null,
+            input.labels ? JSON.stringify(input.labels) : null,
+            input.sourceUrl ?? null,
+            now,
+            now
+        );
+        return this.getById(id)!;
+    }
+
+    getById(id: string): Requirement | null {
+        const row = this.db.prepare('SELECT * FROM requirements WHERE id = ?').get(id) as RequirementRow | undefined;
+        return row ? rowToRequirement(row) : null;
+    }
+
+    getByReqKey(reqKey: string): Requirement | null {
+        const row = this.db.prepare('SELECT * FROM requirements WHERE req_key = ?').get(reqKey) as RequirementRow | undefined;
+        return row ? rowToRequirement(row) : null;
+    }
+
+    /** 同步去重键查找（spec §2.2：(project_id, source, source_key) 唯一索引） */
+    findByDedupKey(projectId: string, source: string, sourceKey: string): Requirement | null {
+        const row = this.db.prepare(
+            'SELECT * FROM requirements WHERE project_id = ? AND source = ? AND source_key = ?'
+        ).get(projectId, source, sourceKey) as RequirementRow | undefined;
+        return row ? rowToRequirement(row) : null;
+    }
+
+    listByProject(projectId: string, opts?: { status?: RequirementStatus }): Requirement[] {
+        const rows = opts?.status
+            ? this.db.prepare('SELECT * FROM requirements WHERE project_id = ? AND status = ? ORDER BY created_at DESC')
+                .all(projectId, opts.status) as unknown as RequirementRow[]
+            : this.db.prepare('SELECT * FROM requirements WHERE project_id = ? ORDER BY created_at DESC')
+                .all(projectId) as unknown as RequirementRow[];
+        return rows.map(rowToRequirement);
+    }
+
+    /**
+     * 再次同步命中去重键时只更新元数据，绝不回退状态机（spec §2.2）。
+     */
+    updateMetadata(id: string, input: UpdateRequirementMetadataInput): Requirement | null {
+        const existing = this.getById(id);
+        if (!existing) return null;
+
+        const now = new Date().toISOString();
+        this.db.prepare(
+            `UPDATE requirements
+             SET title = ?, description = ?, labels = ?, source_url = ?, updated_at = ?
+             WHERE id = ?`
+        ).run(
+            input.title ?? existing.title,
+            input.description !== undefined ? input.description : existing.description,
+            input.labels !== undefined ? JSON.stringify(input.labels) : (existing.labels.length ? JSON.stringify(existing.labels) : null),
+            input.sourceUrl !== undefined ? input.sourceUrl : existing.sourceUrl,
+            now,
+            id
+        );
+        return this.getById(id);
+    }
+
+    updateStatus(id: string, status: RequirementStatus): void {
+        const now = new Date().toISOString();
+        this.db.prepare('UPDATE requirements SET status = ?, updated_at = ? WHERE id = ?')
+            .run(status, now, id);
+    }
+
+    markSourceClosed(id: string, closed: boolean = true): void {
+        const now = new Date().toISOString();
+        this.db.prepare('UPDATE requirements SET source_closed = ?, updated_at = ? WHERE id = ?')
+            .run(closed ? 1 : 0, now, id);
+    }
+
+    delete(id: string): boolean {
+        const result = this.db.prepare('DELETE FROM requirements WHERE id = ?').run(id);
+        return result.changes > 0;
+    }
+
+    /**
+     * 手动需求的项目内自增序列（spec §2.2：高位段/前缀避免与 issue 号撞车，如 M10001）。
+     * 返回完整的数字段（含前缀），调用方拼接为 req_key = `{project_name}#{数字段}`。
+     */
+    nextManualSequence(projectId: string): string {
+        const rows = this.db.prepare(
+            `SELECT source_key FROM requirements WHERE project_id = ? AND source = 'manual'`
+        ).all(projectId) as unknown as Array<{ source_key: string }>;
+
+        let maxSeq = MANUAL_SEQUENCE_START - 1;
+        for (const row of rows) {
+            const match = row.source_key.match(new RegExp(`^${MANUAL_REQ_KEY_PREFIX}(\\d+)$`));
+            if (match) {
+                const seq = parseInt(match[1], 10);
+                if (seq > maxSeq) maxSeq = seq;
+            }
+        }
+        return `${MANUAL_REQ_KEY_PREFIX}${maxSeq + 1}`;
+    }
+}
+
+export const requirementRepository = new RequirementRepository();

--- a/src/core/requirement-run-repository.ts
+++ b/src/core/requirement-run-repository.ts
@@ -1,0 +1,150 @@
+import { nanoid } from 'nanoid';
+import { db } from './database.js';
+
+export type RequirementRunStatus = 'running' | 'waiting_input' | 'succeeded' | 'failed' | 'cancelled';
+
+export interface RequirementRun {
+    id: string;
+    requirementId: string;
+    projectId: string;
+    engine: string;
+    worktreePath: string | null;
+    branch: string | null;
+    sessionId: string;
+    status: RequirementRunStatus;
+    retryNo: number;
+    prUrl: string | null;
+    errorMessage: string | null;
+    tokenCost: Record<string, unknown> | null;
+    startedAt: string;
+    finishedAt: string | null;
+}
+
+interface RequirementRunRow {
+    id: string;
+    requirement_id: string;
+    project_id: string;
+    engine: string;
+    worktree_path: string | null;
+    branch: string | null;
+    session_id: string;
+    status: string;
+    retry_no: number;
+    pr_url: string | null;
+    error_message: string | null;
+    token_cost: string | null;
+    started_at: string;
+    finished_at: string | null;
+}
+
+function rowToRun(row: RequirementRunRow): RequirementRun {
+    return {
+        id: row.id,
+        requirementId: row.requirement_id,
+        projectId: row.project_id,
+        engine: row.engine,
+        worktreePath: row.worktree_path,
+        branch: row.branch,
+        sessionId: row.session_id,
+        status: row.status as RequirementRunStatus,
+        retryNo: row.retry_no,
+        prUrl: row.pr_url,
+        errorMessage: row.error_message,
+        tokenCost: row.token_cost ? JSON.parse(row.token_cost) : null,
+        startedAt: row.started_at,
+        finishedAt: row.finished_at,
+    };
+}
+
+export interface CreateRequirementRunInput {
+    requirementId: string;
+    projectId: string;
+    engine: string;
+    sessionId: string;
+    worktreePath?: string;
+    branch?: string;
+    retryNo?: number;
+}
+
+export class RequirementRunRepository {
+    private db: typeof db;
+
+    constructor(database?: typeof db) {
+        this.db = database ?? db;
+    }
+
+    create(input: CreateRequirementRunInput): RequirementRun {
+        const id = nanoid();
+        const now = new Date().toISOString();
+        this.db.prepare(
+            `INSERT INTO requirement_runs (id, requirement_id, project_id, engine, worktree_path, branch, session_id, status, retry_no, started_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)`
+        ).run(
+            id,
+            input.requirementId,
+            input.projectId,
+            input.engine,
+            input.worktreePath ?? null,
+            input.branch ?? null,
+            input.sessionId,
+            input.retryNo ?? 0,
+            now
+        );
+        return this.getById(id)!;
+    }
+
+    getById(id: string): RequirementRun | null {
+        const row = this.db.prepare('SELECT * FROM requirement_runs WHERE id = ?').get(id) as RequirementRunRow | undefined;
+        return row ? rowToRun(row) : null;
+    }
+
+    getBySessionId(sessionId: string): RequirementRun | null {
+        const row = this.db.prepare('SELECT * FROM requirement_runs WHERE session_id = ?').get(sessionId) as RequirementRunRow | undefined;
+        return row ? rowToRun(row) : null;
+    }
+
+    listByRequirement(requirementId: string): RequirementRun[] {
+        const rows = this.db.prepare('SELECT * FROM requirement_runs WHERE requirement_id = ? ORDER BY started_at DESC')
+            .all(requirementId) as unknown as RequirementRunRow[];
+        return rows.map(rowToRun);
+    }
+
+    listByProject(projectId: string, limit = 50): RequirementRun[] {
+        const rows = this.db.prepare('SELECT * FROM requirement_runs WHERE project_id = ? ORDER BY started_at DESC LIMIT ?')
+            .all(projectId, limit) as unknown as RequirementRunRow[];
+        return rows.map(rowToRun);
+    }
+
+    updateStatus(id: string, status: RequirementRunStatus, opts?: { errorMessage?: string; finished?: boolean }): void {
+        const finishedAt = opts?.finished ? new Date().toISOString() : undefined;
+        if (finishedAt !== undefined) {
+            this.db.prepare('UPDATE requirement_runs SET status = ?, error_message = ?, finished_at = ? WHERE id = ?')
+                .run(status, opts?.errorMessage ?? null, finishedAt, id);
+        } else {
+            this.db.prepare('UPDATE requirement_runs SET status = ?, error_message = ? WHERE id = ?')
+                .run(status, opts?.errorMessage ?? null, id);
+        }
+    }
+
+    setPrUrl(id: string, prUrl: string): void {
+        this.db.prepare('UPDATE requirement_runs SET pr_url = ? WHERE id = ?').run(prUrl, id);
+    }
+
+    setTokenCost(id: string, tokenCost: Record<string, unknown>): void {
+        this.db.prepare('UPDATE requirement_runs SET token_cost = ? WHERE id = ?').run(JSON.stringify(tokenCost), id);
+    }
+
+    incrementRetryFrom(previousRun: RequirementRun, sessionId: string): RequirementRun {
+        return this.create({
+            requirementId: previousRun.requirementId,
+            projectId: previousRun.projectId,
+            engine: previousRun.engine,
+            sessionId,
+            worktreePath: previousRun.worktreePath ?? undefined,
+            branch: previousRun.branch ?? undefined,
+            retryNo: previousRun.retryNo + 1,
+        });
+    }
+}
+
+export const requirementRunRepository = new RequirementRunRepository();

--- a/src/gateway/routes/projects.ts
+++ b/src/gateway/routes/projects.ts
@@ -1,0 +1,76 @@
+import type { FastifyInstance } from 'fastify';
+import { projectRepository } from '../../core/project-repository.js';
+import type { GatewayDeps } from '../route-deps.js';
+
+/**
+ * 研发流程管理模块：项目（Project）CRUD 路由。
+ * 实施地图 #61 ticket #62（数据层）；需求同步/发起研发等路由在后续 ticket 中补充。
+ */
+export async function registerProjectRoutes(app: FastifyInstance, deps: GatewayDeps): Promise<void> {
+    app.get('/api/projects', async () => {
+        return projectRepository.list();
+    });
+
+    app.get<{ Params: { id: string } }>('/api/projects/:id', async (request, reply) => {
+        const project = projectRepository.getById(request.params.id);
+        if (!project) { reply.status(404); return { error: 'Project not found' }; }
+        return project;
+    });
+
+    app.post<{
+        Body: {
+            name: string;
+            dir: string;
+            description?: string;
+            syncSource?: string;
+            syncConfig?: Record<string, unknown>;
+            maxConcurrentRuns?: number;
+        };
+    }>('/api/projects', async (request, reply) => {
+        const { name, dir, description, syncSource, syncConfig, maxConcurrentRuns } = request.body ?? {};
+        if (!name || !dir) {
+            reply.status(400);
+            return { error: 'Missing required fields: name, dir' };
+        }
+        if (projectRepository.getByName(name)) {
+            reply.status(409);
+            return { error: `Project name "${name}" already exists` };
+        }
+        try {
+            const project = projectRepository.create({ name, dir, description, syncSource, syncConfig, maxConcurrentRuns });
+            reply.status(201);
+            return project;
+        } catch (error: any) {
+            deps.logger.error(`Create project error: ${error.message}`);
+            reply.status(500);
+            return { error: error.message };
+        }
+    });
+
+    app.patch<{
+        Params: { id: string };
+        Body: {
+            dir?: string;
+            description?: string;
+            syncSource?: string;
+            syncConfig?: Record<string, unknown>;
+            maxConcurrentRuns?: number;
+        };
+    }>('/api/projects/:id', async (request, reply) => {
+        try {
+            const project = projectRepository.update(request.params.id, request.body ?? {});
+            if (!project) { reply.status(404); return { error: 'Project not found' }; }
+            return project;
+        } catch (error: any) {
+            deps.logger.error(`Update project error: ${error.message}`);
+            reply.status(500);
+            return { error: error.message };
+        }
+    });
+
+    app.delete<{ Params: { id: string } }>('/api/projects/:id', async (request, reply) => {
+        const deleted = projectRepository.delete(request.params.id);
+        if (!deleted) { reply.status(404); return { error: 'Project not found' }; }
+        return { success: true };
+    });
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -22,6 +22,7 @@ import { registerWorkflowRoutes } from './routes/workflows.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerImRoutes } from './routes/im.js';
 import { registerAgentPoolRoutes } from './routes/agents.js';
+import { registerProjectRoutes } from './routes/projects.js';
 
 /**
  * Gateway 服务器
@@ -223,6 +224,7 @@ export class GatewayServer {
         registerAuditRoutes(this.app, deps);
         registerImRoutes(this.app, deps);
         registerAgentPoolRoutes(this.app, deps);
+        registerProjectRoutes(this.app, deps);
 
         // ===== AGENT GATEWAY =====
         this.agentGateway.registerRoutes(this.app);

--- a/tests/project-repository.test.ts
+++ b/tests/project-repository.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { ProjectRepository } from '../src/core/project-repository.js';
+
+function createTestDb(): DatabaseSync {
+    const db = new DatabaseSync(':memory:');
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS projects (
+            id                  TEXT PRIMARY KEY,
+            name                TEXT NOT NULL UNIQUE,
+            dir                 TEXT NOT NULL,
+            description         TEXT,
+            sync_source         TEXT NOT NULL DEFAULT 'github',
+            sync_config         TEXT,
+            last_synced_at      TEXT,
+            max_concurrent_runs INTEGER NOT NULL DEFAULT 2,
+            skills_installed_at TEXT,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL
+        );
+    `);
+    return db;
+}
+
+describe('ProjectRepository', () => {
+    let repo: ProjectRepository;
+
+    beforeEach(() => {
+        repo = new ProjectRepository(createTestDb() as any);
+    });
+
+    it('creates and retrieves a project with defaults', () => {
+        const project = repo.create({ name: 'cmasterBot', dir: '/repo/cmasterBot' });
+        expect(project.name).toBe('cmasterBot');
+        expect(project.syncSource).toBe('github');
+        expect(project.maxConcurrentRuns).toBe(2);
+        expect(project.lastSyncedAt).toBeNull();
+        expect(project.skillsInstalledAt).toBeNull();
+
+        const fetched = repo.getById(project.id);
+        expect(fetched).toEqual(project);
+    });
+
+    it('creates a project with custom syncConfig', () => {
+        const project = repo.create({
+            name: 'other-repo',
+            dir: '/repo/other',
+            syncConfig: { labelFilter: ['bug'] },
+            maxConcurrentRuns: 5,
+        });
+        expect(project.syncConfig).toEqual({ labelFilter: ['bug'] });
+        expect(project.maxConcurrentRuns).toBe(5);
+    });
+
+    it('looks up a project by name', () => {
+        repo.create({ name: 'cmasterBot', dir: '/repo/cmasterBot' });
+        expect(repo.getByName('cmasterBot')).not.toBeNull();
+        expect(repo.getByName('nonexistent')).toBeNull();
+    });
+
+    it('lists all projects newest first', () => {
+        const a = repo.create({ name: 'a', dir: '/a' });
+        const b = repo.create({ name: 'b', dir: '/b' });
+        const list = repo.list();
+        expect(list.map(p => p.id)).toEqual(expect.arrayContaining([a.id, b.id]));
+        expect(list).toHaveLength(2);
+    });
+
+    it('updates project fields', () => {
+        const project = repo.create({ name: 'cmasterBot', dir: '/old' });
+        const updated = repo.update(project.id, { dir: '/new', maxConcurrentRuns: 4 });
+        expect(updated!.dir).toBe('/new');
+        expect(updated!.maxConcurrentRuns).toBe(4);
+    });
+
+    it('update returns null for non-existent project', () => {
+        expect(repo.update('nonexistent', { dir: '/x' })).toBeNull();
+    });
+
+    it('touchSynced sets last_synced_at', () => {
+        const project = repo.create({ name: 'cmasterBot', dir: '/repo' });
+        repo.touchSynced(project.id, '2026-07-11T00:00:00.000Z');
+        expect(repo.getById(project.id)!.lastSyncedAt).toBe('2026-07-11T00:00:00.000Z');
+    });
+
+    it('markSkillsInstalled sets skills_installed_at', () => {
+        const project = repo.create({ name: 'cmasterBot', dir: '/repo' });
+        repo.markSkillsInstalled(project.id, '2026-07-11T00:00:00.000Z');
+        expect(repo.getById(project.id)!.skillsInstalledAt).toBe('2026-07-11T00:00:00.000Z');
+    });
+
+    it('deletes a project', () => {
+        const project = repo.create({ name: 'cmasterBot', dir: '/repo' });
+        expect(repo.delete(project.id)).toBe(true);
+        expect(repo.getById(project.id)).toBeNull();
+        expect(repo.delete(project.id)).toBe(false);
+    });
+});

--- a/tests/requirement-repository.test.ts
+++ b/tests/requirement-repository.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { RequirementRepository } from '../src/core/requirement-repository.js';
+
+function createTestDb(): DatabaseSync {
+    const db = new DatabaseSync(':memory:');
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS projects (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            dir TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS requirements (
+            id             TEXT PRIMARY KEY,
+            project_id     TEXT NOT NULL,
+            req_key        TEXT NOT NULL,
+            source         TEXT NOT NULL,
+            source_key     TEXT NOT NULL,
+            title          TEXT NOT NULL,
+            description    TEXT,
+            labels         TEXT,
+            status         TEXT NOT NULL DEFAULT 'synced',
+            source_url     TEXT,
+            source_closed  INTEGER NOT NULL DEFAULT 0,
+            created_at     TEXT NOT NULL,
+            updated_at     TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_req_key      ON requirements(req_key);
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_req_dedup    ON requirements(project_id, source, source_key);
+        CREATE INDEX IF NOT EXISTS idx_req_project_status ON requirements(project_id, status);
+    `);
+    db.exec(`INSERT INTO projects (id, name, dir, created_at, updated_at) VALUES ('p1', 'cmasterBot', '/repo', '2026-01-01', '2026-01-01')`);
+    return db;
+}
+
+describe('RequirementRepository', () => {
+    let repo: RequirementRepository;
+
+    beforeEach(() => {
+        repo = new RequirementRepository(createTestDb() as any);
+    });
+
+    it('creates a synced requirement with status defaulting to synced', () => {
+        const req = repo.create({
+            projectId: 'p1',
+            reqKey: 'cmasterBot#42',
+            source: 'github',
+            sourceKey: '42',
+            title: 'Add feature X',
+            labels: ['bug'],
+            sourceUrl: 'https://github.com/x/y/issues/42',
+        });
+        expect(req.status).toBe('synced');
+        expect(req.sourceClosed).toBe(false);
+        expect(req.labels).toEqual(['bug']);
+    });
+
+    it('looks up by req_key and by dedup key', () => {
+        const req = repo.create({
+            projectId: 'p1', reqKey: 'cmasterBot#42', source: 'github', sourceKey: '42', title: 'X',
+        });
+        expect(repo.getByReqKey('cmasterBot#42')!.id).toBe(req.id);
+        expect(repo.findByDedupKey('p1', 'github', '42')!.id).toBe(req.id);
+        expect(repo.findByDedupKey('p1', 'github', '999')).toBeNull();
+    });
+
+    it('rejects duplicate req_key via unique index', () => {
+        repo.create({ projectId: 'p1', reqKey: 'cmasterBot#42', source: 'github', sourceKey: '42', title: 'X' });
+        expect(() =>
+            repo.create({ projectId: 'p1', reqKey: 'cmasterBot#42', source: 'github', sourceKey: '999', title: 'Y' })
+        ).toThrow();
+    });
+
+    it('lists requirements by project, optionally filtered by status', () => {
+        const a = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        repo.create({ projectId: 'p1', reqKey: 'cmasterBot#2', source: 'github', sourceKey: '2', title: 'B' });
+        repo.updateStatus(a.id, 'queued');
+
+        expect(repo.listByProject('p1')).toHaveLength(2);
+        expect(repo.listByProject('p1', { status: 'queued' }).map(r => r.id)).toEqual([a.id]);
+        expect(repo.listByProject('p1', { status: 'merged' })).toHaveLength(0);
+    });
+
+    it('updateMetadata updates fields but never touches status (spec §2.2)', () => {
+        const req = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'Old title' });
+        repo.updateStatus(req.id, 'implemented');
+
+        const updated = repo.updateMetadata(req.id, { title: 'New title', labels: ['p0'] });
+        expect(updated!.title).toBe('New title');
+        expect(updated!.labels).toEqual(['p0']);
+        expect(updated!.status).toBe('implemented');
+    });
+
+    it('updateStatus transitions the state machine field', () => {
+        const req = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        repo.updateStatus(req.id, 'in_progress');
+        expect(repo.getById(req.id)!.status).toBe('in_progress');
+    });
+
+    it('markSourceClosed sets the flag without touching status', () => {
+        const req = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        repo.updateStatus(req.id, 'queued');
+        repo.markSourceClosed(req.id);
+        const fetched = repo.getById(req.id)!;
+        expect(fetched.sourceClosed).toBe(true);
+        expect(fetched.status).toBe('queued');
+    });
+
+    it('nextManualSequence starts at M10000 and increments per project', () => {
+        expect(repo.nextManualSequence('p1')).toBe('M10000');
+        repo.create({ projectId: 'p1', reqKey: 'cmasterBot#M10000', source: 'manual', sourceKey: 'M10000', title: 'Manual A' });
+        expect(repo.nextManualSequence('p1')).toBe('M10001');
+        repo.create({ projectId: 'p1', reqKey: 'cmasterBot#M10001', source: 'manual', sourceKey: 'M10001', title: 'Manual B' });
+        expect(repo.nextManualSequence('p1')).toBe('M10002');
+    });
+
+    it('nextManualSequence is scoped per project', () => {
+        repo.create({ projectId: 'p1', reqKey: 'cmasterBot#M10000', source: 'manual', sourceKey: 'M10000', title: 'Manual A' });
+        expect(repo.nextManualSequence('p2')).toBe('M10000');
+    });
+
+    it('deletes a requirement', () => {
+        const req = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        expect(repo.delete(req.id)).toBe(true);
+        expect(repo.getById(req.id)).toBeNull();
+    });
+});

--- a/tests/requirement-run-repository.test.ts
+++ b/tests/requirement-run-repository.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { RequirementRunRepository } from '../src/core/requirement-run-repository.js';
+
+function createTestDb(): DatabaseSync {
+    const db = new DatabaseSync(':memory:');
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS requirement_runs (
+            id              TEXT PRIMARY KEY,
+            requirement_id  TEXT NOT NULL,
+            project_id      TEXT NOT NULL,
+            engine          TEXT NOT NULL,
+            worktree_path   TEXT,
+            branch          TEXT,
+            session_id      TEXT NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'running',
+            retry_no        INTEGER NOT NULL DEFAULT 0,
+            pr_url          TEXT,
+            error_message   TEXT,
+            token_cost      TEXT,
+            started_at      TEXT NOT NULL,
+            finished_at     TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_req_runs_requirement ON requirement_runs(requirement_id, started_at);
+        CREATE INDEX IF NOT EXISTS idx_req_runs_project     ON requirement_runs(project_id, started_at);
+    `);
+    return db;
+}
+
+describe('RequirementRunRepository', () => {
+    let repo: RequirementRunRepository;
+
+    beforeEach(() => {
+        repo = new RequirementRunRepository(createTestDb() as any);
+    });
+
+    it('creates a run defaulting to running / retry_no 0', () => {
+        const run = repo.create({
+            requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1',
+            worktreePath: '/repo/.cmaster/worktrees/cmasterBot-42', branch: 'req/cmasterBot-42',
+        });
+        expect(run.status).toBe('running');
+        expect(run.retryNo).toBe(0);
+        expect(run.finishedAt).toBeNull();
+    });
+
+    it('looks up a run by session id', () => {
+        const run = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1' });
+        expect(repo.getBySessionId('s1')!.id).toBe(run.id);
+        expect(repo.getBySessionId('nonexistent')).toBeNull();
+    });
+
+    it('lists runs by requirement, most recent first', () => {
+        const a = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1' });
+        const b = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's2' });
+        const runs = repo.listByRequirement('r1');
+        expect(runs.map(r => r.id)).toEqual(expect.arrayContaining([a.id, b.id]));
+        expect(runs).toHaveLength(2);
+    });
+
+    it('lists runs by project respecting the limit', () => {
+        repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1' });
+        repo.create({ requirementId: 'r2', projectId: 'p1', engine: 'claude-code', sessionId: 's2' });
+        expect(repo.listByProject('p1', 1)).toHaveLength(1);
+        expect(repo.listByProject('p1')).toHaveLength(2);
+    });
+
+    it('updateStatus without finished leaves finished_at untouched', () => {
+        const run = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1' });
+        repo.updateStatus(run.id, 'waiting_input');
+        const fetched = repo.getById(run.id)!;
+        expect(fetched.status).toBe('waiting_input');
+        expect(fetched.finishedAt).toBeNull();
+    });
+
+    it('updateStatus with finished=true sets finished_at and error_message', () => {
+        const run = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1' });
+        repo.updateStatus(run.id, 'failed', { errorMessage: 'boom', finished: true });
+        const fetched = repo.getById(run.id)!;
+        expect(fetched.status).toBe('failed');
+        expect(fetched.errorMessage).toBe('boom');
+        expect(fetched.finishedAt).not.toBeNull();
+    });
+
+    it('setPrUrl and setTokenCost update the respective fields', () => {
+        const run = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1' });
+        repo.setPrUrl(run.id, 'https://github.com/x/y/pull/1');
+        repo.setTokenCost(run.id, { promptTokens: 100, completionTokens: 50 });
+        const fetched = repo.getById(run.id)!;
+        expect(fetched.prUrl).toBe('https://github.com/x/y/pull/1');
+        expect(fetched.tokenCost).toEqual({ promptTokens: 100, completionTokens: 50 });
+    });
+
+    it('incrementRetryFrom creates a new run carrying forward worktree/branch and bumped retry_no', () => {
+        const first = repo.create({
+            requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1',
+            worktreePath: '/wt', branch: 'req/x-1',
+        });
+        repo.updateStatus(first.id, 'failed', { finished: true });
+
+        const retry = repo.incrementRetryFrom(first, 's2');
+        expect(retry.retryNo).toBe(1);
+        expect(retry.worktreePath).toBe('/wt');
+        expect(retry.branch).toBe('req/x-1');
+        expect(retry.status).toBe('running');
+        expect(repo.listByRequirement('r1')).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
## Summary

实施地图 [研发流程管理模块 实施地图 #61](https://github.com/yiyisf/masterBot/issues/61) 的 ticket [数据层 #62](https://github.com/yiyisf/masterBot/issues/62)。

- 新增 `projects` / `requirements` / `requirement_runs` 三张表（schema 对齐 `docs/dev-workflow-management-spec.md` §2.3/§3/§6.1，仅用标准列型，遵循 §6.4 可移植性约束）
- 新增 `ProjectRepository` / `RequirementRepository` / `RequirementRunRepository` 三个 repository（`src/core/`），风格对齐既有 `task-repository.ts`
- 新增 `/api/projects` 项目 CRUD 路由（`src/gateway/routes/projects.ts`），已注册进 `server.ts`
- `RequirementRepository` 预留了 `findByDedupKey` / `updateMetadata`（只更元数据不回退状态）/ `nextManualSequence` 等接口，供后续同步层 ticket（[#63](https://github.com/yiyisf/masterBot/issues/63)）复用；本 PR 不含需求同步/手动创建的 HTTP 路由，按地图拆分留给 #63

## Test plan

- [x] `npx vitest run` 全绿（新增 27 个用例；既有 5 个失败套件为环境缺包问题 `gpt-tokenizer`/`exceljs`，master 上同样失败，与本次改动无关）
- [x] `npx tsc --noEmit` 无新增错误（唯一报错为 master 既有的 `gpt-tokenizer` 模块缺失，已核实与本次改动无关）
- [x] `npm run build` 结果一致

按 wayfinder 实施地图约定，本 ticket resolve = 本 PR 合并进 master；合并后我会在 ticket #62 上记录决议并关闭。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>