### PR TITLE
feat(dev-workflow): codex 引擎接入（真实二进制实测 + 显式降级）

### DIFF
--- a/src/core/harness/codex-engine.ts
+++ b/src/core/harness/codex-engine.ts
@@ -3,20 +3,29 @@
  *
  * 驱动方式：`codex exec --json`（headless/结构化输出模式，非 PTY 全交互黑盒）。
  *
- * 实测记录（实施地图 #61 ticket #65）：用真实 codex-cli 0.39.0 二进制、极简只读 prompt
- * 实测确认了以下事实：
+ * 实测记录（实施地图 #61 ticket #65）：
+ *
+ * 第一轮，用真实 codex-cli 0.39.0 二进制、aicoding provider（测试账号无 API 额度，
+ * 402 Payment Required，只跑出了启动失败路径）：
  * - `codex exec --help` 不暴露 `-a/--ask-for-approval`（该参数只在交互式顶层 `codex` 命令下有效），
  *   非交互模式本就没有"运行中途转人工"的编程接口——印证 capabilities.interactiveApproval = false。
  * - `--json` 输出的 JSONL 里，前两行是配置回显（含 model/workdir/sandbox 等字段，无 `msg` 包装）
  *   和 prompt 回显（`{"prompt": "..."}`，同样无 `msg` 包装）；之后每行是
  *   `{"id": "<turn-id>", "msg": {"type": "<event-type>", ...}}` 的信封。
- * - 已验证的 `msg.type`：`task_started`（带 `model_context_window`）、`stream_error`（瞬时重试，
- *   非终态失败）、`error`（终态失败）。
- * - 受限于测试账号无可用 API 额度（402 Payment Required），未能跑出成功路径的完整事件序列——
- *   `agent_message`/`agent_reasoning`/`exec_command_begin`/`exec_command_end`/`task_complete`/
- *   `token_count` 等事件类型的字段名是基于 Codex 协议的一般性认知**推断**，不是实测确认。
- *   `_translateLine()` 对任何未识别的 `msg.type` 一律降级为 meta 步骤透出原始 payload
- *   （不静默丢弃），实测/真实调用时如与推断不符，据此调整映射即可，不影响整体骨架。
+ * - 确认 `msg.type`：`task_started`（带 `model_context_window`，可能是 null）、`stream_error`
+ *   （瞬时重试，非终态失败）、`error`（终态失败）。
+ *
+ * 第二轮，改用 `-c model_provider` 覆写指向一个 OpenAI 协议兼容、有真实额度的 provider
+ * （用户在 PR review 里指出并授权），跑出了完整的成功路径：
+ * - 确认 `agent_message`：`{"type":"agent_message","message":"pong"}`——字段名与第一轮的推断一致。
+ * - 确认 `token_count`：`{"type":"token_count","info":null}`——纯用量信息，不产出用户可见步骤。
+ * - **没有观察到 `task_complete` 事件**：成功路径就是 `task_started` → `agent_message` →
+ *   `token_count`，随后进程直接退出（exit code 0）——完成由进程退出信号，不是靠专门的事件。
+ *   下面仍保留 `task_complete` 分支作为兜底（万一更复杂/多轮场景里真的会出现），但不是必经路径。
+ * - `agent_reasoning`/`exec_command_begin`/`exec_command_end` 仍未观察到（这次的 prompt 刻意
+ *   要求不调用任何工具），字段名沿用第一轮基于 Codex 协议一般认知的推断，未经实测确认。
+ * `_translateLine()` 对任何未识别的 `msg.type` 一律降级为 meta 步骤透出原始 payload（不静默
+ * 丢弃），后续如与推断不符，据此调整映射即可，不影响整体骨架。
  */
 
 import { spawn } from 'child_process';
@@ -135,7 +144,7 @@ export class CodexEngine implements IAgentEngine {
 
         const msg = parsed.msg;
         switch (msg.type) {
-            // ── 已用真实二进制验证 ──
+            // ── 已用真实二进制验证（两轮实测，见文件头注释）──
             case 'task_started':
                 yield { type: 'meta', content: `codex 任务已启动（context window: ${msg.model_context_window ?? '-'}）`, timestamp: now() };
                 break;
@@ -150,8 +159,16 @@ export class CodexEngine implements IAgentEngine {
                 yield { type: 'meta', content: '❌ codex 执行失败', timestamp: now() };
                 break;
 
-            // ── 未用真实二进制验证，基于 Codex 协议一般认知推断（见文件头注释）──
             case 'agent_message':
+                if (typeof msg.message === 'string') {
+                    yield { type: 'content', content: msg.message, timestamp: now() };
+                }
+                break;
+
+            case 'token_count':
+                break; // 纯用量信息，不产出用户可见步骤
+
+            // ── 未用真实二进制验证，基于 Codex 协议一般认知推断（见文件头注释）──
             case 'agent_message_delta':
                 if (typeof msg.message === 'string') {
                     yield { type: 'content', content: msg.message, timestamp: now() };
@@ -187,9 +204,8 @@ export class CodexEngine implements IAgentEngine {
                 break;
             }
 
-            case 'token_count':
-                break; // 纯用量信息，不产出用户可见步骤
-
+            // 实测的成功路径里没有出现过这个事件（进程直接退出表示完成）；保留作为兜底，
+            // 以防更复杂/多轮场景里真的会有一个显式的完成事件
             case 'task_complete':
                 yield { type: 'answer', content: String(msg.last_agent_message ?? msg.message ?? ''), timestamp: now() };
                 yield { type: 'meta', content: '✅ codex 会话完成', timestamp: now() };

--- a/src/core/harness/codex-engine.ts
+++ b/src/core/harness/codex-engine.ts
@@ -1,0 +1,203 @@
+/**
+ * CodexEngine — 基于 codex CLI 的执行引擎（研发流程管理模块，spec §5.3/§5.5）
+ *
+ * 驱动方式：`codex exec --json`（headless/结构化输出模式，非 PTY 全交互黑盒）。
+ *
+ * 实测记录（实施地图 #61 ticket #65）：用真实 codex-cli 0.39.0 二进制、极简只读 prompt
+ * 实测确认了以下事实：
+ * - `codex exec --help` 不暴露 `-a/--ask-for-approval`（该参数只在交互式顶层 `codex` 命令下有效），
+ *   非交互模式本就没有"运行中途转人工"的编程接口——印证 capabilities.interactiveApproval = false。
+ * - `--json` 输出的 JSONL 里，前两行是配置回显（含 model/workdir/sandbox 等字段，无 `msg` 包装）
+ *   和 prompt 回显（`{"prompt": "..."}`，同样无 `msg` 包装）；之后每行是
+ *   `{"id": "<turn-id>", "msg": {"type": "<event-type>", ...}}` 的信封。
+ * - 已验证的 `msg.type`：`task_started`（带 `model_context_window`）、`stream_error`（瞬时重试，
+ *   非终态失败）、`error`（终态失败）。
+ * - 受限于测试账号无可用 API 额度（402 Payment Required），未能跑出成功路径的完整事件序列——
+ *   `agent_message`/`agent_reasoning`/`exec_command_begin`/`exec_command_end`/`task_complete`/
+ *   `token_count` 等事件类型的字段名是基于 Codex 协议的一般性认知**推断**，不是实测确认。
+ *   `_translateLine()` 对任何未识别的 `msg.type` 一律降级为 meta 步骤透出原始 payload
+ *   （不静默丢弃），实测/真实调用时如与推断不符，据此调整映射即可，不影响整体骨架。
+ */
+
+import { spawn } from 'child_process';
+import { createInterface } from 'readline';
+import type { ExecutionStep, Logger } from '../../types.js';
+import type { IAgentEngine, EngineRunContext, EngineCapabilities } from './agent-engine.js';
+
+export interface CodexEngineOptions {
+    /** 工作目录（默认 process.cwd()）*/
+    cwd?: string;
+    /** codex 可执行文件路径/名（默认 'codex'；测试用可注入 fake 脚本）*/
+    binaryPath?: string;
+    /** 沙箱策略（默认 workspace-write，与 spec §5.3 一致）*/
+    sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+}
+
+interface CodexJsonLine {
+    msg?: { type: string; [key: string]: unknown };
+    model?: string;
+    workdir?: string;
+    sandbox?: string;
+    [key: string]: unknown;
+}
+
+export class CodexEngine implements IAgentEngine {
+    readonly kind = 'codex' as const;
+    // codex exec 非交互模式无编程式转人工的接口（-a/--ask-for-approval 只在交互式顶层命令下有效，
+    // 已实测确认 `codex exec --help` 不暴露该参数）；不做 PTY 文本匹配兜底（spec §5.5）；v1 无 resume
+    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: false };
+
+    constructor(private logger: Logger, private options: CodexEngineOptions = {}) {}
+
+    async *run(input: string, context: EngineRunContext): AsyncGenerator<ExecutionStep> {
+        const cwd = context.cwd ?? this.options.cwd ?? process.cwd();
+        const binary = this.options.binaryPath ?? 'codex';
+        const sandbox = this.options.sandbox ?? 'workspace-write';
+        const args = ['exec', '--json', '--sandbox', sandbox, '--skip-git-repo-check', input];
+
+        this.logger.info(`[codex-engine] Starting "${binary} exec" (cwd: ${cwd}, sandbox: ${sandbox})`);
+
+        const child = spawn(binary, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+
+        const onAbort = () => child.kill();
+        if (context.abortSignal) {
+            if (context.abortSignal.aborted) child.kill();
+            else context.abortSignal.addEventListener('abort', onAbort, { once: true });
+        }
+
+        let stderrBuf = '';
+        child.stderr?.on('data', (d: Buffer) => { stderrBuf += d.toString('utf-8'); });
+
+        let spawnError: Error | undefined;
+        child.on('error', (err: NodeJS.ErrnoException) => {
+            // ENOENT 在这里可能是 codex 二进制未找到，也可能是 cwd 本身不存在（worktree 被意外删除）
+            spawnError = err.code === 'ENOENT'
+                ? new Error(`无法启动 codex（可执行文件 "${binary}" 未找到，或工作目录不存在：${cwd}）`)
+                : err;
+        });
+
+        // 先挂 close 监听再开始读 stdout，避免子进程在读完之前就已退出导致的竞态。
+        // 被信号杀死（如 abort 触发 kill()）时 code 是 null、signal 非空——不能用 `code ?? 0`
+        // 简单归零，否则会把"被中止"误判为"正常退出成功"。
+        let exitCode: number | null = null;
+        let exitSignal: NodeJS.Signals | null = null;
+        const closePromise = new Promise<void>((resolve) => {
+            child.on('close', (code, signal) => { exitCode = code; exitSignal = signal; resolve(); });
+        });
+
+        if (child.stdout) {
+            const rl = createInterface({ input: child.stdout });
+            try {
+                for await (const line of rl) {
+                    if (!line.trim()) continue;
+                    yield* this._translateLine(line);
+                }
+            } finally {
+                rl.close();
+            }
+        }
+
+        await closePromise;
+        if (context.abortSignal) context.abortSignal.removeEventListener('abort', onAbort);
+
+        if (spawnError) throw spawnError;
+        if (exitSignal) {
+            throw new Error(`codex exec terminated by signal ${exitSignal}${context.abortSignal?.aborted ? ' (aborted)' : ''}`);
+        }
+        if (exitCode !== 0) {
+            throw new Error(`codex exec exited with code ${exitCode}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`);
+        }
+    }
+
+    // ─────────────────────────────── private ───────────────────────────────
+
+    private *_translateLine(raw: string): Generator<ExecutionStep> {
+        let parsed: CodexJsonLine;
+        try {
+            parsed = JSON.parse(raw);
+        } catch {
+            return; // --json 模式下不应出现非 JSON 行；容错跳过而非整体失败
+        }
+
+        const now = () => new Date();
+
+        // 前两行（配置回显 / prompt 回显）没有 msg 包装（实测确认）
+        if (!parsed.msg) {
+            if (parsed.workdir !== undefined || parsed.sandbox !== undefined) {
+                yield {
+                    type: 'meta',
+                    content: `🚀 codex 会话已启动（model: ${parsed.model ?? '-'}, sandbox: ${parsed.sandbox ?? '-'}）`,
+                    timestamp: now(),
+                };
+            }
+            return;
+        }
+
+        const msg = parsed.msg;
+        switch (msg.type) {
+            // ── 已用真实二进制验证 ──
+            case 'task_started':
+                yield { type: 'meta', content: `codex 任务已启动（context window: ${msg.model_context_window ?? '-'}）`, timestamp: now() };
+                break;
+
+            case 'stream_error':
+                // 瞬时重试（内部已在重试），非终态失败，不中断执行
+                yield { type: 'meta', content: `⚠️ codex 流错误（重试中）：${String(msg.message ?? '')}`, timestamp: now() };
+                break;
+
+            case 'error':
+                yield { type: 'answer', content: String(msg.message ?? '未知错误'), timestamp: now() };
+                yield { type: 'meta', content: '❌ codex 执行失败', timestamp: now() };
+                break;
+
+            // ── 未用真实二进制验证，基于 Codex 协议一般认知推断（见文件头注释）──
+            case 'agent_message':
+            case 'agent_message_delta':
+                if (typeof msg.message === 'string') {
+                    yield { type: 'content', content: msg.message, timestamp: now() };
+                }
+                break;
+
+            case 'agent_reasoning':
+            case 'agent_reasoning_delta':
+                if (typeof msg.text === 'string') {
+                    yield { type: 'thought', content: msg.text, timestamp: now() };
+                }
+                break;
+
+            case 'exec_command_begin': {
+                const command = Array.isArray(msg.command) ? msg.command.join(' ') : String(msg.command ?? '');
+                yield {
+                    type: 'action',
+                    content: `执行命令：${command}`,
+                    toolName: 'Bash',
+                    toolInput: { command },
+                    timestamp: now(),
+                };
+                break;
+            }
+
+            case 'exec_command_end': {
+                const out = String(msg.stdout ?? msg.output ?? '');
+                yield {
+                    type: 'observation',
+                    content: out.length > 2000 ? out.slice(0, 2000) + `\n...[截断，共 ${out.length} 字符]` : out,
+                    timestamp: now(),
+                };
+                break;
+            }
+
+            case 'token_count':
+                break; // 纯用量信息，不产出用户可见步骤
+
+            case 'task_complete':
+                yield { type: 'answer', content: String(msg.last_agent_message ?? msg.message ?? ''), timestamp: now() };
+                yield { type: 'meta', content: '✅ codex 会话完成', timestamp: now() };
+                break;
+
+            default:
+                // 未识别的事件类型：不静默丢弃，以 meta 形式透出原始 payload
+                yield { type: 'meta', content: `[codex:${msg.type}] ${JSON.stringify(msg).slice(0, 500)}`, timestamp: now() };
+        }
+    }
+}

--- a/src/core/requirement-execution-service.ts
+++ b/src/core/requirement-execution-service.ts
@@ -5,6 +5,7 @@ import { requirementRepository, type RequirementRepository, type Requirement } f
 import { requirementRunRepository, type RequirementRunRepository, type RequirementRun } from './requirement-run-repository.js';
 import { worktreeManager, type WorktreeManager } from './worktree-manager.js';
 import { ClaudeAgentSdkEngine } from './harness/claude-sdk-engine.js';
+import { CodexEngine } from './harness/codex-engine.js';
 import type { IAgentEngine } from './harness/agent-engine.js';
 import { defaultAgentSpec, type AgentSpec } from './harness/agent-spec.js';
 
@@ -15,10 +16,20 @@ const noopMemory: MemoryAccess = {
     async search() { return []; },
 };
 
-/** v1 只支持默认 claude-code 引擎；codex/opencode/pi 留给后续 ticket（实施地图 #61 #65/#66） */
+/** opencode/pi 留给后续 ticket（实施地图 #61 #66） */
+export type ExecutionEngineKind = 'claude-code' | 'codex';
+
 const STARTABLE_STATUSES: Requirement['status'][] = ['synced', 'queued', 'failed'];
 
+/** ExecutionEngineKind → requirement_runs.engine 列存的值（对齐 AgentEngineKind） */
+const RUN_ENGINE_LABEL: Record<ExecutionEngineKind, string> = {
+    'claude-code': 'claude-agent-sdk',
+    codex: 'codex',
+};
+
 export interface StartRunOptions {
+    /** 默认 claude-code；codex 无 interactiveApproval，approvalMode 对其无效（spec §5.5） */
+    engine?: ExecutionEngineKind;
     approvalMode?: 'auto' | 'ask-on-risky';
 }
 
@@ -28,8 +39,8 @@ export interface RequirementExecutionServiceDeps {
     runs?: RequirementRunRepository;
     worktree?: WorktreeManager;
     logger?: Logger;
-    /** 依赖注入：测试用 fake engine 替换真实 SDK 引擎 */
-    createEngine?: (spec: AgentSpec, logger: Logger) => IAgentEngine;
+    /** 依赖注入：测试用 fake engine 替换真实引擎 */
+    createEngine?: (engineKind: ExecutionEngineKind, spec: AgentSpec, logger: Logger) => IAgentEngine;
 }
 
 const consoleLogger: Logger = {
@@ -52,7 +63,7 @@ export class RequirementExecutionService {
     private runs: RequirementRunRepository;
     private worktree: WorktreeManager;
     private logger: Logger;
-    private createEngine: (spec: AgentSpec, logger: Logger) => IAgentEngine;
+    private createEngine: (engineKind: ExecutionEngineKind, spec: AgentSpec, logger: Logger) => IAgentEngine;
 
     constructor(deps: RequirementExecutionServiceDeps = {}) {
         this.projects = deps.projects ?? projectRepository;
@@ -60,7 +71,10 @@ export class RequirementExecutionService {
         this.runs = deps.runs ?? requirementRunRepository;
         this.worktree = deps.worktree ?? worktreeManager;
         this.logger = deps.logger ?? consoleLogger;
-        this.createEngine = deps.createEngine ?? ((spec, logger) => new ClaudeAgentSdkEngine(spec, logger, {}));
+        this.createEngine = deps.createEngine ?? ((engineKind, spec, logger) =>
+            engineKind === 'codex'
+                ? new CodexEngine(logger, {})
+                : new ClaudeAgentSdkEngine(spec, logger, {}));
     }
 
     /**
@@ -76,12 +90,13 @@ export class RequirementExecutionService {
         const project = this.projects.getById(requirement.projectId);
         if (!project) throw new Error(`Project not found: ${requirement.projectId}`);
 
+        const engineKind = options.engine ?? 'claude-code';
         const { path: worktreePath, branch } = await this.worktree.ensure(project, requirement);
         const sessionId = nanoid();
         const run = this.runs.create({
             requirementId: requirement.id,
             projectId: project.id,
-            engine: 'claude-agent-sdk',
+            engine: RUN_ENGINE_LABEL[engineKind],
             sessionId,
             worktreePath,
             branch,
@@ -111,7 +126,7 @@ export class RequirementExecutionService {
                 '请实现该需求、提交代码并开 PR。若需要澄清需求或做出只有人类才能决定的选择，调用 ask_user 工具向人类提问。',
             ].filter(Boolean).join('\n\n'),
         });
-        const engine = this.createEngine(spec, this.logger);
+        const engine = this.createEngine(options.engine ?? 'claude-code', spec, this.logger);
         const task = `实现需求 ${requirement.reqKey}：${requirement.title}`;
 
         let awaitingResume = false;

--- a/src/gateway/routes/requirements.ts
+++ b/src/gateway/routes/requirements.ts
@@ -68,12 +68,13 @@ export async function registerRequirementRoutes(app: FastifyInstance, deps: Gate
         return requirement;
     });
 
-    // 发起研发（v1 仅默认 claude-code 引擎；点火即走，异步执行，状态变化通过 requirement/run 轮询）
-    app.post<{ Params: { id: string }; Body: { approvalMode?: 'auto' | 'ask-on-risky' } }>(
+    // 发起研发（默认 claude-code 引擎，可选 codex；点火即走，异步执行，状态变化通过 requirement/run 轮询）
+    app.post<{ Params: { id: string }; Body: { engine?: 'claude-code' | 'codex'; approvalMode?: 'auto' | 'ask-on-risky' } }>(
         '/api/requirements/:id/start',
         async (request, reply) => {
             try {
                 const result = await requirementExecutionService.start(request.params.id, {
+                    engine: request.body?.engine,
                     approvalMode: request.body?.approvalMode,
                 });
                 reply.status(202);

--- a/tests/codex-engine.test.ts
+++ b/tests/codex-engine.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, chmodSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { CodexEngine } from '../src/core/harness/codex-engine.js';
+import type { ExecutionStep, Logger, MemoryAccess } from '../src/types.js';
+
+const mockLogger: Logger = { debug() {}, info() {}, warn() {}, error() {} };
+const mockMemory: MemoryAccess = { get: async () => undefined, set: async () => {}, search: async () => [] };
+
+let tmpDir: string;
+let fakeBinPath: string;
+
+async function drain(gen: AsyncGenerator<ExecutionStep>): Promise<ExecutionStep[]> {
+    const steps: ExecutionStep[] = [];
+    for await (const s of gen) steps.push(s);
+    return steps;
+}
+
+beforeAll(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'fake-codex-'));
+    fakeBinPath = path.join(tmpDir, 'fake-codex.cjs');
+    writeFileSync(fakeBinPath, `#!/usr/bin/env node
+const fs = require('fs');
+if (process.env.FAKE_CODEX_ARGS_FILE) {
+    fs.writeFileSync(process.env.FAKE_CODEX_ARGS_FILE, JSON.stringify(process.argv.slice(2)));
+}
+const output = process.env.FAKE_CODEX_OUTPUT || '';
+if (output) process.stdout.write(output);
+const stderrOut = process.env.FAKE_CODEX_STDERR || '';
+if (stderrOut) process.stderr.write(stderrOut);
+process.exitCode = parseInt(process.env.FAKE_CODEX_EXIT_CODE || '0', 10);
+`);
+    chmodSync(fakeBinPath, 0o755);
+});
+
+afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+    delete process.env.FAKE_CODEX_OUTPUT;
+    delete process.env.FAKE_CODEX_STDERR;
+    delete process.env.FAKE_CODEX_EXIT_CODE;
+    delete process.env.FAKE_CODEX_ARGS_FILE;
+});
+
+describe('CodexEngine', () => {
+    it('capabilities: interactiveApproval=false, resume=false（显式降级，spec §5.5）', () => {
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
+    });
+
+    it('拼装的 CLI 参数包含 exec/--json/--sandbox/--skip-git-repo-check 与 prompt（不含 -a/--ask-for-approval，实测确认 exec 不支持该参数）', async () => {
+        const argsFile = path.join(tmpDir, 'args.json');
+        process.env.FAKE_CODEX_ARGS_FILE = argsFile;
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sandbox: 'read-only' });
+        await drain(engine.run('implement X', { sessionId: 's8', memory: mockMemory, cwd: tmpDir }));
+        const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+        expect(args).toEqual(['exec', '--json', '--sandbox', 'read-only', '--skip-git-repo-check', 'implement X']);
+    });
+
+    it('解析真实实测过的事件形状：配置回显 → meta，task_started → meta（实施地图 #61 ticket #65 实测记录）', async () => {
+        process.env.FAKE_CODEX_OUTPUT = [
+            JSON.stringify({ approval: 'never', model: 'gpt-5', workdir: '/tmp', provider: 'aicoding', sandbox: 'workspace-write' }),
+            JSON.stringify({ prompt: 'do the task' }),
+            JSON.stringify({ id: '0', msg: { type: 'task_started', model_context_window: 272000 } }),
+        ].join('\n') + '\n';
+
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const steps = await drain(engine.run('do the task', { sessionId: 's1', memory: mockMemory }));
+
+        expect(steps).toHaveLength(2);
+        expect(steps[0].type).toBe('meta');
+        expect(steps[0].content).toContain('gpt-5');
+        expect(steps[1].content).toContain('272000');
+    });
+
+    it('stream_error 视为瞬时警告（meta，不中断），error 视为终态失败（answer+meta）——均实测确认', async () => {
+        process.env.FAKE_CODEX_OUTPUT = [
+            JSON.stringify({ id: '0', msg: { type: 'stream_error', message: '402 Payment Required' } }),
+            JSON.stringify({ id: '0', msg: { type: 'error', message: 'unexpected status 402' } }),
+        ].join('\n') + '\n';
+
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const steps = await drain(engine.run('task', { sessionId: 's2', memory: mockMemory }));
+
+        expect(steps.some(s => s.type === 'meta' && s.content.includes('重试中'))).toBe(true);
+        expect(steps.some(s => s.type === 'answer' && s.content.includes('402'))).toBe(true);
+    });
+
+    it('未识别的事件类型不静默丢弃，降级为 meta 透出原始 payload', async () => {
+        process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'some_future_event', foo: 'bar' } }) + '\n';
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const steps = await drain(engine.run('task', { sessionId: 's3', memory: mockMemory }));
+        expect(steps).toHaveLength(1);
+        expect(steps[0].content).toContain('some_future_event');
+        expect(steps[0].content).toContain('bar');
+    });
+
+    it('非 JSON 行被容错跳过，不中断整体解析', async () => {
+        process.env.FAKE_CODEX_OUTPUT = [
+            'not json at all',
+            JSON.stringify({ id: '0', msg: { type: 'task_started', model_context_window: 1000 } }),
+        ].join('\n') + '\n';
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const steps = await drain(engine.run('task', { sessionId: 's3b', memory: mockMemory }));
+        expect(steps).toHaveLength(1);
+        expect(steps[0].content).toContain('1000');
+    });
+
+    it('推断事件映射（未实测，基于协议一般认知）：agent_message→content, agent_reasoning→thought, exec_command_begin/end→action/observation, token_count 静默, task_complete→answer+meta', async () => {
+        process.env.FAKE_CODEX_OUTPUT = [
+            JSON.stringify({ id: '0', msg: { type: 'agent_reasoning', text: '思考中...' } }),
+            JSON.stringify({ id: '0', msg: { type: 'agent_message', message: '我来处理这个任务' } }),
+            JSON.stringify({ id: '0', msg: { type: 'exec_command_begin', command: ['ls', '-la'] } }),
+            JSON.stringify({ id: '0', msg: { type: 'exec_command_end', stdout: 'file1\nfile2' } }),
+            JSON.stringify({ id: '0', msg: { type: 'token_count', input_tokens: 100 } }),
+            JSON.stringify({ id: '0', msg: { type: 'task_complete', last_agent_message: '完成了' } }),
+        ].join('\n') + '\n';
+
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const steps = await drain(engine.run('task', { sessionId: 's4', memory: mockMemory }));
+
+        expect(steps.find(s => s.type === 'thought')?.content).toBe('思考中...');
+        expect(steps.find(s => s.type === 'content')?.content).toBe('我来处理这个任务');
+        const action = steps.find(s => s.type === 'action');
+        expect(action?.toolName).toBe('Bash');
+        expect(action?.content).toContain('ls -la');
+        expect(steps.find(s => s.type === 'observation')?.content).toContain('file1');
+        expect(steps.some(s => s.content?.includes('input_tokens'))).toBe(false);
+        expect(steps.find(s => s.type === 'answer')?.content).toBe('完成了');
+    });
+
+    it('非零退出码抛错，携带 stderr', async () => {
+        process.env.FAKE_CODEX_EXIT_CODE = '1';
+        process.env.FAKE_CODEX_STDERR = 'boom';
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        await expect(drain(engine.run('task', { sessionId: 's5', memory: mockMemory })))
+            .rejects.toThrow(/exited with code 1/);
+    });
+
+    it('可执行文件不存在时给出清晰错误（不是裸 ENOENT）', async () => {
+        const engine = new CodexEngine(mockLogger, { binaryPath: path.join(tmpDir, 'does-not-exist-binary') });
+        await expect(drain(engine.run('task', { sessionId: 's6', memory: mockMemory })))
+            .rejects.toThrow(/未找到/);
+    });
+
+    it('abortSignal 触发时终止子进程，不会一直挂起', async () => {
+        const slowScript = path.join(tmpDir, 'slow-codex.cjs');
+        writeFileSync(slowScript, `#!/usr/bin/env node\nsetTimeout(() => { process.exit(0); }, 30000);\n`);
+        chmodSync(slowScript, 0o755);
+
+        const engine = new CodexEngine(mockLogger, { binaryPath: slowScript });
+        const controller = new AbortController();
+        const runPromise = drain(engine.run('task', { sessionId: 's7', memory: mockMemory, abortSignal: controller.signal }));
+
+        controller.abort();
+        // kill 后进程以信号终止（非 0 退出码），run() 应该 reject 而不是永久挂起
+        await expect(runPromise).rejects.toThrow();
+    });
+});

--- a/tests/codex-engine.test.ts
+++ b/tests/codex-engine.test.ts
@@ -89,6 +89,33 @@ describe('CodexEngine', () => {
         expect(steps.some(s => s.type === 'answer' && s.content.includes('402'))).toBe(true);
     });
 
+    it('完整成功路径（第二轮实测，改用 OpenAI 兼容 provider 拿到真实额度）：task_started → agent_message → token_count，无 task_complete', async () => {
+        // 真实抓到的 JSONL（prompt: "Just reply with the single word: pong."）：
+        // {"id":"0","msg":{"type":"task_started","model_context_window":null}}
+        // {"id":"0","msg":{"type":"agent_message","message":"pong"}}
+        // {"id":"0","msg":{"type":"token_count","info":null}}
+        // 进程随后直接退出（code 0）——完成靠进程退出，不是靠专门的事件。
+        process.env.FAKE_CODEX_OUTPUT = [
+            JSON.stringify({ workdir: '/repo', provider: 'mistral_probe', approval: 'never', sandbox: 'read-only', model: 'mistral-large-latest' }),
+            JSON.stringify({ prompt: 'Just reply with the single word: pong. Do not run any commands.' }),
+            JSON.stringify({ id: '0', msg: { type: 'task_started', model_context_window: null } }),
+            JSON.stringify({ id: '0', msg: { type: 'agent_message', message: 'pong' } }),
+            JSON.stringify({ id: '0', msg: { type: 'token_count', info: null } }),
+        ].join('\n') + '\n';
+
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const steps = await drain(engine.run('Just reply with the single word: pong.', { sessionId: 's1b', memory: mockMemory }));
+
+        // 配置回显 1 条 meta（prompt 回显不产出）+ task_started 1 条 meta + agent_message 1 条
+        // content（token_count 不产出步骤）= 3 步
+        expect(steps).toHaveLength(3);
+        expect(steps[0].type).toBe('meta');
+        expect(steps[0].content).toContain('mistral-large-latest');
+        expect(steps[1]).toMatchObject({ type: 'meta' });
+        expect(steps[1].content).toContain('context window: -'); // model_context_window: null → '-'
+        expect(steps[2]).toMatchObject({ type: 'content', content: 'pong' });
+    });
+
     it('未识别的事件类型不静默丢弃，降级为 meta 透出原始 payload', async () => {
         process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'some_future_event', foo: 'bar' } }) + '\n';
         const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
@@ -109,13 +136,11 @@ describe('CodexEngine', () => {
         expect(steps[0].content).toContain('1000');
     });
 
-    it('推断事件映射（未实测，基于协议一般认知）：agent_message→content, agent_reasoning→thought, exec_command_begin/end→action/observation, token_count 静默, task_complete→answer+meta', async () => {
+    it('推断事件映射（仍未实测——两轮实测的 prompt 都没有触发工具调用/多轮）：agent_reasoning→thought, exec_command_begin/end→action/observation, task_complete→answer+meta（未在真实成功路径里出现，兜底分支）', async () => {
         process.env.FAKE_CODEX_OUTPUT = [
             JSON.stringify({ id: '0', msg: { type: 'agent_reasoning', text: '思考中...' } }),
-            JSON.stringify({ id: '0', msg: { type: 'agent_message', message: '我来处理这个任务' } }),
             JSON.stringify({ id: '0', msg: { type: 'exec_command_begin', command: ['ls', '-la'] } }),
             JSON.stringify({ id: '0', msg: { type: 'exec_command_end', stdout: 'file1\nfile2' } }),
-            JSON.stringify({ id: '0', msg: { type: 'token_count', input_tokens: 100 } }),
             JSON.stringify({ id: '0', msg: { type: 'task_complete', last_agent_message: '完成了' } }),
         ].join('\n') + '\n';
 
@@ -123,12 +148,10 @@ describe('CodexEngine', () => {
         const steps = await drain(engine.run('task', { sessionId: 's4', memory: mockMemory }));
 
         expect(steps.find(s => s.type === 'thought')?.content).toBe('思考中...');
-        expect(steps.find(s => s.type === 'content')?.content).toBe('我来处理这个任务');
         const action = steps.find(s => s.type === 'action');
         expect(action?.toolName).toBe('Bash');
         expect(action?.content).toContain('ls -la');
         expect(steps.find(s => s.type === 'observation')?.content).toContain('file1');
-        expect(steps.some(s => s.content?.includes('input_tokens'))).toBe(false);
         expect(steps.find(s => s.type === 'answer')?.content).toBe('完成了');
     });
 

--- a/tests/requirement-execution-service.test.ts
+++ b/tests/requirement-execution-service.test.ts
@@ -84,7 +84,7 @@ describe('RequirementExecutionService', () => {
         projectId = projects.create({ name: 'cmasterBot', dir: '/repo/cmasterBot' }).id;
     });
 
-    function makeService(createEngine: (spec: any, logger: any) => IAgentEngine) {
+    function makeService(createEngine: (engineKind: any, spec: any, logger: any) => IAgentEngine) {
         return new RequirementExecutionService({
             projects, requirements, runs, worktree,
             logger: { debug() {}, info() {}, warn() {}, error() {} },
@@ -231,5 +231,27 @@ describe('RequirementExecutionService', () => {
         const { runId } = await service.start(requirement.id);
         expect(runId).toBeTruthy();
         expect(worktree.ensure).toHaveBeenCalled();
+    });
+
+    it('start() 默认引擎为 claude-code，run.engine 记为 claude-agent-sdk', async () => {
+        const createEngine = vi.fn(() => engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]));
+        const service = makeService(createEngine);
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#8', source: 'github', sourceKey: '8', title: 'Add feature',
+        });
+        const { runId } = await service.start(requirement.id);
+        expect(createEngine).toHaveBeenCalledWith('claude-code', expect.anything(), expect.anything());
+        expect(runs.getById(runId)!.engine).toBe('claude-agent-sdk');
+    });
+
+    it('start({ engine: "codex" }) 走 codex 分支，run.engine 记为 codex', async () => {
+        const createEngine = vi.fn(() => engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]));
+        const service = makeService(createEngine);
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#9', source: 'github', sourceKey: '9', title: 'Add feature',
+        });
+        const { runId } = await service.start(requirement.id, { engine: 'codex' });
+        expect(createEngine).toHaveBeenCalledWith('codex', expect.anything(), expect.anything());
+        expect(runs.getById(runId)!.engine).toBe('codex');
     });
 });


### PR DESCRIPTION
## Summary

实施地图 [研发流程管理模块 实施地图 #61](https://github.com/yiyisf/masterBot/issues/61) 的 ticket [codex 引擎接入 #65](https://github.com/yiyisf/masterBot/issues/65)。

- **CodexEngine**（`src/core/harness/codex-engine.ts`）：驱动 `codex exec --json`，用 `readline` 逐行解析 JSONL 输出 → `ExecutionStep`。`capabilities = { interactiveApproval: false, resume: false }`（显式降级，spec §5.5）；不做 PTY 文本匹配兜底。
- **接入 `RequirementExecutionService`**：`StartRunOptions` 新增 `engine?: 'claude-code' | 'codex'`（默认 `claude-code`），`createEngine` 工厂按 `engineKind` 分派；`POST /api/requirements/:id/start` 路由透传 `engine` 参数；`requirement_runs.engine` 列正确记录实际使用的引擎。

### 真实二进制实测记录（本仓库已安装 codex-cli 0.39.0）

用一个极简、只读、几乎零成本的 prompt 跑了 `codex exec --json`，确认了：
- `codex exec --help` **不暴露** `-a/--ask-for-approval`（该参数只在交互式顶层 `codex` 命令下有效）——印证非交互模式本就没有编程式转人工的接口，`interactiveApproval: false` 是对的，不是保守估计。
- `--json` 输出的 JSONL 形状：前两行是配置回显（`model`/`workdir`/`sandbox` 等字段，无 `msg` 包装）和 prompt 回显（`{"prompt": "..."}`），之后每行是 `{"id": "<turn-id>", "msg": {"type": "<event-type>", ...}}` 的信封。
- 已验证的 `msg.type`：`task_started`（带 `model_context_window`）、`stream_error`（瞬时重试，非终态）、`error`（终态失败）。

**受限于测试账号无可用 API 额度**（`402 Payment Required`），没能跑出成功路径的完整事件序列——`agent_message`/`agent_reasoning`/`exec_command_begin`/`exec_command_end`/`task_complete`/`token_count` 等事件类型是基于 Codex 协议一般性认知**推断**的，不是实测确认。代码里已用注释明确区分"已实测"和"推断"两部分；`_translateLine()` 对任何未识别的 `msg.type` 一律降级为 `meta` 步骤透出原始 payload（不静默丢弃），后续拿到可用额度实测后，如与推断不符，照着调整映射即可，不影响整体骨架。这个决策是和用户一起过的（详见 ticket #65 讨论）。

## Test plan

- [x] `npx vitest run` 全绿（370 个用例，含本次新增 12 个：`CodexEngine` 用一个可控的 fake 二进制脚本覆盖 capabilities/CLI 参数拼装/已实测事件解析/未识别事件降级/非 JSON 行容错/非零退出码/二进制未找到/abortSignal 终止子进程；`RequirementExecutionService` 新增 2 个用例验证 engine 参数分派与 `requirement_runs.engine` 落库）
- [x] `npx tsc --noEmit` / `npm run build` 均无错误
- [x] 本地重复跑 3 次完整测试套件确认无 flaky
- [x] 顺带修了一个真实 bug：codex 子进程被信号杀死（如 abort）时 exit code 是 `null`，之前 `code ?? 0` 会把"被中止"误判为"正常退出成功"

按 wayfinder 实施地图约定，本 ticket resolve = 本 PR 合并进 master；合并后我会在 ticket #65 上记录决议并关闭。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>