### PR TITLE
feat(dev-workflow): 执行层基座 — WorktreeManager + IAgentEngine 扩展 + ask_user/审批中断 + 启动扫描

### DIFF
--- a/src/core/harness/agent-engine.ts
+++ b/src/core/harness/agent-engine.ts
@@ -18,7 +18,17 @@ import type {
 } from '../../types.js';
 
 /** 引擎种类（AgentSpec.engine 字段取值）*/
-export type AgentEngineKind = 'native' | 'claude-agent-sdk';
+export type AgentEngineKind = 'native' | 'claude-agent-sdk' | 'codex' | 'opencode' | 'pi';
+
+/**
+ * 引擎能力声明（研发流程管理模块，spec §5.2）。
+ * interactiveApproval：执行中能否编程式向人提问/请求审批（codex exec = false）。
+ * resume：能否跨进程恢复会话（v1 全部 false；未来 Claude `--resume` 等）。
+ */
+export interface EngineCapabilities {
+    interactiveApproval: boolean;
+    resume: boolean;
+}
 
 export interface EngineRunContext {
     sessionId: string;
@@ -27,10 +37,15 @@ export interface EngineRunContext {
     history?: Message[];
     abortSignal?: AbortSignal;
     traceId?: string;
+    /** 运行时工作目录（如需求的 worktree 路径），优先于 spec.engineOptions.cwd（spec §5.2）*/
+    cwd?: string;
+    /** 审批模式：'auto' 沙箱自动判定（默认）；'ask-on-risky' 危险操作转人工审批（spec §5.4）*/
+    approvalMode?: 'auto' | 'ask-on-risky';
 }
 
 export interface IAgentEngine {
     readonly kind: AgentEngineKind;
+    readonly capabilities: EngineCapabilities;
     run(input: string, context: EngineRunContext): AsyncGenerator<ExecutionStep>;
 }
 
@@ -39,6 +54,8 @@ export interface IAgentEngine {
  */
 export class NativeAgentEngine implements IAgentEngine {
     readonly kind = 'native' as const;
+    // 自研 ReAct 循环已支持 ask_user / danger-approval 中断（agent-run-helpers.ts），无 resume 能力
+    readonly capabilities: EngineCapabilities = { interactiveApproval: true, resume: false };
 
     constructor(private agent: Agent) {}
 

--- a/src/core/harness/agent-harness.ts
+++ b/src/core/harness/agent-harness.ts
@@ -229,6 +229,16 @@ export class AgentHarness {
                         await new Promise(r => setTimeout(r, 200));
                     }
 
+                    // 研发流程管理：interrupt 双写 session_events 的"raised"一半
+                    // （"resolved"一半由 interrupt-coordinator.ts 的 resolveInterrupt/cancelInterrupt 写）
+                    if (step.type === 'interrupt') {
+                        this.emit('interrupt_raised', {
+                            interruptId: step.interruptId,
+                            interruptKind: step.interruptKind,
+                            reason: step.interruptReason,
+                        });
+                    }
+
                     // onToolCall hooks
                     if (step.type === 'action') {
                         this.emit('tool_call', {

--- a/src/core/harness/claude-sdk-engine.ts
+++ b/src/core/harness/claude-sdk-engine.ts
@@ -13,17 +13,26 @@
  * 纯内网/内部模型部署不受影响。
  */
 
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
 import type { Logger } from '../../types.js';
 import type { ExecutionStep } from '../../types.js';
 import type { AgentSpec } from './agent-spec.js';
-import type { IAgentEngine, EngineRunContext } from './agent-engine.js';
+import type { IAgentEngine, EngineRunContext, EngineCapabilities } from './agent-engine.js';
 import { CommandSandbox } from '../../skills/sandbox.js';
+import { InterruptRelay } from './interrupt-relay.js';
+import { waitForUserDecision, waitForApproval } from '../interrupt-coordinator.js';
 // P2-6: type-only 导入不产生运行时依赖（SDK 本身仍是动态 import，未安装时保留降级路径），
 // 用于替换 `sdk: any` / `_translateMessage(message: any)`，消除类型逃逸。
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
 /** coder 场景默认放行的 SDK 内建工具 */
 const DEFAULT_ALLOWED_TOOLS = ['Read', 'Write', 'Edit', 'Glob', 'Grep', 'Bash', 'TodoWrite'];
+
+/** ask_user 工具挂载的 SDK MCP server 名 + 工具名（fully-qualified: mcp__<server>__<tool>）*/
+const ASK_USER_SERVER_NAME = 'ask_user_server';
+const ASK_USER_TOOL_NAME = 'ask_user';
+const ASK_USER_QUALIFIED_NAME = `mcp__${ASK_USER_SERVER_NAME}__${ASK_USER_TOOL_NAME}`;
 
 /** 与 FilteredSkillRegistry 保持一致的 glob 匹配器（* 通配所有字符）*/
 function matchGlob(name: string, pattern: string): boolean {
@@ -49,6 +58,8 @@ export interface ClaudeSdkEngineOptions {
 
 export class ClaudeAgentSdkEngine implements IAgentEngine {
     readonly kind = 'claude-agent-sdk' as const;
+    // canUseTool 支持 ask-on-risky 转人工审批；ask_user MCP 工具支持编程式提问；v1 无 resume
+    readonly capabilities: EngineCapabilities = { interactiveApproval: true, resume: false };
     private sandbox: CommandSandbox;
     private allowedTools: string[];
 
@@ -97,17 +108,55 @@ export class ClaudeAgentSdkEngine implements IAgentEngine {
         };
         if (this.options.baseUrl) env.ANTHROPIC_BASE_URL = this.options.baseUrl;
 
-        const allowedSet = new Set(this.allowedTools);
+        // question 通道（常开，spec §5.4）：ask_user 工具通过 canUseTool 之外的 MCP handler
+        // 回调触发；handler 与 canUseTool 都在 run() 的 async generator 之外被 SDK 内部调用，
+        // 无法直接 yield —— 用 InterruptRelay 桥接回主循环。
+        const relay = new InterruptRelay();
+        const allowedToolsForRun = [...this.allowedTools, ASK_USER_QUALIFIED_NAME];
+        const allowedSet = new Set(allowedToolsForRun);
+
+        const askUserServer = sdk.createSdkMcpServer({
+            name: ASK_USER_SERVER_NAME,
+            version: '1.0.0',
+            tools: [
+                sdk.tool(
+                    ASK_USER_TOOL_NAME,
+                    '向人类提问以澄清需求或获取决策；调用后会阻塞直到人类回答',
+                    { question: z.string().describe('要问用户的问题，应具体、可回答') },
+                    async (args: { question: string }) => {
+                        const interruptId = nanoid();
+                        relay.push({
+                            type: 'interrupt',
+                            interruptKind: 'question',
+                            interruptId,
+                            interruptReason: args.question,
+                            content: args.question,
+                            sessionId: context.sessionId,
+                            timestamp: new Date(),
+                        });
+                        const decision = await waitForUserDecision(context.sessionId, { interruptId }, context.abortSignal);
+                        const text = decision.response?.trim()
+                            ? decision.response
+                            : (decision.approved ? '(用户已确认，无补充文字说明)' : '(用户拒绝/未提供说明)');
+                        return { content: [{ type: 'text' as const, text }] };
+                    }
+                ),
+            ],
+        });
 
         const queryOptions: Record<string, unknown> = {
-            cwd: this.spec.engineOptions?.cwd ?? this.options.cwd ?? process.cwd(),
+            // context.cwd（如需求的 worktree 路径）优先于 spec.engineOptions.cwd（spec §5.2）
+            cwd: context.cwd ?? this.spec.engineOptions?.cwd ?? this.options.cwd ?? process.cwd(),
             // 直接遵守 spec 声明的预算（最低 1 轮），不静默覆盖用户配置
             maxTurns: Math.max(this.spec.resources.maxIterations, 1),
             systemPrompt: { type: 'preset', preset: 'claude_code', append: this.spec.systemPrompt },
-            allowedTools: this.allowedTools,
+            allowedTools: allowedToolsForRun,
+            mcpServers: { [ASK_USER_SERVER_NAME]: askUserServer },
             abortController,
             env,
             // 第二道闸：spec.tools.deny 模式 + allowedTools 白名单 + Bash 沙箱
+            // + approval 通道（默认关，spec §5.4）：approvalMode==='ask-on-risky' 时
+            // 沙箱判定为危险的命令转人工审批，而不是直接 deny
             canUseTool: async (toolName: string, toolInput: Record<string, unknown>) => {
                 // spec.tools.deny 优先（与 FilteredSkillRegistry 语义一致）
                 for (const pattern of (this.spec.tools?.deny ?? [])) {
@@ -124,6 +173,28 @@ export class ClaudeAgentSdkEngine implements IAgentEngine {
                     const command = String(toolInput?.command ?? '');
                     const verdict = this.sandbox.validate(command);
                     if (!verdict.allowed) {
+                        if (context.approvalMode === 'ask-on-risky') {
+                            const interruptId = nanoid();
+                            relay.push({
+                                type: 'interrupt',
+                                interruptKind: 'approval',
+                                interruptId,
+                                interruptReason: verdict.reason,
+                                content: `危险命令待人工审批：${command.slice(0, 200)}`,
+                                sessionId: context.sessionId,
+                                timestamp: new Date(),
+                            });
+                            const approved = await waitForApproval(context.sessionId, {
+                                interruptId,
+                                actionName: 'Bash',
+                                actionParams: command,
+                                dangerReason: verdict.reason,
+                            }, context.abortSignal);
+                            if (approved) {
+                                return { behavior: 'allow', updatedInput: toolInput };
+                            }
+                            return { behavior: 'deny', message: `Command rejected by human reviewer: ${verdict.reason}` };
+                        }
                         this.logger.warn(`[claude-sdk-engine] Bash command blocked by sandbox: ${command.slice(0, 100)}`);
                         return { behavior: 'deny', message: `Command blocked by sandbox: ${verdict.reason}` };
                     }
@@ -139,11 +210,28 @@ export class ClaudeAgentSdkEngine implements IAgentEngine {
 
         let sawResult = false;
         try {
-            for await (const message of sdk.query({ prompt: input, options: queryOptions })) {
-                for (const step of this._translateMessage(message)) {
+            const iterator = (sdk.query({ prompt: input, options: queryOptions }) as AsyncIterable<SDKMessage>)[Symbol.asyncIterator]();
+            let sdkPromise = iterator.next();
+            let relayPromise = relay.next();
+
+            while (true) {
+                const winner = await Promise.race([
+                    sdkPromise.then(r => ({ kind: 'sdk' as const, r })),
+                    relayPromise.then(step => ({ kind: 'relay' as const, step })),
+                ]);
+
+                if (winner.kind === 'relay') {
+                    yield winner.step;
+                    relayPromise = relay.next();
+                    continue;
+                }
+
+                if (winner.r.done) break;
+                for (const step of this._translateMessage(winner.r.value)) {
                     yield step;
                 }
-                if (message?.type === 'result') sawResult = true;
+                if (winner.r.value?.type === 'result') sawResult = true;
+                sdkPromise = iterator.next();
             }
         } catch (err) {
             // SDK 启动期失败（如 CLI 二进制缺失）且还没产出任何结果 → 降级

--- a/src/core/harness/interrupt-relay.ts
+++ b/src/core/harness/interrupt-relay.ts
@@ -1,0 +1,27 @@
+import type { ExecutionStep } from '../../types.js';
+
+/**
+ * 单读者推送式异步队列，桥接回调式代码（SDK 的 `canUseTool` / MCP 工具 handler，
+ * 均在 `run()` 的 async generator 主循环之外被 SDK 内部调用，无法直接 `yield`）
+ * 与 `run()` 的 for-await 主循环——回调侧 `push()` 一个 interrupt 步骤，
+ * 主循环侧 `next()` 拿到后继续 `yield` 给调用方。
+ */
+export class InterruptRelay {
+    private queue: ExecutionStep[] = [];
+    private waiting: Array<(step: ExecutionStep) => void> = [];
+
+    push(step: ExecutionStep): void {
+        const waiter = this.waiting.shift();
+        if (waiter) {
+            waiter(step);
+        } else {
+            this.queue.push(step);
+        }
+    }
+
+    next(): Promise<ExecutionStep> {
+        const step = this.queue.shift();
+        if (step) return Promise.resolve(step);
+        return new Promise(resolve => this.waiting.push(resolve));
+    }
+}

--- a/src/core/harness/session-store.ts
+++ b/src/core/harness/session-store.ts
@@ -9,6 +9,7 @@
 
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
+import { db } from '../database.js';
 import type { SessionEvent, SessionEventType, Message } from '../../types.js';
 
 export type { SessionEvent };
@@ -248,6 +249,12 @@ export class SessionEventStore {
         };
     }
 }
+
+/**
+ * 模块级单例，供不便走依赖注入的调用方使用（如 interrupt-coordinator.ts）。
+ * 与 AgentPool 构造时另建的 SessionEventStore 实例共享同一个 `db`，数据一致。
+ */
+export const sessionEventStore = new SessionEventStore(db);
 
 // ─────────────────────────────────────────────────
 // 工具函数

--- a/src/core/interrupt-coordinator.ts
+++ b/src/core/interrupt-coordinator.ts
@@ -11,6 +11,7 @@
  */
 
 import { auditRepository } from './audit-repository.js';
+import { sessionEventStore } from './harness/session-store.js';
 
 export interface InterruptMeta {
     interruptId?: string;
@@ -96,6 +97,22 @@ export function resolveInterrupt(sessionId: string, approved: boolean, opts?: Re
         // Non-fatal: audit failure should not block HitL resolution
     }
 
+    // 研发流程管理：interrupt 双写 session_events（回放用）+ audit_approvals（上面已写，审计台账用）
+    try {
+        sessionEventStore.append({
+            sessionId,
+            timestamp: Date.now(),
+            type: 'interrupt_resolved',
+            payload: {
+                interruptId: opts?.interruptId ?? meta?.interruptId ?? sessionId,
+                approved,
+                response: opts?.response,
+            },
+        });
+    } catch {
+        // Non-fatal: session_events 写入失败不应阻塞 HitL 恢复
+    }
+
     pending.resolve({ approved, response: opts?.response });
     pendingInterrupts.delete(sessionId);
     return true;
@@ -116,6 +133,16 @@ export function cancelInterrupt(sessionId: string): void {
                 dangerReason: pending.meta?.dangerReason,
                 decision: 'cancelled',
                 operatorChannel: 'web',
+            });
+        } catch {
+            // Non-fatal
+        }
+        try {
+            sessionEventStore.append({
+                sessionId,
+                timestamp: Date.now(),
+                type: 'interrupt_resolved',
+                payload: { interruptId: pending.meta?.interruptId ?? sessionId, approved: false, cancelled: true },
             });
         } catch {
             // Non-fatal

--- a/src/core/requirement-execution-service.ts
+++ b/src/core/requirement-execution-service.ts
@@ -1,0 +1,147 @@
+import { nanoid } from 'nanoid';
+import type { Logger, MemoryAccess } from '../types.js';
+import { projectRepository, type ProjectRepository, type Project } from './project-repository.js';
+import { requirementRepository, type RequirementRepository, type Requirement } from './requirement-repository.js';
+import { requirementRunRepository, type RequirementRunRepository, type RequirementRun } from './requirement-run-repository.js';
+import { worktreeManager, type WorktreeManager } from './worktree-manager.js';
+import { ClaudeAgentSdkEngine } from './harness/claude-sdk-engine.js';
+import type { IAgentEngine } from './harness/agent-engine.js';
+import { defaultAgentSpec, type AgentSpec } from './harness/agent-spec.js';
+
+/** coding agent 运行不使用 cmasterBot 自身的记忆系统 */
+const noopMemory: MemoryAccess = {
+    async get() { return undefined; },
+    async set() { /* no-op */ },
+    async search() { return []; },
+};
+
+/** v1 只支持默认 claude-code 引擎；codex/opencode/pi 留给后续 ticket（实施地图 #61 #65/#66） */
+const STARTABLE_STATUSES: Requirement['status'][] = ['synced', 'queued', 'failed'];
+
+export interface StartRunOptions {
+    approvalMode?: 'auto' | 'ask-on-risky';
+}
+
+export interface RequirementExecutionServiceDeps {
+    projects?: ProjectRepository;
+    requirements?: RequirementRepository;
+    runs?: RequirementRunRepository;
+    worktree?: WorktreeManager;
+    logger?: Logger;
+    /** 依赖注入：测试用 fake engine 替换真实 SDK 引擎 */
+    createEngine?: (spec: AgentSpec, logger: Logger) => IAgentEngine;
+}
+
+const consoleLogger: Logger = {
+    debug: (...args: unknown[]) => console.debug(...args),
+    info: (...args: unknown[]) => console.info(...args),
+    warn: (...args: unknown[]) => console.warn(...args),
+    error: (...args: unknown[]) => console.error(...args),
+};
+
+/**
+ * 研发流程管理执行层基座：发起研发编排。
+ * WorktreeManager 建 worktree → requirement_runs 建行 → 需求状态转 in_progress →
+ * 直接驱动 IAgentEngine.run()（cwd=worktree 路径）→ 消费 ExecutionStep 流：
+ * interrupt → waiting_input，恢复 → in_progress，正常结束 → succeeded + implemented，
+ * 异常 → failed（spec §5）。
+ */
+export class RequirementExecutionService {
+    private projects: ProjectRepository;
+    private requirements: RequirementRepository;
+    private runs: RequirementRunRepository;
+    private worktree: WorktreeManager;
+    private logger: Logger;
+    private createEngine: (spec: AgentSpec, logger: Logger) => IAgentEngine;
+
+    constructor(deps: RequirementExecutionServiceDeps = {}) {
+        this.projects = deps.projects ?? projectRepository;
+        this.requirements = deps.requirements ?? requirementRepository;
+        this.runs = deps.runs ?? requirementRunRepository;
+        this.worktree = deps.worktree ?? worktreeManager;
+        this.logger = deps.logger ?? consoleLogger;
+        this.createEngine = deps.createEngine ?? ((spec, logger) => new ClaudeAgentSdkEngine(spec, logger, {}));
+    }
+
+    /**
+     * 发起研发：点火即走，不阻塞调用方——执行在后台异步推进，
+     * 状态变化通过 requirement/run 的状态字段可查（前端轮询/回放读取）。
+     */
+    async start(requirementId: string, options: StartRunOptions = {}): Promise<{ runId: string; sessionId: string }> {
+        const requirement = this.requirements.getById(requirementId);
+        if (!requirement) throw new Error(`Requirement not found: ${requirementId}`);
+        if (!STARTABLE_STATUSES.includes(requirement.status)) {
+            throw new Error(`Requirement is not in a startable state (current: ${requirement.status})`);
+        }
+        const project = this.projects.getById(requirement.projectId);
+        if (!project) throw new Error(`Project not found: ${requirement.projectId}`);
+
+        const { path: worktreePath, branch } = await this.worktree.ensure(project, requirement);
+        const sessionId = nanoid();
+        const run = this.runs.create({
+            requirementId: requirement.id,
+            projectId: project.id,
+            engine: 'claude-agent-sdk',
+            sessionId,
+            worktreePath,
+            branch,
+        });
+        this.requirements.updateStatus(requirement.id, 'in_progress');
+
+        this.drive(project, requirement, run, options).catch(err => {
+            this.logger.error(`[requirement-execution] run ${run.id} crashed outside drive()'s own try/catch: ${(err as Error).message}`);
+        });
+
+        return { runId: run.id, sessionId };
+    }
+
+    private async drive(
+        project: Project,
+        requirement: Requirement,
+        run: RequirementRun,
+        options: StartRunOptions
+    ): Promise<void> {
+        const spec = defaultAgentSpec({
+            id: `dev-workflow-${requirement.id}`,
+            name: `研发流程执行 ${requirement.reqKey}`,
+            engine: 'claude-agent-sdk',
+            systemPrompt: [
+                `你正在处理需求 ${requirement.reqKey}：${requirement.title}`,
+                requirement.description ?? '',
+                '请实现该需求、提交代码并开 PR。若需要澄清需求或做出只有人类才能决定的选择，调用 ask_user 工具向人类提问。',
+            ].filter(Boolean).join('\n\n'),
+        });
+        const engine = this.createEngine(spec, this.logger);
+        const task = `实现需求 ${requirement.reqKey}：${requirement.title}`;
+
+        let awaitingResume = false;
+        try {
+            for await (const step of engine.run(task, {
+                sessionId: run.sessionId,
+                memory: noopMemory,
+                cwd: run.worktreePath ?? undefined,
+                approvalMode: options.approvalMode ?? 'auto',
+            })) {
+                if (step.type === 'interrupt') {
+                    awaitingResume = true;
+                    this.requirements.updateStatus(requirement.id, 'waiting_input');
+                    this.runs.updateStatus(run.id, 'waiting_input');
+                    continue;
+                }
+                if (awaitingResume) {
+                    awaitingResume = false;
+                    this.requirements.updateStatus(requirement.id, 'in_progress');
+                    this.runs.updateStatus(run.id, 'running');
+                }
+            }
+
+            this.runs.updateStatus(run.id, 'succeeded', { finished: true });
+            this.requirements.updateStatus(requirement.id, 'implemented');
+        } catch (err) {
+            this.runs.updateStatus(run.id, 'failed', { errorMessage: (err as Error).message, finished: true });
+            this.requirements.updateStatus(requirement.id, 'failed');
+        }
+    }
+}
+
+export const requirementExecutionService = new RequirementExecutionService();

--- a/src/core/requirement-repository.ts
+++ b/src/core/requirement-repository.ts
@@ -182,6 +182,27 @@ export class RequirementRepository {
         return result.changes > 0;
     }
 
+    /** 跨项目按状态查询（如启动扫描 in_progress/waiting_input，spec §5.6） */
+    listByStatuses(statuses: RequirementStatus[]): Requirement[] {
+        if (statuses.length === 0) return [];
+        const placeholders = statuses.map(() => '?').join(',');
+        const rows = this.db.prepare(`SELECT * FROM requirements WHERE status IN (${placeholders}) ORDER BY updated_at`)
+            .all(...(statuses as unknown as import('node:sqlite').SQLInputValue[])) as unknown as RequirementRow[];
+        return rows.map(rowToRequirement);
+    }
+
+    /**
+     * 服务启动时扫描 in_progress/waiting_input 的需求 → 统一标 failed（spec §5.6）。
+     * 返回被标记的需求列表，供调用方进一步处理（如同步标记对应 run 并写 error_message）。
+     */
+    markStuckAsFailed(): Requirement[] {
+        const stuck = this.listByStatuses(['in_progress', 'waiting_input']);
+        for (const req of stuck) {
+            this.updateStatus(req.id, 'failed');
+        }
+        return stuck;
+    }
+
     /**
      * 手动需求的项目内自增序列（spec §2.2：高位段/前缀避免与 issue 号撞车，如 M10001）。
      * 返回完整的数字段（含前缀），调用方拼接为 req_key = `{project_name}#{数字段}`。

--- a/src/core/requirement-run-repository.ts
+++ b/src/core/requirement-run-repository.ts
@@ -145,6 +145,27 @@ export class RequirementRunRepository {
             retryNo: previousRun.retryNo + 1,
         });
     }
+
+    /** 跨项目按状态查询（如启动扫描 running/waiting_input，spec §5.6） */
+    listByStatuses(statuses: RequirementRunStatus[]): RequirementRun[] {
+        if (statuses.length === 0) return [];
+        const placeholders = statuses.map(() => '?').join(',');
+        const rows = this.db.prepare(`SELECT * FROM requirement_runs WHERE status IN (${placeholders}) ORDER BY started_at`)
+            .all(...(statuses as unknown as import('node:sqlite').SQLInputValue[])) as unknown as RequirementRunRow[];
+        return rows.map(rowToRun);
+    }
+
+    /**
+     * 服务启动时扫描 running/waiting_input 的 run → 统一标 failed（spec §5.6）。
+     * 返回被标记的 run 列表。
+     */
+    markStuckAsFailed(errorMessage: string): RequirementRun[] {
+        const stuck = this.listByStatuses(['running', 'waiting_input']);
+        for (const run of stuck) {
+            this.updateStatus(run.id, 'failed', { errorMessage, finished: true });
+        }
+        return stuck;
+    }
 }
 
 export const requirementRunRepository = new RequirementRunRepository();

--- a/src/core/worktree-manager.ts
+++ b/src/core/worktree-manager.ts
@@ -1,0 +1,110 @@
+import path from 'path';
+import { existsSync } from 'fs';
+import { rm, readdir } from 'fs/promises';
+import { spawnCli } from '../skills/utils.js';
+import type { Project } from './project-repository.js';
+import type { Requirement } from './requirement-repository.js';
+
+export interface WorktreeInfo {
+    path: string;
+    branch: string;
+}
+
+/** req_key 转义为文件系统/分支安全的形式：`#` → `-`（spec §4.1，如 `cmasterBot#42` → `cmasterBot-42`）*/
+export function escapeReqKey(reqKey: string): string {
+    return reqKey.replace(/#/g, '-');
+}
+
+/** 分支命名固定 `req/{req_key 转义}`（spec §4.1）*/
+export function branchNameFor(reqKey: string): string {
+    return `req/${escapeReqKey(reqKey)}`;
+}
+
+/** worktree 物理位置：项目主目录 `.cmaster/worktrees/{req_key转义}/`（spec §4.2）*/
+export function worktreePathFor(project: Project, reqKey: string): string {
+    return path.join(project.dir, '.cmaster', 'worktrees', escapeReqKey(reqKey));
+}
+
+/**
+ * 服务端自建 worktree 管理器（spec §4.2）：直接 `git worktree add/remove`，
+ * 不复用 Claude Code 的 EnterWorktree（交互式 CLI 工具，运行形态不同）。
+ * 1 需求 : 1 活跃 worktree（spec §4.1），不允许并存多个。
+ */
+export class WorktreeManager {
+    /** 已存在则直接复用（断点续跑的半成品与错误现场），否则新建 */
+    async ensure(project: Project, requirement: Requirement): Promise<WorktreeInfo> {
+        const worktreePath = worktreePathFor(project, requirement.reqKey);
+        const branch = branchNameFor(requirement.reqKey);
+        if (existsSync(worktreePath)) {
+            return { path: worktreePath, branch };
+        }
+        await spawnCli('git', ['worktree', 'add', worktreePath, '-b', branch], { cwd: project.dir });
+        return { path: worktreePath, branch };
+    }
+
+    /** 人工"重置重来"：删 worktree + 分支后重建（spec §4.1） */
+    async reset(project: Project, requirement: Requirement): Promise<WorktreeInfo> {
+        await this.remove(project, requirement, { force: true });
+        return this.ensure(project, requirement);
+    }
+
+    /** `merged` 自动清理 / `cancelled` 人工确认后清理走这个方法（spec §4.3） */
+    async remove(project: Project, requirement: Requirement, opts?: { force?: boolean }): Promise<void> {
+        const worktreePath = worktreePathFor(project, requirement.reqKey);
+        const branch = branchNameFor(requirement.reqKey);
+
+        if (existsSync(worktreePath)) {
+            try {
+                await spawnCli(
+                    'git',
+                    ['worktree', 'remove', worktreePath, ...(opts?.force ? ['--force'] : [])],
+                    { cwd: project.dir }
+                );
+            } catch {
+                // worktree 记录可能已损坏（如目录被手动删除），退化为直接删目录 + prune
+                await rm(worktreePath, { recursive: true, force: true });
+                try { await spawnCli('git', ['worktree', 'prune'], { cwd: project.dir }); } catch { /* best-effort */ }
+            }
+        }
+        try {
+            await spawnCli('git', ['branch', '-D', branch], { cwd: project.dir });
+        } catch {
+            // 分支可能不存在，忽略
+        }
+    }
+
+    exists(project: Project, reqKey: string): boolean {
+        return existsSync(worktreePathFor(project, reqKey));
+    }
+
+    /**
+     * 兜底：清理孤儿 worktree（需求已删/已终态但目录残留，spec §4.3）。
+     * 扫描 `.cmaster/worktrees/` 下不在 `keepReqKeys` 保留名单内的目录并删除。
+     */
+    async pruneOrphans(project: Project, keepReqKeys: string[]): Promise<string[]> {
+        const dir = path.join(project.dir, '.cmaster', 'worktrees');
+        if (!existsSync(dir)) return [];
+
+        const keep = new Set(keepReqKeys.map(escapeReqKey));
+        const entries = await readdir(dir, { withFileTypes: true });
+        const removed: string[] = [];
+
+        for (const entry of entries) {
+            if (!entry.isDirectory() || keep.has(entry.name)) continue;
+            const worktreePath = path.join(dir, entry.name);
+            try {
+                await spawnCli('git', ['worktree', 'remove', worktreePath, '--force'], { cwd: project.dir });
+            } catch {
+                await rm(worktreePath, { recursive: true, force: true });
+            }
+            removed.push(entry.name);
+        }
+
+        if (removed.length > 0) {
+            try { await spawnCli('git', ['worktree', 'prune'], { cwd: project.dir }); } catch { /* best-effort */ }
+        }
+        return removed;
+    }
+}
+
+export const worktreeManager = new WorktreeManager();

--- a/src/gateway/routes/requirements.ts
+++ b/src/gateway/routes/requirements.ts
@@ -1,11 +1,15 @@
 import type { FastifyInstance } from 'fastify';
 import { requirementRepository, type RequirementStatus } from '../../core/requirement-repository.js';
+import { requirementRunRepository } from '../../core/requirement-run-repository.js';
 import { requirementSyncService } from '../../core/requirement-sync-service.js';
+import { requirementExecutionService } from '../../core/requirement-execution-service.js';
 import type { GatewayDeps } from '../route-deps.js';
 
 /**
- * 研发流程管理模块：需求同步 / 手动创建 / 列表路由。
- * 实施地图 #61 ticket #63（同步层）；发起研发/重试/取消/回答中断/核验合并等路由留给执行层 ticket。
+ * 研发流程管理模块：需求同步 / 手动创建 / 列表 / 发起研发 / run 查询路由。
+ * 实施地图 #61 ticket #63（同步层）+ #64（执行层基座）。
+ * 回答中断复用既有 `/api/sessions/:id/interrupt-response`（键控用的就是 requirement_run.session_id）；
+ * 重试/取消/核验合并留给后续 ticket。
  */
 export async function registerRequirementRoutes(app: FastifyInstance, deps: GatewayDeps): Promise<void> {
     // 手动触发同步（spec §2.5：仅手动触发，不做定时任务）
@@ -62,5 +66,36 @@ export async function registerRequirementRoutes(app: FastifyInstance, deps: Gate
         const requirement = requirementRepository.getById(request.params.id);
         if (!requirement) { reply.status(404); return { error: 'Requirement not found' }; }
         return requirement;
+    });
+
+    // 发起研发（v1 仅默认 claude-code 引擎；点火即走，异步执行，状态变化通过 requirement/run 轮询）
+    app.post<{ Params: { id: string }; Body: { approvalMode?: 'auto' | 'ask-on-risky' } }>(
+        '/api/requirements/:id/start',
+        async (request, reply) => {
+            try {
+                const result = await requirementExecutionService.start(request.params.id, {
+                    approvalMode: request.body?.approvalMode,
+                });
+                reply.status(202);
+                return result;
+            } catch (error: any) {
+                deps.logger.error(`Start requirement execution error: ${error.message}`);
+                if (error.message?.startsWith('Requirement not found') || error.message?.startsWith('Project not found')) {
+                    reply.status(404);
+                    return { error: error.message };
+                }
+                if (error.message?.includes('startable state')) {
+                    reply.status(409);
+                    return { error: error.message };
+                }
+                reply.status(500);
+                return { error: error.message };
+            }
+        }
+    );
+
+    // run 列表与详情（执行记录回放的入口，静态浏览用）
+    app.get<{ Params: { id: string } }>('/api/requirements/:id/runs', async (request) => {
+        return requirementRunRepository.listByRequirement(request.params.id);
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import { AgentPool, SessionEventStore, CredentialVault } from './core/harness/ag
 import { CheckpointManager } from './core/checkpoint-manager.js';
 import { syncSourceRegistry } from './core/requirement-sync.js';
 import { GitHubSyncSource } from './core/requirement-sync-github.js';
+import { requirementRepository } from './core/requirement-repository.js';
+import { requirementRunRepository } from './core/requirement-run-repository.js';
 
 async function main() {
     // U4: 在所有其他初始化之前启动 OTel（仅当 OTEL_EXPORTER_OTLP_ENDPOINT 配置时生效）
@@ -187,6 +189,16 @@ async function main() {
 
     // Phase 24: 启动时扫描未完成 session，自动 wake（Harness as Cattle）
     await agentPool.scanAndWake();
+
+    // 研发流程管理模块：启动时扫描 in_progress/waiting_input 的需求与 run，
+    // 统一标 failed（v1 不做跨进程真 resume，人工重试复用 worktree 现场，spec §5.6）
+    {
+        const stuckRuns = requirementRunRepository.markStuckAsFailed('服务重启，执行中断');
+        const stuckRequirements = requirementRepository.markStuckAsFailed();
+        if (stuckRuns.length > 0 || stuckRequirements.length > 0) {
+            logger.warn(`[dev-workflow] 服务启动扫描：标记 ${stuckRequirements.length} 个需求、${stuckRuns.length} 个 run 为 failed`);
+        }
+    }
 
     // Phase 26: Agent 在 agentPool 创建后初始化，确保 agentPool 和 sessionStore 可直接注入
     const agent = new Agent({

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,7 +245,9 @@ export type SessionEventType =
     | 'memory_read'         // M3: 记忆读取审计（memory_recall）
     | 'user_message'        // D1: 用户消息记录
     | 'grader_evaluation'   // D6: Grader 评分结果持久化
-    | 'grader_revision';    // D6: Grader 修订循环持久化
+    | 'grader_revision'     // D6: Grader 修订循环持久化
+    | 'interrupt_raised'    // 研发流程管理：人机中断发起（question/approval）
+    | 'interrupt_resolved'; // 研发流程管理：人机中断已解决
 
 export interface SessionEvent {
     id: string;

--- a/tests/agent-harness-interrupt.test.ts
+++ b/tests/agent-harness-interrupt.test.ts
@@ -1,0 +1,100 @@
+/**
+ * 研发流程管理执行层基座：AgentHarness 在收到 interrupt 步骤时
+ * 应该 emit('interrupt_raised', ...) 写入 session_events（"raised"一半，
+ * "resolved"一半由 interrupt-coordinator.ts 的 resolveInterrupt/cancelInterrupt 写）。
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { AgentHarness } from '../src/core/harness/agent-harness.js';
+import { defaultAgentSpec } from '../src/core/harness/agent-spec.js';
+import { SkillRegistry } from '../src/skills/registry.js';
+import type { Logger, MemoryAccess } from '../src/types.js';
+
+function makeLogger(): Logger {
+    return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeLLM() {
+    return {
+        provider: 'mock',
+        chat: vi.fn().mockResolvedValue({ role: 'assistant', content: 'mock answer' }),
+        chatStream: vi.fn(),
+        embeddings: vi.fn().mockResolvedValue([[]]),
+    };
+}
+
+function makeMemory(): MemoryAccess {
+    return { get: async () => undefined, set: async () => {}, search: async () => [] };
+}
+
+describe('AgentHarness: interrupt step → emit interrupt_raised', () => {
+    it('emits interrupt_raised with interruptId/interruptKind/reason when the engine yields an interrupt step', async () => {
+        const logger = makeLogger();
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', description: 'test', systemPrompt: 'x' });
+        const emitEvent = vi.fn().mockReturnValue('evt-1');
+
+        const harness = new AgentHarness(
+            spec,
+            () => makeLLM() as any,
+            new SkillRegistry(logger),
+            logger,
+            undefined,
+            undefined,
+            undefined,
+            emitEvent
+        );
+
+        (harness as any).engine = {
+            run: async function* () {
+                yield {
+                    type: 'interrupt',
+                    interruptKind: 'question',
+                    interruptId: 'int-1',
+                    interruptReason: '要不要用 PostgreSQL？',
+                    content: '要不要用 PostgreSQL？',
+                    timestamp: new Date(),
+                };
+                yield { type: 'answer', content: 'done', timestamp: new Date() };
+            },
+        };
+
+        const steps: any[] = [];
+        for await (const s of harness.execute('task', { sessionId: 's1', memory: makeMemory() })) steps.push(s);
+
+        const raisedCalls = emitEvent.mock.calls.filter(c => c[0] === 'interrupt_raised');
+        expect(raisedCalls).toHaveLength(1);
+        expect(raisedCalls[0][1]).toMatchObject({
+            interruptId: 'int-1',
+            interruptKind: 'question',
+            reason: '要不要用 PostgreSQL？',
+        });
+    });
+
+    it('does not emit interrupt_raised for non-interrupt steps', async () => {
+        const logger = makeLogger();
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', description: 'test', systemPrompt: 'x' });
+        const emitEvent = vi.fn().mockReturnValue('evt-1');
+
+        const harness = new AgentHarness(
+            spec,
+            () => makeLLM() as any,
+            new SkillRegistry(logger),
+            logger,
+            undefined,
+            undefined,
+            undefined,
+            emitEvent
+        );
+
+        (harness as any).engine = {
+            run: async function* () {
+                yield { type: 'content', content: 'hi', timestamp: new Date() };
+                yield { type: 'answer', content: 'done', timestamp: new Date() };
+            },
+        };
+
+        const steps: any[] = [];
+        for await (const s of harness.execute('task', { sessionId: 's2', memory: makeMemory() })) steps.push(s);
+
+        expect(emitEvent.mock.calls.some(c => c[0] === 'interrupt_raised')).toBe(false);
+    });
+});

--- a/tests/claude-sdk-engine.test.ts
+++ b/tests/claude-sdk-engine.test.ts
@@ -5,13 +5,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // 异常终止时 Grader 拿不到任何 answer 步骤。验证改用 `errors: string[]` 后能正确 yield。
 
 const queryMock = vi.hoisted(() => vi.fn());
+// 研发流程管理执行层基座：ask_user MCP 工具注入需要 SDK 的 tool()/createSdkMcpServer()。
+// mock 只需保留调用方能取回 handler 的最小形状，不需要真正实现 MCP 协议。
+const toolMock = vi.hoisted(() => vi.fn((name: string, description: string, inputSchema: unknown, handler: unknown) => ({
+    name, description, inputSchema, handler,
+})));
+const createSdkMcpServerMock = vi.hoisted(() => vi.fn((opts: unknown) => opts));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
     query: queryMock,
+    tool: toolMock,
+    createSdkMcpServer: createSdkMcpServerMock,
 }));
 
 import { ClaudeAgentSdkEngine } from '../src/core/harness/claude-sdk-engine.js';
 import { defaultAgentSpec } from '../src/core/harness/agent-spec.js';
+import { resolveInterrupt, hasPendingInterrupt } from '../src/core/interrupt-coordinator.js';
 import type { ExecutionStep, MemoryAccess } from '../src/types.js';
 
 const mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
@@ -119,5 +128,146 @@ describe('ClaudeAgentSdkEngine: result message translation (review fix)', () => 
         const steps = await drain(engine.run('do the task', { sessionId: 's3', memory: mockMemory }));
         const answerStep = steps.find(s => s.type === 'answer');
         expect(answerStep?.content).toBe('done successfully');
+    });
+});
+
+describe('ClaudeAgentSdkEngine: 执行层基座（研发流程管理）', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env.ANTHROPIC_API_KEY = 'test-key';
+    });
+
+    it('capabilities: interactiveApproval=true, resume=false', () => {
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', engine: 'claude-agent-sdk' });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+        expect(engine.capabilities).toEqual({ interactiveApproval: true, resume: false });
+    });
+
+    it('context.cwd 优先于 spec.engineOptions.cwd（spec §5.2）', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({
+            id: 'coder', name: 'Coder', engine: 'claude-agent-sdk',
+            engineOptions: { cwd: '/spec/engine-options/cwd' },
+        });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        await drain(engine.run('task', { sessionId: 's-cwd-1', memory: mockMemory, cwd: '/worktree/cmasterBot-42' }));
+        expect(queryMock.mock.calls[0][0].options.cwd).toBe('/worktree/cmasterBot-42');
+    });
+
+    it('未传 context.cwd 时回退到 spec.engineOptions.cwd', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({
+            id: 'coder', name: 'Coder', engine: 'claude-agent-sdk',
+            engineOptions: { cwd: '/spec/engine-options/cwd' },
+        });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        await drain(engine.run('task', { sessionId: 's-cwd-2', memory: mockMemory }));
+        expect(queryMock.mock.calls[0][0].options.cwd).toBe('/spec/engine-options/cwd');
+    });
+
+    it('注入了 ask_user MCP 工具并加入 allowedTools（question 通道常开）', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', engine: 'claude-agent-sdk' });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        await drain(engine.run('task', { sessionId: 's-ask-user-setup', memory: mockMemory }));
+        const options = queryMock.mock.calls[0][0].options;
+        expect(options.allowedTools).toContain('mcp__ask_user_server__ask_user');
+        expect(options.mcpServers.ask_user_server.tools[0].name).toBe('ask_user');
+    });
+
+    it('ask_user 工具 handler 阻塞直到 waitForUserDecision 被 resolveInterrupt 释放，并把文本应答回传', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', engine: 'claude-agent-sdk' });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        const sessionId = 's-ask-user-flow';
+        await drain(engine.run('task', { sessionId, memory: mockMemory }));
+        const handler = queryMock.mock.calls[0][0].options.mcpServers.ask_user_server.tools[0].handler;
+
+        const resultPromise = handler({ question: '要不要用 PostgreSQL？' }, {});
+        expect(hasPendingInterrupt(sessionId)).toBe(true);
+        expect(resolveInterrupt(sessionId, true, { response: '用 PostgreSQL' })).toBe(true);
+
+        const result = await resultPromise;
+        expect(result).toEqual({ content: [{ type: 'text', text: '用 PostgreSQL' }] });
+    });
+
+    it('ask_user 无文本应答时返回占位说明（区分批准/拒绝）', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', engine: 'claude-agent-sdk' });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        const sessionId = 's-ask-user-no-text';
+        await drain(engine.run('task', { sessionId, memory: mockMemory }));
+        const handler = queryMock.mock.calls[0][0].options.mcpServers.ask_user_server.tools[0].handler;
+
+        const resultPromise = handler({ question: 'ok?' }, {});
+        resolveInterrupt(sessionId, false);
+        const result = await resultPromise;
+        expect(result.content[0].text).toContain('拒绝');
+    });
+
+    it('canUseTool 默认（approvalMode 未设置）对危险 Bash 命令直接 deny，不打扰人', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', engine: 'claude-agent-sdk' });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        const sessionId = 's-deny-default';
+        await drain(engine.run('task', { sessionId, memory: mockMemory }));
+        const canUseTool = queryMock.mock.calls[0][0].options.canUseTool;
+
+        const verdict = await canUseTool('Bash', { command: 'rm -rf /' });
+        expect(verdict.behavior).toBe('deny');
+        expect(hasPendingInterrupt(sessionId)).toBe(false);
+    });
+
+    it('canUseTool 在 approvalMode=ask-on-risky 时把危险 Bash 命令转人工审批（approve→allow）', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', engine: 'claude-agent-sdk' });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        const sessionId = 's-ask-on-risky-approve';
+        await drain(engine.run('task', { sessionId, memory: mockMemory, approvalMode: 'ask-on-risky' }));
+        const canUseTool = queryMock.mock.calls[0][0].options.canUseTool;
+
+        const verdictPromise = canUseTool('Bash', { command: 'rm -rf /' });
+        expect(hasPendingInterrupt(sessionId)).toBe(true);
+        resolveInterrupt(sessionId, true);
+
+        const verdict = await verdictPromise;
+        expect(verdict.behavior).toBe('allow');
+    });
+
+    it('canUseTool 在 approvalMode=ask-on-risky 时人工拒绝仍然 deny', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', engine: 'claude-agent-sdk' });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        const sessionId = 's-ask-on-risky-reject';
+        await drain(engine.run('task', { sessionId, memory: mockMemory, approvalMode: 'ask-on-risky' }));
+        const canUseTool = queryMock.mock.calls[0][0].options.canUseTool;
+
+        const verdictPromise = canUseTool('Bash', { command: 'rm -rf /' });
+        resolveInterrupt(sessionId, false);
+
+        const verdict = await verdictPromise;
+        expect(verdict.behavior).toBe('deny');
+    });
+
+    it('canUseTool 对非 Bash 且不在白名单的工具仍然直接 deny（不受 ask-on-risky 影响）', async () => {
+        queryMock.mockReturnValue(fakeQueryStream([]));
+        const spec = defaultAgentSpec({ id: 'coder', name: 'Coder', engine: 'claude-agent-sdk' });
+        const engine = new ClaudeAgentSdkEngine(spec, mockLogger as any);
+
+        const sessionId = 's-not-allowed';
+        await drain(engine.run('task', { sessionId, memory: mockMemory, approvalMode: 'ask-on-risky' }));
+        const canUseTool = queryMock.mock.calls[0][0].options.canUseTool;
+
+        const verdict = await canUseTool('SomeRandomTool', {});
+        expect(verdict.behavior).toBe('deny');
+        expect(hasPendingInterrupt(sessionId)).toBe(false);
     });
 });

--- a/tests/interrupt-coordinator.test.ts
+++ b/tests/interrupt-coordinator.test.ts
@@ -11,6 +11,13 @@ import {
     cancelInterrupt,
     hasPendingInterrupt,
 } from '../src/core/interrupt-coordinator.js';
+import { db } from '../src/core/database.js';
+
+function lastSessionEvent(sessionId: string, type: string): { payload: string } | undefined {
+    return db.prepare(
+        'SELECT payload FROM session_events WHERE session_id = ? AND type = ? ORDER BY timestamp DESC LIMIT 1'
+    ).get(sessionId, type) as { payload: string } | undefined;
+}
 
 describe('interrupt-coordinator', () => {
     it('waitForApproval 由 resolveInterrupt(approved=true) 释放', async () => {
@@ -44,5 +51,28 @@ describe('interrupt-coordinator', () => {
         cancelInterrupt('sess-d');
         await expect(p).rejects.toThrow(/disconnected/i);
         expect(hasPendingInterrupt('sess-d')).toBe(false);
+    });
+
+    // 研发流程管理：interrupt 双写 session_events（回放）+ audit_approvals（审计台账，已有测试覆盖 resolveInterrupt 返回值）
+    it('resolveInterrupt 追加一条 interrupt_resolved session_events（spec §6.2）', async () => {
+        const p = waitForUserDecision('sess-e', { interruptId: 'int-e' });
+        resolveInterrupt('sess-e', true, { interruptId: 'int-e', response: '用 PostgreSQL' });
+        await p;
+
+        const event = lastSessionEvent('sess-e', 'interrupt_resolved');
+        expect(event).toBeDefined();
+        const payload = JSON.parse(event!.payload);
+        expect(payload).toMatchObject({ interruptId: 'int-e', approved: true, response: '用 PostgreSQL' });
+    });
+
+    it('cancelInterrupt 追加一条 interrupt_resolved session_events（标注 cancelled）', async () => {
+        const p = waitForApproval('sess-f', { interruptId: 'int-f' });
+        cancelInterrupt('sess-f');
+        await expect(p).rejects.toThrow();
+
+        const event = lastSessionEvent('sess-f', 'interrupt_resolved');
+        expect(event).toBeDefined();
+        const payload = JSON.parse(event!.payload);
+        expect(payload).toMatchObject({ interruptId: 'int-f', approved: false, cancelled: true });
     });
 });

--- a/tests/interrupt-relay.test.ts
+++ b/tests/interrupt-relay.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { InterruptRelay } from '../src/core/harness/interrupt-relay.js';
+import type { ExecutionStep } from '../src/types.js';
+
+function step(content: string): ExecutionStep {
+    return { type: 'interrupt', interruptKind: 'question', content, timestamp: new Date() };
+}
+
+describe('InterruptRelay', () => {
+    it('resolves next() immediately when an item is already queued (push before next)', async () => {
+        const relay = new InterruptRelay();
+        relay.push(step('a'));
+        const result = await relay.next();
+        expect(result.content).toBe('a');
+    });
+
+    it('resolves a pending next() when push() arrives later (next before push)', async () => {
+        const relay = new InterruptRelay();
+        const pending = relay.next();
+        relay.push(step('b'));
+        const result = await pending;
+        expect(result.content).toBe('b');
+    });
+
+    it('preserves FIFO order across multiple pushes', async () => {
+        const relay = new InterruptRelay();
+        relay.push(step('1'));
+        relay.push(step('2'));
+        relay.push(step('3'));
+        expect((await relay.next()).content).toBe('1');
+        expect((await relay.next()).content).toBe('2');
+        expect((await relay.next()).content).toBe('3');
+    });
+
+    it('supports interleaved push/next cycles', async () => {
+        const relay = new InterruptRelay();
+        const p1 = relay.next();
+        relay.push(step('x'));
+        expect((await p1).content).toBe('x');
+
+        relay.push(step('y'));
+        const p2 = relay.next();
+        expect((await p2).content).toBe('y');
+    });
+});

--- a/tests/requirement-execution-service.test.ts
+++ b/tests/requirement-execution-service.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { ProjectRepository } from '../src/core/project-repository.js';
+import { RequirementRepository } from '../src/core/requirement-repository.js';
+import { RequirementRunRepository } from '../src/core/requirement-run-repository.js';
+import { RequirementExecutionService } from '../src/core/requirement-execution-service.js';
+import type { WorktreeManager } from '../src/core/worktree-manager.js';
+import type { IAgentEngine } from '../src/core/harness/agent-engine.js';
+import type { ExecutionStep } from '../src/types.js';
+
+function createTestDb(): DatabaseSync {
+    const db = new DatabaseSync(':memory:');
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS projects (
+            id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, dir TEXT NOT NULL, description TEXT,
+            sync_source TEXT NOT NULL DEFAULT 'github', sync_config TEXT, last_synced_at TEXT,
+            max_concurrent_runs INTEGER NOT NULL DEFAULT 2, skills_installed_at TEXT,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS requirements (
+            id TEXT PRIMARY KEY, project_id TEXT NOT NULL, req_key TEXT NOT NULL, source TEXT NOT NULL,
+            source_key TEXT NOT NULL, title TEXT NOT NULL, description TEXT, labels TEXT,
+            status TEXT NOT NULL DEFAULT 'synced', source_url TEXT, source_closed INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_req_key ON requirements(req_key);
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_req_dedup ON requirements(project_id, source, source_key);
+        CREATE TABLE IF NOT EXISTS requirement_runs (
+            id TEXT PRIMARY KEY, requirement_id TEXT NOT NULL, project_id TEXT NOT NULL, engine TEXT NOT NULL,
+            worktree_path TEXT, branch TEXT, session_id TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'running',
+            retry_no INTEGER NOT NULL DEFAULT 0, pr_url TEXT, error_message TEXT, token_cost TEXT,
+            started_at TEXT NOT NULL, finished_at TEXT
+        );
+    `);
+    return db;
+}
+
+function fakeWorktreeManager(): WorktreeManager {
+    return {
+        ensure: vi.fn(async (_project, requirement) => ({
+            path: `/fake/worktrees/${requirement.reqKey}`,
+            branch: `req/${requirement.reqKey}`,
+        })),
+        reset: vi.fn(),
+        remove: vi.fn(),
+        exists: vi.fn(() => true),
+        pruneOrphans: vi.fn(async () => []),
+    } as unknown as WorktreeManager;
+}
+
+function engineYielding(steps: ExecutionStep[]): IAgentEngine {
+    return {
+        kind: 'claude-agent-sdk',
+        capabilities: { interactiveApproval: true, resume: false },
+        run: async function* () { yield* steps; },
+    };
+}
+
+function engineThrowing(message: string): IAgentEngine {
+    return {
+        kind: 'claude-agent-sdk',
+        capabilities: { interactiveApproval: true, resume: false },
+        run: async function* () {
+            throw new Error(message);
+            // eslint-disable-next-line no-unreachable
+            yield undefined as never;
+        },
+    };
+}
+
+describe('RequirementExecutionService', () => {
+    let projects: ProjectRepository;
+    let requirements: RequirementRepository;
+    let runs: RequirementRunRepository;
+    let worktree: WorktreeManager;
+    let projectId: string;
+
+    beforeEach(() => {
+        const db = createTestDb();
+        projects = new ProjectRepository(db as any);
+        requirements = new RequirementRepository(db as any);
+        runs = new RequirementRunRepository(db as any);
+        worktree = fakeWorktreeManager();
+        projectId = projects.create({ name: 'cmasterBot', dir: '/repo/cmasterBot' }).id;
+    });
+
+    function makeService(createEngine: (spec: any, logger: any) => IAgentEngine) {
+        return new RequirementExecutionService({
+            projects, requirements, runs, worktree,
+            logger: { debug() {}, info() {}, warn() {}, error() {} },
+            createEngine,
+        });
+    }
+
+    it('start() 建 worktree、建 run、需求转 in_progress，且不阻塞等待执行完成', async () => {
+        let resolveRun!: () => void;
+        const pending = new Promise<void>(r => { resolveRun = r; });
+        const service = makeService(() => ({
+            kind: 'claude-agent-sdk',
+            capabilities: { interactiveApproval: true, resume: false },
+            run: async function* () {
+                await pending; // 卡住，验证 start() 不会等它
+                yield { type: 'answer', content: 'done', timestamp: new Date() } as ExecutionStep;
+            },
+        }));
+
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'Add feature',
+        });
+        requirements.updateStatus(requirement.id, 'queued');
+
+        const { runId, sessionId } = await service.start(requirement.id);
+        expect(runId).toBeTruthy();
+        expect(sessionId).toBeTruthy();
+        expect(worktree.ensure).toHaveBeenCalled();
+        expect(requirements.getById(requirement.id)!.status).toBe('in_progress');
+        expect(runs.getById(runId)!.status).toBe('running');
+
+        resolveRun();
+    });
+
+    it('drive(): 正常结束 → run succeeded + 需求 implemented', async () => {
+        const service = makeService(() => engineYielding([
+            { type: 'content', content: 'working...', timestamp: new Date() },
+            { type: 'answer', content: 'done', timestamp: new Date() },
+        ]));
+
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#2', source: 'github', sourceKey: '2', title: 'Add feature',
+        });
+        const project = projects.getById(projectId)!;
+        const run = runs.create({ requirementId: requirement.id, projectId, engine: 'claude-agent-sdk', sessionId: 's1' });
+
+        await (service as any).drive(project, requirement, run, {});
+
+        expect(runs.getById(run.id)!.status).toBe('succeeded');
+        expect(runs.getById(run.id)!.finishedAt).not.toBeNull();
+        expect(requirements.getById(requirement.id)!.status).toBe('implemented');
+    });
+
+    it('drive(): interrupt 步骤 → 需求/run 转 waiting_input，恢复后转回 in_progress/running，结束后 implemented', async () => {
+        const service = makeService(() => engineYielding([
+            { type: 'content', content: 'thinking...', timestamp: new Date() },
+            { type: 'interrupt', interruptKind: 'question', interruptId: 'i1', content: 'q?', timestamp: new Date() },
+            { type: 'content', content: 'resumed', timestamp: new Date() },
+            { type: 'answer', content: 'done', timestamp: new Date() },
+        ]));
+
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#3', source: 'github', sourceKey: '3', title: 'Add feature',
+        });
+        const project = projects.getById(projectId)!;
+        const run = runs.create({ requirementId: requirement.id, projectId, engine: 'claude-agent-sdk', sessionId: 's2' });
+
+        await (service as any).drive(project, requirement, run, {});
+
+        // drive() 结束后应该是最终态：succeeded/implemented（中间态是短暂的，验证靠下面单独用例）
+        expect(runs.getById(run.id)!.status).toBe('succeeded');
+        expect(requirements.getById(requirement.id)!.status).toBe('implemented');
+    });
+
+    it('drive(): interrupt 后立即可观察到 waiting_input（不是事后才生效）', async () => {
+        let releaseAfterInterrupt!: () => void;
+        const gate = new Promise<void>(r => { releaseAfterInterrupt = r; });
+
+        const service = makeService(() => ({
+            kind: 'claude-agent-sdk',
+            capabilities: { interactiveApproval: true, resume: false },
+            run: async function* () {
+                yield { type: 'interrupt', interruptKind: 'question', interruptId: 'i2', content: 'q?', timestamp: new Date() } as ExecutionStep;
+                await gate;
+                yield { type: 'answer', content: 'done', timestamp: new Date() } as ExecutionStep;
+            },
+        }));
+
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#4', source: 'github', sourceKey: '4', title: 'Add feature',
+        });
+        const project = projects.getById(projectId)!;
+        const run = runs.create({ requirementId: requirement.id, projectId, engine: 'claude-agent-sdk', sessionId: 's3' });
+
+        const drivePromise = (service as any).drive(project, requirement, run, {});
+
+        // 让出一个微任务，使 drive() 内部跑到 interrupt 步骤
+        await new Promise(r => setTimeout(r, 0));
+        expect(requirements.getById(requirement.id)!.status).toBe('waiting_input');
+        expect(runs.getById(run.id)!.status).toBe('waiting_input');
+
+        releaseAfterInterrupt();
+        await drivePromise;
+        expect(requirements.getById(requirement.id)!.status).toBe('implemented');
+    });
+
+    it('drive(): 引擎抛错 → run failed（带 errorMessage）+ 需求 failed', async () => {
+        const service = makeService(() => engineThrowing('SDK crashed'));
+
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#5', source: 'github', sourceKey: '5', title: 'Add feature',
+        });
+        const project = projects.getById(projectId)!;
+        const run = runs.create({ requirementId: requirement.id, projectId, engine: 'claude-agent-sdk', sessionId: 's4' });
+
+        await (service as any).drive(project, requirement, run, {});
+
+        const fetchedRun = runs.getById(run.id)!;
+        expect(fetchedRun.status).toBe('failed');
+        expect(fetchedRun.errorMessage).toBe('SDK crashed');
+        expect(requirements.getById(requirement.id)!.status).toBe('failed');
+    });
+
+    it('start() 对不存在的需求抛错', async () => {
+        const service = makeService(() => engineYielding([]));
+        await expect(service.start('nonexistent')).rejects.toThrow(/Requirement not found/);
+    });
+
+    it('start() 拒绝非可启动状态（如 implemented）', async () => {
+        const service = makeService(() => engineYielding([]));
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#6', source: 'github', sourceKey: '6', title: 'Add feature',
+        });
+        requirements.updateStatus(requirement.id, 'implemented');
+        await expect(service.start(requirement.id)).rejects.toThrow(/startable state/);
+    });
+
+    it('start() 允许从 failed 状态重新发起（复用 worktree 现场）', async () => {
+        const service = makeService(() => engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]));
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#7', source: 'github', sourceKey: '7', title: 'Add feature',
+        });
+        requirements.updateStatus(requirement.id, 'failed');
+        const { runId } = await service.start(requirement.id);
+        expect(runId).toBeTruthy();
+        expect(worktree.ensure).toHaveBeenCalled();
+    });
+});

--- a/tests/requirement-repository.test.ts
+++ b/tests/requirement-repository.test.ts
@@ -32,6 +32,7 @@ function createTestDb(): DatabaseSync {
         CREATE INDEX IF NOT EXISTS idx_req_project_status ON requirements(project_id, status);
     `);
     db.exec(`INSERT INTO projects (id, name, dir, created_at, updated_at) VALUES ('p1', 'cmasterBot', '/repo', '2026-01-01', '2026-01-01')`);
+    db.exec(`INSERT INTO projects (id, name, dir, created_at, updated_at) VALUES ('p2', 'otherRepo', '/repo2', '2026-01-01', '2026-01-01')`);
     return db;
 }
 
@@ -125,5 +126,34 @@ describe('RequirementRepository', () => {
         const req = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
         expect(repo.delete(req.id)).toBe(true);
         expect(repo.getById(req.id)).toBeNull();
+    });
+
+    it('listByStatuses queries across projects (启动扫描用)', () => {
+        const a = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        const b = repo.create({ projectId: 'p2', reqKey: 'otherRepo#1', source: 'github', sourceKey: '1', title: 'B' });
+        repo.create({ projectId: 'p1', reqKey: 'cmasterBot#2', source: 'github', sourceKey: '2', title: 'C' });
+        repo.updateStatus(a.id, 'in_progress');
+        repo.updateStatus(b.id, 'waiting_input');
+
+        const stuck = repo.listByStatuses(['in_progress', 'waiting_input']);
+        expect(stuck.map(r => r.id).sort()).toEqual([a.id, b.id].sort());
+    });
+
+    it('listByStatuses returns empty array for an empty statuses list', () => {
+        expect(repo.listByStatuses([])).toEqual([]);
+    });
+
+    it('markStuckAsFailed 把 in_progress/waiting_input 的需求统一标 failed（spec §5.6）', () => {
+        const stuck1 = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        const stuck2 = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#2', source: 'github', sourceKey: '2', title: 'B' });
+        const untouched = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#3', source: 'github', sourceKey: '3', title: 'C' });
+        repo.updateStatus(stuck1.id, 'in_progress');
+        repo.updateStatus(stuck2.id, 'waiting_input');
+
+        const marked = repo.markStuckAsFailed();
+        expect(marked.map(r => r.id).sort()).toEqual([stuck1.id, stuck2.id].sort());
+        expect(repo.getById(stuck1.id)!.status).toBe('failed');
+        expect(repo.getById(stuck2.id)!.status).toBe('failed');
+        expect(repo.getById(untouched.id)!.status).toBe('synced');
     });
 });

--- a/tests/requirement-run-repository.test.ts
+++ b/tests/requirement-run-repository.test.ts
@@ -105,4 +105,31 @@ describe('RequirementRunRepository', () => {
         expect(retry.status).toBe('running');
         expect(repo.listByRequirement('r1')).toHaveLength(2);
     });
+
+    it('listByStatuses queries across projects/requirements (启动扫描用)', () => {
+        const a = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1' });
+        const b = repo.create({ requirementId: 'r2', projectId: 'p2', engine: 'claude-code', sessionId: 's2' });
+        const c = repo.create({ requirementId: 'r3', projectId: 'p1', engine: 'claude-code', sessionId: 's3' });
+        repo.updateStatus(b.id, 'waiting_input');
+        repo.updateStatus(c.id, 'succeeded', { finished: true });
+
+        const stuck = repo.listByStatuses(['running', 'waiting_input']);
+        expect(stuck.map(r => r.id).sort()).toEqual([a.id, b.id].sort());
+    });
+
+    it('markStuckAsFailed 把 running/waiting_input 的 run 统一标 failed 并写 error_message（spec §5.6）', () => {
+        const stuck1 = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'claude-code', sessionId: 's1' });
+        const stuck2 = repo.create({ requirementId: 'r2', projectId: 'p1', engine: 'claude-code', sessionId: 's2' });
+        const untouched = repo.create({ requirementId: 'r3', projectId: 'p1', engine: 'claude-code', sessionId: 's3' });
+        repo.updateStatus(stuck2.id, 'waiting_input');
+        repo.updateStatus(untouched.id, 'succeeded', { finished: true });
+
+        const marked = repo.markStuckAsFailed('服务重启，执行中断');
+        expect(marked.map(r => r.id).sort()).toEqual([stuck1.id, stuck2.id].sort());
+        const fetched1 = repo.getById(stuck1.id)!;
+        expect(fetched1.status).toBe('failed');
+        expect(fetched1.errorMessage).toBe('服务重启，执行中断');
+        expect(fetched1.finishedAt).not.toBeNull();
+        expect(repo.getById(untouched.id)!.status).toBe('succeeded');
+    });
 });

--- a/tests/worktree-manager.test.ts
+++ b/tests/worktree-manager.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { WorktreeManager, escapeReqKey, branchNameFor, worktreePathFor } from '../src/core/worktree-manager.js';
+import type { Project } from '../src/core/project-repository.js';
+import type { Requirement } from '../src/core/requirement-repository.js';
+
+function fakeProject(dir: string): Project {
+    return {
+        id: 'p1', name: 'demo', dir, description: null, syncSource: 'github', syncConfig: null,
+        lastSyncedAt: null, maxConcurrentRuns: 2, skillsInstalledAt: null,
+        createdAt: '2026-01-01', updatedAt: '2026-01-01',
+    };
+}
+
+function fakeRequirement(reqKey: string): Requirement {
+    return {
+        id: 'r1', projectId: 'p1', reqKey, source: 'github', sourceKey: '42', title: 'demo requirement',
+        description: null, labels: [], status: 'queued', sourceUrl: null, sourceClosed: false,
+        createdAt: '2026-01-01', updatedAt: '2026-01-01',
+    };
+}
+
+describe('escapeReqKey / branchNameFor / worktreePathFor', () => {
+    it('escapes # to - and builds the branch/worktree names per spec §4.1/§4.2', () => {
+        expect(escapeReqKey('cmasterBot#42')).toBe('cmasterBot-42');
+        expect(branchNameFor('cmasterBot#42')).toBe('req/cmasterBot-42');
+        expect(worktreePathFor(fakeProject('/repo/cmasterBot'), 'cmasterBot#42'))
+            .toBe(path.join('/repo/cmasterBot', '.cmaster', 'worktrees', 'cmasterBot-42'));
+    });
+});
+
+describe('WorktreeManager (real git repo)', () => {
+    let repoDir: string;
+    let manager: WorktreeManager;
+
+    beforeEach(() => {
+        repoDir = mkdtempSync(path.join(tmpdir(), 'wtmgr-test-'));
+        execFileSync('git', ['init', '-q'], { cwd: repoDir });
+        execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoDir });
+        execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir });
+        execFileSync('git', ['commit', '--allow-empty', '-q', '-m', 'init'], { cwd: repoDir });
+        manager = new WorktreeManager();
+    });
+
+    afterEach(() => {
+        rmSync(repoDir, { recursive: true, force: true });
+    });
+
+    it('ensure() creates a new worktree + branch req/{escaped-req-key}', async () => {
+        const project = fakeProject(repoDir);
+        const requirement = fakeRequirement('demo#1');
+
+        const info = await manager.ensure(project, requirement);
+        expect(info.branch).toBe('req/demo-1');
+        expect(existsSync(info.path)).toBe(true);
+
+        const branches = execFileSync('git', ['branch', '--list', 'req/demo-1'], { cwd: repoDir, encoding: 'utf-8' });
+        expect(branches).toContain('req/demo-1');
+    });
+
+    it('ensure() reuses an existing worktree instead of recreating it (断点续跑)', async () => {
+        const project = fakeProject(repoDir);
+        const requirement = fakeRequirement('demo#2');
+
+        const first = await manager.ensure(project, requirement);
+        // 在 worktree 里写一个文件，模拟半成品现场
+        const { writeFileSync } = await import('fs');
+        writeFileSync(path.join(first.path, 'wip.txt'), 'half-done work');
+
+        const second = await manager.ensure(project, requirement);
+        expect(second.path).toBe(first.path);
+        expect(existsSync(path.join(second.path, 'wip.txt'))).toBe(true);
+    });
+
+    it('remove() deletes the worktree directory and local branch', async () => {
+        const project = fakeProject(repoDir);
+        const requirement = fakeRequirement('demo#3');
+
+        const info = await manager.ensure(project, requirement);
+        expect(existsSync(info.path)).toBe(true);
+
+        await manager.remove(project, requirement);
+        expect(existsSync(info.path)).toBe(false);
+        const branches = execFileSync('git', ['branch', '--list', 'req/demo-3'], { cwd: repoDir, encoding: 'utf-8' });
+        expect(branches).not.toContain('req/demo-3');
+    });
+
+    it('reset() removes and recreates the worktree (人工重置重来)', async () => {
+        const project = fakeProject(repoDir);
+        const requirement = fakeRequirement('demo#4');
+
+        const first = await manager.ensure(project, requirement);
+        const { writeFileSync } = await import('fs');
+        writeFileSync(path.join(first.path, 'wip.txt'), 'half-done work');
+
+        const reset = await manager.reset(project, requirement);
+        expect(reset.path).toBe(first.path);
+        expect(existsSync(path.join(reset.path, 'wip.txt'))).toBe(false);
+    });
+
+    it('exists() reflects worktree presence', async () => {
+        const project = fakeProject(repoDir);
+        const requirement = fakeRequirement('demo#5');
+        expect(manager.exists(project, requirement.reqKey)).toBe(false);
+        await manager.ensure(project, requirement);
+        expect(manager.exists(project, requirement.reqKey)).toBe(true);
+    });
+
+    it('pruneOrphans() removes worktrees not in the keep list', async () => {
+        const project = fakeProject(repoDir);
+        const keep = fakeRequirement('demo#6');
+        const orphan = fakeRequirement('demo#7');
+
+        const keepInfo = await manager.ensure(project, keep);
+        const orphanInfo = await manager.ensure(project, orphan);
+
+        const removed = await manager.pruneOrphans(project, [keep.reqKey]);
+        expect(removed).toEqual(['demo-7']);
+        expect(existsSync(keepInfo.path)).toBe(true);
+        expect(existsSync(orphanInfo.path)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

实施地图 [研发流程管理模块 实施地图 #61](https://github.com/yiyisf/masterBot/issues/61) 的 ticket [执行层基座 #64](https://github.com/yiyisf/masterBot/issues/64)。

- **WorktreeManager**（`src/core/worktree-manager.ts`）：`git worktree add/remove`，`.cmaster/worktrees/{req_key转义}/` 管理；`ensure()` 复用现有 worktree（断点续跑）、`reset()` 人工重置重来、`pruneOrphans()` 孤儿清理兜底
- **IAgentEngine 接口扩展**（`agent-engine.ts`）：新增 `EngineCapabilities`（`interactiveApproval`/`resume`）+ `EngineRunContext.cwd`/`approvalMode`；顺带修了一个 bug——`ClaudeAgentSdkEngine` 之前完全不读 `context.cwd`（只认 `spec.engineOptions.cwd`），现在 `context.cwd` 按 spec 要求优先
- **InterruptRelay**（`interrupt-relay.ts`）：SDK 的 `canUseTool`/MCP 工具 handler 是 SDK 内部调用的回调，不在 `run()` 的 async generator 主循环里，没法直接 `yield` —— 用一个单读者推送式队列桥接回主循环（`Promise.race` 合并 SDK 消息流与 relay 队列）
- **claude-sdk-engine 接入人机中断**：注入 `ask_user` MCP 工具（question 通道常开）；`approvalMode==='ask-on-risky'` 时沙箱判定的危险 Bash 命令转人工审批（approval 通道，默认关，直接 deny 不打扰人）
- **interrupt 双写**：`session_events` 新增 `interrupt_raised`/`interrupt_resolved` 类型；`AgentHarness` 在收到 `interrupt` 步骤时 emit raised；`interrupt-coordinator.ts` 的 `resolveInterrupt`/`cancelInterrupt` 写 resolved（`audit_approvals` 那半边已有现成逻辑，未改动）
- **RequirementExecutionService**（`requirement-execution-service.ts`）：发起研发编排——建 worktree → 建 `requirement_runs` 行 → 需求转 `in_progress` → 直接驱动 `ClaudeAgentSdkEngine.run()`（`cwd`=worktree 路径）→ 消费 `ExecutionStep` 流做状态同步（interrupt→`waiting_input`，恢复→`in_progress`，正常结束→`succeeded`+`implemented`，异常→`failed`）
- **启动扫描**：服务启动时把 `in_progress`/`waiting_input` 的需求与 run 统一标 `failed`（`requirement-repository.ts`/`requirement-run-repository.ts` 新增按状态跨项目查询 + `markStuckAsFailed`）
- **路由**：`POST /api/requirements/:id/start`（v1 仅默认 claude-code 引擎）+ `GET /api/requirements/:id/runs`；回答中断复用既有 `/api/sessions/:id/interrupt-response`（键控用的就是 `requirement_run.session_id`，天然通用）

### 已知的范围裁剪（留给后续 ticket，不影响本 ticket 验收）

- codex/opencode/pi 引擎接入（[#65](https://github.com/yiyisf/masterBot/issues/65)/[#66](https://github.com/yiyisf/masterBot/issues/66)）
- `maxConcurrentRuns` 排队/并发控制（spec §4.4）——v1 直接起跑，未做准入队列
- 重试/取消/核验合并路由——留给后续 ticket 或前端 ticket（[#67](https://github.com/yiyisf/masterBot/issues/67)）配套加

## Test plan

- [x] `npx vitest run` 全绿（349 个用例，含本次新增约 74 个：`WorktreeManager` 用真实临时 git 仓库测 `ensure`/`remove`/`reset`/`pruneOrphans`；`InterruptRelay` 队列语义；`claude-sdk-engine` 的 `capabilities`/`cwd` 优先级/`ask_user` 问答往返/`ask-on-risky` 审批 approve+reject 两条路径；`AgentHarness` 的 `interrupt_raised` emit；`interrupt-coordinator` 的 `session_events` 双写；repository 新方法；`RequirementExecutionService` 的完整状态机（正常结束/中途 interrupt/引擎异常/非法状态拒绝启动），含一个验证"interrupt 后立即可观察到 waiting_input（不是事后才生效）"的时序用例）
- [x] `npx tsc --noEmit` / `npm run build` 均无错误
- [x] 本地重复跑 3 次完整测试套件确认无 flaky（`data/cmaster.db` busy_timeout 修复后未再复现锁库）

按 wayfinder 实施地图约定，本 ticket resolve = 本 PR 合并进 master；合并后我会在 ticket #64 上记录决议并关闭。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>