### PR TITLE
feat(dev-workflow): 同步层 — RequirementSyncSource + GitHub adapter + 手动建需求

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ CHROMA_URL=http://localhost:8000
 
 # Logging
 LOG_LEVEL=info
+
+# GitHub（研发流程管理模块：需求同步，可选，公开仓库可不设置）
+GITHUB_TOKEN=

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -17,6 +17,10 @@ export function initDatabase(): DatabaseSync {
     }
 
     const db = new DatabaseSync(DB_PATH);
+    // 多个进程/worker 并发首次 import 时都会执行本函数的建表/迁移语句，
+    // 若无 busy_timeout，node:sqlite 遇锁会立即抛 SQLITE_BUSY（"database is locked"）
+    // 而不是排队等待，在测试并行度较高时会必现（而非偶发）。
+    db.exec('PRAGMA busy_timeout = 5000');
     db.exec('PRAGMA journal_mode = WAL');
 
     // 创建表结构

--- a/src/core/requirement-sync-github.ts
+++ b/src/core/requirement-sync-github.ts
@@ -1,0 +1,144 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { Project } from './project-repository.js';
+import type { RequirementSyncSource, RemoteRequirement, SyncOptions } from './requirement-sync.js';
+
+const execFileAsync = promisify(execFile);
+
+const GITHUB_API_BASE = 'https://api.github.com';
+const PAGE_SIZE = 100;
+
+export interface RepoInfo {
+    owner: string;
+    repo: string;
+}
+
+interface GitHubIssue {
+    number: number;
+    title: string;
+    body: string | null;
+    labels: Array<{ name: string } | string>;
+    html_url: string;
+    state: 'open' | 'closed';
+    pull_request?: unknown;
+}
+
+/**
+ * 解析 GitHub remote URL，支持 https://github.com/owner/repo(.git) 与
+ * git@github.com:owner/repo(.git) 两种形式（纯函数，便于单测）。
+ */
+export function parseGitHubRemoteUrl(url: string): RepoInfo {
+    const match = url.trim().match(/github\.com[:/]+([^/]+)\/([^/.]+?)(\.git)?$/);
+    if (!match) {
+        throw new Error(`无法从 git remote origin 推断 GitHub owner/repo: ${url}`);
+    }
+    return { owner: match[1], repo: match[2] };
+}
+
+/** 从项目目录的 `git remote origin` 推断 owner/repo（spec §2.5）。 */
+export async function inferRepoInfoFromGitRemote(dir: string): Promise<RepoInfo> {
+    const { stdout } = await execFileAsync('git', ['-C', dir, 'remote', 'get-url', 'origin']);
+    return parseGitHubRemoteUrl(stdout);
+}
+
+export interface GitHubSyncSourceDeps {
+    /** 依赖注入，便于单测；默认使用全局 fetch */
+    fetchImpl?: typeof fetch;
+    /** 依赖注入，便于单测；默认读取 project.syncConfig.owner/repo 覆盖，否则从 git remote 推断 */
+    resolveRepoInfo?: (project: Project) => Promise<RepoInfo>;
+    /** 默认取 process.env.GITHUB_TOKEN；公开仓库可不设置 */
+    token?: string;
+}
+
+/**
+ * 默认 GitHub adapter（spec §2.5）：仅 open issue、排除 PR、可选 label 过滤、
+ * last_synced_at 增量水位线（首次全量拉 open，之后 since+state=all 捕获远程关闭）。
+ */
+export class GitHubSyncSource implements RequirementSyncSource {
+    readonly name = 'github';
+    private fetchImpl: typeof fetch;
+    private resolveRepoInfoImpl: (project: Project) => Promise<RepoInfo>;
+    private token?: string;
+
+    constructor(deps: GitHubSyncSourceDeps = {}) {
+        this.fetchImpl = deps.fetchImpl ?? fetch;
+        this.resolveRepoInfoImpl = deps.resolveRepoInfo ?? ((project) => this.defaultResolveRepoInfo(project));
+        this.token = deps.token ?? process.env.GITHUB_TOKEN;
+    }
+
+    private async defaultResolveRepoInfo(project: Project): Promise<RepoInfo> {
+        const config = project.syncConfig as { owner?: string; repo?: string } | null;
+        if (config?.owner && config?.repo) {
+            return { owner: config.owner, repo: config.repo };
+        }
+        return inferRepoInfoFromGitRemote(project.dir);
+    }
+
+    private buildHeaders(): Record<string, string> {
+        const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
+        if (this.token) headers.Authorization = `Bearer ${this.token}`;
+        return headers;
+    }
+
+    async fetchRequirements(project: Project, options: SyncOptions): Promise<RemoteRequirement[]> {
+        const { owner, repo } = await this.resolveRepoInfoImpl(project);
+        const baseParams = new URLSearchParams({ per_page: String(PAGE_SIZE) });
+        if (options.since) {
+            baseParams.set('state', 'all');
+            baseParams.set('since', options.since);
+        } else {
+            baseParams.set('state', 'open');
+        }
+
+        const headers = this.buildHeaders();
+        const issues = await this.fetchAllPages(owner, repo, baseParams, headers);
+        const labelFilter = (project.syncConfig as { labelFilter?: string[] } | null)?.labelFilter;
+
+        return issues
+            .filter(issue => !issue.pull_request)
+            .filter(issue => {
+                if (!labelFilter || labelFilter.length === 0) return true;
+                const issueLabels = issue.labels.map(l => (typeof l === 'string' ? l : l.name));
+                return issueLabels.some(name => labelFilter.includes(name));
+            })
+            .map(issue => ({
+                sourceKey: String(issue.number),
+                title: issue.title,
+                description: issue.body ?? undefined,
+                labels: issue.labels.map(l => (typeof l === 'string' ? l : l.name)),
+                sourceUrl: issue.html_url,
+                closed: issue.state === 'closed',
+            }));
+    }
+
+    async testConnection(project: Project): Promise<boolean> {
+        try {
+            const { owner, repo } = await this.resolveRepoInfoImpl(project);
+            const res = await this.fetchImpl(`${GITHUB_API_BASE}/repos/${owner}/${repo}`, { headers: this.buildHeaders() });
+            return res.ok;
+        } catch {
+            return false;
+        }
+    }
+
+    private async fetchAllPages(
+        owner: string,
+        repo: string,
+        baseParams: URLSearchParams,
+        headers: Record<string, string>
+    ): Promise<GitHubIssue[]> {
+        const results: GitHubIssue[] = [];
+        for (let page = 1; ; page++) {
+            const params = new URLSearchParams(baseParams);
+            params.set('page', String(page));
+            const res = await this.fetchImpl(`${GITHUB_API_BASE}/repos/${owner}/${repo}/issues?${params.toString()}`, { headers });
+            if (!res.ok) {
+                throw new Error(`GitHub API 请求失败: ${res.status} ${res.statusText}`);
+            }
+            const batch = await res.json() as GitHubIssue[];
+            results.push(...batch);
+            if (batch.length < PAGE_SIZE) break;
+        }
+        return results;
+    }
+}

--- a/src/core/requirement-sync-service.ts
+++ b/src/core/requirement-sync-service.ts
@@ -1,0 +1,111 @@
+import { projectRepository, type ProjectRepository } from './project-repository.js';
+import { requirementRepository, type RequirementRepository, type Requirement } from './requirement-repository.js';
+import { syncSourceRegistry, type SyncSourceRegistry } from './requirement-sync.js';
+
+export interface SyncProjectResult {
+    source: string;
+    created: number;
+    updated: number;
+    closed: number;
+    syncedAt: string;
+}
+
+export interface CreateManualRequirementInput {
+    title: string;
+    description?: string;
+    labels?: string[];
+}
+
+export interface RequirementSyncServiceDeps {
+    projects?: ProjectRepository;
+    requirements?: RequirementRepository;
+    registry?: SyncSourceRegistry;
+}
+
+/**
+ * 需求同步编排：驱动某个项目走一次同步（拉取 + 落库去重 upsert），
+ * 以及手动创建需求。落库规则见 spec §2.2：命中去重键只更元数据，绝不回退状态机。
+ */
+export class RequirementSyncService {
+    private projects: ProjectRepository;
+    private requirements: RequirementRepository;
+    private registry: SyncSourceRegistry;
+
+    constructor(deps: RequirementSyncServiceDeps = {}) {
+        this.projects = deps.projects ?? projectRepository;
+        this.requirements = deps.requirements ?? requirementRepository;
+        this.registry = deps.registry ?? syncSourceRegistry;
+    }
+
+    async syncProject(projectId: string): Promise<SyncProjectResult> {
+        const project = this.projects.getById(projectId);
+        if (!project) throw new Error(`Project not found: ${projectId}`);
+
+        const source = this.registry.get(project.syncSource);
+        if (!source) throw new Error(`Unknown sync source: ${project.syncSource}`);
+
+        const remoteItems = await source.fetchRequirements(project, { since: project.lastSyncedAt ?? undefined });
+
+        let created = 0;
+        let updated = 0;
+        let closed = 0;
+
+        for (const item of remoteItems) {
+            const existing = this.requirements.findByDedupKey(project.id, source.name, item.sourceKey);
+
+            if (!existing) {
+                const requirement = this.requirements.create({
+                    projectId: project.id,
+                    reqKey: `${project.name}#${item.sourceKey}`,
+                    source: source.name,
+                    sourceKey: item.sourceKey,
+                    title: item.title,
+                    description: item.description,
+                    labels: item.labels,
+                    sourceUrl: item.sourceUrl,
+                });
+                created++;
+                if (item.closed) {
+                    this.requirements.markSourceClosed(requirement.id);
+                    closed++;
+                }
+                continue;
+            }
+
+            this.requirements.updateMetadata(existing.id, {
+                title: item.title,
+                description: item.description,
+                labels: item.labels,
+                sourceUrl: item.sourceUrl,
+            });
+            updated++;
+            if (item.closed && !existing.sourceClosed) {
+                this.requirements.markSourceClosed(existing.id);
+                closed++;
+            }
+        }
+
+        const syncedAt = new Date().toISOString();
+        this.projects.touchSynced(project.id, syncedAt);
+
+        return { source: source.name, created, updated, closed, syncedAt };
+    }
+
+    createManualRequirement(projectId: string, input: CreateManualRequirementInput): Requirement {
+        const project = this.projects.getById(projectId);
+        if (!project) throw new Error(`Project not found: ${projectId}`);
+
+        const seq = this.requirements.nextManualSequence(project.id);
+        return this.requirements.create({
+            projectId: project.id,
+            reqKey: `${project.name}#${seq}`,
+            source: 'manual',
+            sourceKey: seq,
+            title: input.title,
+            description: input.description,
+            labels: input.labels,
+        });
+    }
+}
+
+export const requirementSyncService = new RequirementSyncService();

--- a/src/core/requirement-sync.ts
+++ b/src/core/requirement-sync.ts
@@ -1,0 +1,57 @@
+import type { Project } from './project-repository.js';
+
+/**
+ * 从外部渠道拉取到的一条原始需求，字段已归一化为渠道无关的形状；
+ * 落库前由同步编排层（requirement-sync-service.ts）转换为 requirements 表行。
+ */
+export interface RemoteRequirement {
+    /** 渠道内原始标识（如 GitHub issue number 的字符串形式），对应 requirements.source_key */
+    sourceKey: string;
+    title: string;
+    description?: string;
+    labels: string[];
+    sourceUrl?: string;
+    /** 远程条目是否已关闭（用于打 source_closed 标记，不驱动状态机，spec §2.2） */
+    closed: boolean;
+}
+
+export interface SyncOptions {
+    /** 增量水位线（对应 projects.last_synced_at）；不传表示首次全量同步 */
+    since?: string;
+}
+
+/**
+ * 需求同步适配器接口。仿 SkillSource/SkillRegistry 的多源模式（src/skills/registry.ts），
+ * 走代码接口注册而非 YAML 声明式——同步逻辑本质是代码（spec §2.4）。
+ */
+export interface RequirementSyncSource {
+    readonly name: string;
+    fetchRequirements(project: Project, options: SyncOptions): Promise<RemoteRequirement[]>;
+    testConnection?(project: Project): Promise<boolean>;
+}
+
+/**
+ * 同步源注册中心。结构参照 src/core/knowledge-sync.ts 的 KnowledgeSyncService，
+ * 但这里只负责持有/查找 source，实际的落库编排在 requirement-sync-service.ts。
+ */
+export class SyncSourceRegistry {
+    private sources: Map<string, RequirementSyncSource> = new Map();
+
+    register(source: RequirementSyncSource): void {
+        this.sources.set(source.name, source);
+    }
+
+    unregister(name: string): void {
+        this.sources.delete(name);
+    }
+
+    get(name: string): RequirementSyncSource | undefined {
+        return this.sources.get(name);
+    }
+
+    list(): string[] {
+        return Array.from(this.sources.keys());
+    }
+}
+
+export const syncSourceRegistry = new SyncSourceRegistry();

--- a/src/gateway/routes/requirements.ts
+++ b/src/gateway/routes/requirements.ts
@@ -1,0 +1,66 @@
+import type { FastifyInstance } from 'fastify';
+import { requirementRepository, type RequirementStatus } from '../../core/requirement-repository.js';
+import { requirementSyncService } from '../../core/requirement-sync-service.js';
+import type { GatewayDeps } from '../route-deps.js';
+
+/**
+ * 研发流程管理模块：需求同步 / 手动创建 / 列表路由。
+ * 实施地图 #61 ticket #63（同步层）；发起研发/重试/取消/回答中断/核验合并等路由留给执行层 ticket。
+ */
+export async function registerRequirementRoutes(app: FastifyInstance, deps: GatewayDeps): Promise<void> {
+    // 手动触发同步（spec §2.5：仅手动触发，不做定时任务）
+    app.post<{ Params: { id: string } }>('/api/projects/:id/sync', async (request, reply) => {
+        try {
+            const result = await requirementSyncService.syncProject(request.params.id);
+            return result;
+        } catch (error: any) {
+            deps.logger.error(`Sync project error: ${error.message}`);
+            if (error.message?.startsWith('Project not found')) {
+                reply.status(404);
+                return { error: error.message };
+            }
+            reply.status(500);
+            return { error: error.message };
+        }
+    });
+
+    // 手动创建需求
+    app.post<{ Params: { id: string }; Body: { title: string; description?: string; labels?: string[] } }>(
+        '/api/projects/:id/requirements',
+        async (request, reply) => {
+            const { title, description, labels } = request.body ?? {};
+            if (!title) {
+                reply.status(400);
+                return { error: 'Missing required field: title' };
+            }
+            try {
+                const requirement = requirementSyncService.createManualRequirement(request.params.id, { title, description, labels });
+                reply.status(201);
+                return requirement;
+            } catch (error: any) {
+                deps.logger.error(`Create manual requirement error: ${error.message}`);
+                if (error.message?.startsWith('Project not found')) {
+                    reply.status(404);
+                    return { error: error.message };
+                }
+                reply.status(500);
+                return { error: error.message };
+            }
+        }
+    );
+
+    // 列出项目下的需求（可选按状态过滤，对应状态看板列）
+    app.get<{ Params: { id: string }; Querystring: { status?: string } }>(
+        '/api/projects/:id/requirements',
+        async (request) => {
+            const status = request.query.status as RequirementStatus | undefined;
+            return requirementRepository.listByProject(request.params.id, status ? { status } : undefined);
+        }
+    );
+
+    app.get<{ Params: { id: string } }>('/api/requirements/:id', async (request, reply) => {
+        const requirement = requirementRepository.getById(request.params.id);
+        if (!requirement) { reply.status(404); return { error: 'Requirement not found' }; }
+        return requirement;
+    });
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -23,6 +23,7 @@ import { registerAuditRoutes } from './routes/audit.js';
 import { registerImRoutes } from './routes/im.js';
 import { registerAgentPoolRoutes } from './routes/agents.js';
 import { registerProjectRoutes } from './routes/projects.js';
+import { registerRequirementRoutes } from './routes/requirements.js';
 
 /**
  * Gateway 服务器
@@ -225,6 +226,7 @@ export class GatewayServer {
         registerImRoutes(this.app, deps);
         registerAgentPoolRoutes(this.app, deps);
         registerProjectRoutes(this.app, deps);
+        registerRequirementRoutes(this.app, deps);
 
         // ===== AGENT GATEWAY =====
         this.agentGateway.registerRoutes(this.app);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ import { initMemoryRouter } from './memory/memory-router.js';
 import { SoulLoader } from './core/soul-loader.js';
 import { AgentPool, SessionEventStore, CredentialVault } from './core/harness/agent-pool.js';
 import { CheckpointManager } from './core/checkpoint-manager.js';
+import { syncSourceRegistry } from './core/requirement-sync.js';
+import { GitHubSyncSource } from './core/requirement-sync-github.js';
 
 async function main() {
     // U4: 在所有其他初始化之前启动 OTel（仅当 OTEL_EXPORTER_OTLP_ENDPOINT 配置时生效）
@@ -85,6 +87,10 @@ async function main() {
         await skillRegistry.registerSource(source);
         logger.info(`Connector "${source.name}" loaded`);
     }
+
+    // 研发流程管理模块：默认 GitHub 需求同步适配器注册（spec §2.5）
+    syncSourceRegistry.register(new GitHubSyncSource());
+    logger.info('Requirement sync source "github" registered');
 
     const getLlm = () => {
         const provider = config.models.default;

--- a/tests/requirement-sync-github.test.ts
+++ b/tests/requirement-sync-github.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GitHubSyncSource, parseGitHubRemoteUrl } from '../src/core/requirement-sync-github.js';
+import type { Project } from '../src/core/project-repository.js';
+
+function fakeProject(overrides: Partial<Project> = {}): Project {
+    return {
+        id: 'p1',
+        name: 'cmasterBot',
+        dir: '/repo/cmasterBot',
+        description: null,
+        syncSource: 'github',
+        syncConfig: null,
+        lastSyncedAt: null,
+        maxConcurrentRuns: 2,
+        skillsInstalledAt: null,
+        createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
+        ...overrides,
+    };
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+    return { ok, status, statusText: ok ? 'OK' : 'Error', json: async () => body } as Response;
+}
+
+describe('parseGitHubRemoteUrl', () => {
+    it('parses https remote urls', () => {
+        expect(parseGitHubRemoteUrl('https://github.com/yiyisf/masterBot.git')).toEqual({ owner: 'yiyisf', repo: 'masterBot' });
+        expect(parseGitHubRemoteUrl('https://github.com/yiyisf/masterBot')).toEqual({ owner: 'yiyisf', repo: 'masterBot' });
+    });
+
+    it('parses ssh remote urls', () => {
+        expect(parseGitHubRemoteUrl('git@github.com:yiyisf/masterBot.git')).toEqual({ owner: 'yiyisf', repo: 'masterBot' });
+    });
+
+    it('throws for a non-GitHub url', () => {
+        expect(() => parseGitHubRemoteUrl('https://gitlab.com/x/y.git')).toThrow();
+    });
+});
+
+describe('GitHubSyncSource', () => {
+    const resolveRepoInfo = async () => ({ owner: 'yiyisf', repo: 'masterBot' });
+
+    it('excludes pull requests and maps fields', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([
+            { number: 1, title: 'Bug A', body: 'desc', labels: [{ name: 'bug' }], html_url: 'https://x/1', state: 'open' },
+            { number: 2, title: 'A PR', body: null, labels: [], html_url: 'https://x/2', state: 'open', pull_request: {} },
+        ]));
+        const source = new GitHubSyncSource({ fetchImpl: fetchImpl as any, resolveRepoInfo });
+
+        const items = await source.fetchRequirements(fakeProject(), {});
+        expect(items).toHaveLength(1);
+        expect(items[0]).toEqual({
+            sourceKey: '1',
+            title: 'Bug A',
+            description: 'desc',
+            labels: ['bug'],
+            sourceUrl: 'https://x/1',
+            closed: false,
+        });
+    });
+
+    it('uses state=open on first sync (no since) and state=all+since on incremental sync', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([]));
+        const source = new GitHubSyncSource({ fetchImpl: fetchImpl as any, resolveRepoInfo });
+
+        await source.fetchRequirements(fakeProject(), {});
+        let url = new URL(fetchImpl.mock.calls[0][0]);
+        expect(url.searchParams.get('state')).toBe('open');
+        expect(url.searchParams.has('since')).toBe(false);
+
+        fetchImpl.mockClear();
+        await source.fetchRequirements(fakeProject(), { since: '2026-07-01T00:00:00Z' });
+        url = new URL(fetchImpl.mock.calls[0][0]);
+        expect(url.searchParams.get('state')).toBe('all');
+        expect(url.searchParams.get('since')).toBe('2026-07-01T00:00:00Z');
+    });
+
+    it('filters by project-level label filter when configured', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([
+            { number: 1, title: 'A', body: null, labels: [{ name: 'bug' }], html_url: 'https://x/1', state: 'open' },
+            { number: 2, title: 'B', body: null, labels: [{ name: 'chore' }], html_url: 'https://x/2', state: 'open' },
+        ]));
+        const source = new GitHubSyncSource({ fetchImpl: fetchImpl as any, resolveRepoInfo });
+
+        const items = await source.fetchRequirements(fakeProject({ syncConfig: { labelFilter: ['bug'] } }), {});
+        expect(items.map(i => i.sourceKey)).toEqual(['1']);
+    });
+
+    it('marks closed remote items', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([
+            { number: 1, title: 'A', body: null, labels: [], html_url: 'https://x/1', state: 'closed' },
+        ]));
+        const source = new GitHubSyncSource({ fetchImpl: fetchImpl as any, resolveRepoInfo });
+
+        const items = await source.fetchRequirements(fakeProject(), { since: '2026-01-01' });
+        expect(items[0].closed).toBe(true);
+    });
+
+    it('paginates when a full page is returned', async () => {
+        const fullPage = Array.from({ length: 100 }, (_, i) => ({
+            number: i + 1, title: `T${i}`, body: null, labels: [], html_url: 'https://x', state: 'open',
+        }));
+        const secondPage = [{ number: 101, title: 'Last', body: null, labels: [], html_url: 'https://x/101', state: 'open' }];
+        const fetchImpl = vi.fn()
+            .mockResolvedValueOnce(jsonResponse(fullPage))
+            .mockResolvedValueOnce(jsonResponse(secondPage));
+        const source = new GitHubSyncSource({ fetchImpl: fetchImpl as any, resolveRepoInfo });
+
+        const items = await source.fetchRequirements(fakeProject(), {});
+        expect(items).toHaveLength(101);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws when the GitHub API responds with an error status', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({}, false, 403));
+        const source = new GitHubSyncSource({ fetchImpl: fetchImpl as any, resolveRepoInfo });
+        await expect(source.fetchRequirements(fakeProject(), {})).rejects.toThrow(/403/);
+    });
+
+    it('testConnection reflects the response ok status', async () => {
+        const okFetch = vi.fn().mockResolvedValue(jsonResponse({}, true));
+        const okSource = new GitHubSyncSource({ fetchImpl: okFetch as any, resolveRepoInfo });
+        expect(await okSource.testConnection(fakeProject())).toBe(true);
+
+        const failFetch = vi.fn().mockRejectedValue(new Error('network error'));
+        const failSource = new GitHubSyncSource({ fetchImpl: failFetch as any, resolveRepoInfo });
+        expect(await failSource.testConnection(fakeProject())).toBe(false);
+    });
+});

--- a/tests/requirement-sync-service.test.ts
+++ b/tests/requirement-sync-service.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { ProjectRepository } from '../src/core/project-repository.js';
+import { RequirementRepository } from '../src/core/requirement-repository.js';
+import { SyncSourceRegistry, type RequirementSyncSource, type RemoteRequirement } from '../src/core/requirement-sync.js';
+import { RequirementSyncService } from '../src/core/requirement-sync-service.js';
+
+function createTestDb(): DatabaseSync {
+    const db = new DatabaseSync(':memory:');
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS projects (
+            id                  TEXT PRIMARY KEY,
+            name                TEXT NOT NULL UNIQUE,
+            dir                 TEXT NOT NULL,
+            description         TEXT,
+            sync_source         TEXT NOT NULL DEFAULT 'github',
+            sync_config         TEXT,
+            last_synced_at      TEXT,
+            max_concurrent_runs INTEGER NOT NULL DEFAULT 2,
+            skills_installed_at TEXT,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS requirements (
+            id             TEXT PRIMARY KEY,
+            project_id     TEXT NOT NULL,
+            req_key        TEXT NOT NULL,
+            source         TEXT NOT NULL,
+            source_key     TEXT NOT NULL,
+            title          TEXT NOT NULL,
+            description    TEXT,
+            labels         TEXT,
+            status         TEXT NOT NULL DEFAULT 'synced',
+            source_url     TEXT,
+            source_closed  INTEGER NOT NULL DEFAULT 0,
+            created_at     TEXT NOT NULL,
+            updated_at     TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_req_key      ON requirements(req_key);
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_req_dedup    ON requirements(project_id, source, source_key);
+        CREATE INDEX IF NOT EXISTS idx_req_project_status ON requirements(project_id, status);
+    `);
+    return db;
+}
+
+function fakeSource(items: RemoteRequirement[]): RequirementSyncSource {
+    return {
+        name: 'github',
+        async fetchRequirements() { return items; },
+    };
+}
+
+describe('RequirementSyncService', () => {
+    let db: DatabaseSync;
+    let projects: ProjectRepository;
+    let requirements: RequirementRepository;
+    let registry: SyncSourceRegistry;
+    let service: RequirementSyncService;
+    let projectId: string;
+
+    beforeEach(() => {
+        db = createTestDb();
+        projects = new ProjectRepository(db as any);
+        requirements = new RequirementRepository(db as any);
+        registry = new SyncSourceRegistry();
+        service = new RequirementSyncService({ projects, requirements, registry });
+        projectId = projects.create({ name: 'cmasterBot', dir: '/repo/cmasterBot' }).id;
+    });
+
+    it('creates new requirements from remote items on first sync', async () => {
+        registry.register(fakeSource([
+            { sourceKey: '1', title: 'Bug A', labels: ['bug'], closed: false },
+            { sourceKey: '2', title: 'Feature B', labels: [], closed: false },
+        ]));
+
+        const result = await service.syncProject(projectId);
+        expect(result).toMatchObject({ source: 'github', created: 2, updated: 0, closed: 0 });
+
+        const list = requirements.listByProject(projectId);
+        expect(list).toHaveLength(2);
+        expect(list.find(r => r.sourceKey === '1')!.reqKey).toBe('cmasterBot#1');
+        expect(list.find(r => r.sourceKey === '1')!.status).toBe('synced');
+    });
+
+    it('touches project.lastSyncedAt after a sync', async () => {
+        registry.register(fakeSource([]));
+        expect(projects.getById(projectId)!.lastSyncedAt).toBeNull();
+        await service.syncProject(projectId);
+        expect(projects.getById(projectId)!.lastSyncedAt).not.toBeNull();
+    });
+
+    it('re-sync hitting the dedup key only updates metadata, never rolls back status (spec §2.2)', async () => {
+        registry.register(fakeSource([{ sourceKey: '1', title: 'Old title', labels: [], closed: false }]));
+        await service.syncProject(projectId);
+
+        const created = requirements.findByDedupKey(projectId, 'github', '1')!;
+        requirements.updateStatus(created.id, 'implemented');
+
+        registry.register(fakeSource([{ sourceKey: '1', title: 'New title', labels: ['p0'], closed: false }]));
+        const result = await service.syncProject(projectId);
+
+        expect(result).toMatchObject({ created: 0, updated: 1 });
+        const updated = requirements.getById(created.id)!;
+        expect(updated.title).toBe('New title');
+        expect(updated.labels).toEqual(['p0']);
+        expect(updated.status).toBe('implemented');
+    });
+
+    it('marks source_closed when a remote item is closed, without double counting on repeat syncs', async () => {
+        registry.register(fakeSource([{ sourceKey: '1', title: 'A', labels: [], closed: true }]));
+        const first = await service.syncProject(projectId);
+        expect(first).toMatchObject({ created: 1, closed: 1 });
+
+        const req = requirements.findByDedupKey(projectId, 'github', '1')!;
+        expect(req.sourceClosed).toBe(true);
+
+        const second = await service.syncProject(projectId);
+        expect(second).toMatchObject({ updated: 1, closed: 0 });
+    });
+
+    it('throws for an unknown project', async () => {
+        registry.register(fakeSource([]));
+        await expect(service.syncProject('nonexistent')).rejects.toThrow(/Project not found/);
+    });
+
+    it('throws for an unregistered sync source', async () => {
+        await expect(service.syncProject(projectId)).rejects.toThrow(/Unknown sync source/);
+    });
+
+    it('createManualRequirement generates an M-prefixed req_key and source=manual', () => {
+        const req = service.createManualRequirement(projectId, { title: 'Manual work' });
+        expect(req.reqKey).toBe('cmasterBot#M10000');
+        expect(req.source).toBe('manual');
+        expect(req.sourceKey).toBe('M10000');
+        expect(req.status).toBe('synced');
+
+        const second = service.createManualRequirement(projectId, { title: 'More manual work' });
+        expect(second.reqKey).toBe('cmasterBot#M10001');
+    });
+
+    it('createManualRequirement throws for an unknown project', () => {
+        expect(() => service.createManualRequirement('nonexistent', { title: 'X' })).toThrow(/Project not found/);
+    });
+});

--- a/tests/requirement-sync.test.ts
+++ b/tests/requirement-sync.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SyncSourceRegistry, type RequirementSyncSource } from '../src/core/requirement-sync.js';
+
+function fakeSource(name: string): RequirementSyncSource {
+    return {
+        name,
+        async fetchRequirements() { return []; },
+    };
+}
+
+describe('SyncSourceRegistry', () => {
+    let registry: SyncSourceRegistry;
+
+    beforeEach(() => {
+        registry = new SyncSourceRegistry();
+    });
+
+    it('registers and looks up a source by name', () => {
+        const source = fakeSource('github');
+        registry.register(source);
+        expect(registry.get('github')).toBe(source);
+    });
+
+    it('returns undefined for an unregistered source', () => {
+        expect(registry.get('nonexistent')).toBeUndefined();
+    });
+
+    it('lists registered source names', () => {
+        registry.register(fakeSource('github'));
+        registry.register(fakeSource('gitlab'));
+        expect(registry.list().sort()).toEqual(['github', 'gitlab']);
+    });
+
+    it('unregisters a source', () => {
+        registry.register(fakeSource('github'));
+        registry.unregister('github');
+        expect(registry.get('github')).toBeUndefined();
+    });
+
+    it('overwrites a source registered under the same name', () => {
+        const first = fakeSource('github');
+        const second = fakeSource('github');
+        registry.register(first);
+        registry.register(second);
+        expect(registry.get('github')).toBe(second);
+    });
+});


### PR DESCRIPTION
## Summary

实施地图 [研发流程管理模块 实施地图 #61](https://github.com/yiyisf/masterBot/issues/61) 的 ticket [同步层 #63](https://github.com/yiyisf/masterBot/issues/63)。

- 新增 `RequirementSyncSource` 接口 + `SyncSourceRegistry`（`src/core/requirement-sync.ts`），仿 `SkillSource`/`SkillRegistry` 多源模式，代码接口注册（不走 YAML）
- 新增默认 GitHub adapter（`src/core/requirement-sync-github.ts`）：仅 open issue、按 `pull_request` 字段排除 PR、项目级可选 label 过滤、`last_synced_at` 增量水位线（首次全量拉 open，之后 `since`+`state=all` 捕获远程关闭）、从项目目录 `git remote origin` 推断 owner/repo（`syncConfig.owner/repo` 可覆盖）；`fetchImpl`/`resolveRepoInfo` 均可注入，便于测试
- 新增同步编排服务（`src/core/requirement-sync-service.ts`）：命中去重键（`project_id, source, source_key`）只更新元数据，**绝不回退状态机**（spec §2.2）；远程关闭时打 `source_closed` 标记且不重复计数；手动创建需求走 `M` 前缀自增序列
- 新增路由（`src/gateway/routes/requirements.ts`）：`POST /api/projects/:id/sync`、`POST /api/projects/:id/requirements`（手动建）、`GET /api/projects/:id/requirements`、`GET /api/requirements/:id`
- `src/index.ts` 组合根注册默认 GitHub 同步源；`.env.example` 补充可选的 `GITHUB_TOKEN`

发起研发/重试/取消/回答中断/核验合并等路由留给执行层 ticket（[#64](https://github.com/yiyisf/masterBot/issues/64)）。

## Test plan

- [x] `npx vitest run` 全绿（新增 23 个用例；既有 5 个失败套件为环境缺包问题 `gpt-tokenizer`/`exceljs`，与本次改动无关，master 上同样失败）
- [x] `npx tsc --noEmit` / `npm run build` 无新增错误（唯一报错是既有的 `gpt-tokenizer` 缺失，已核实与本次改动无关）
- [x] GitHub adapter 的字段映射/PR 过滤/label 过滤/分页/增量水位线/仓库推断均有单测覆盖（依赖注入 fake fetch，未打真实 API）

按 wayfinder 实施地图约定，本 ticket resolve = 本 PR 合并进 master；合并后我会在 ticket #63 上记录决议并关闭。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>