### PR TITLE
feat(dev-workflow): /projects 看板页 + 配套后端路由（重试/取消/核验合并/执行时间线）

### DIFF
--- a/src/core/harness/codex-engine.ts
+++ b/src/core/harness/codex-engine.ts
@@ -26,6 +26,11 @@
  *   要求不调用任何工具），字段名沿用第一轮基于 Codex 协议一般认知的推断，未经实测确认。
  * `_translateLine()` 对任何未识别的 `msg.type` 一律降级为 meta 步骤透出原始 payload（不静默
  * 丢弃），后续如与推断不符，据此调整映射即可，不影响整体骨架。
+ *
+ * 防御性修复（研发流程管理 ticket #67 联调时在 opencode 引擎上真实踩中同一类 bug 后回头排查）：
+ * `codex exec --help` 同样暴露 `-C/--cd <DIR>`（"Tell the agent to use the specified
+ * directory as its working root"），说明 codex 内部可能不是单纯依赖进程级 cwd 判定工作目录。
+ * 之前只靠 `child_process.spawn()` 的 `cwd` 选项，现在显式加上 `-C`，两边双保险。
  */
 
 import { spawn } from 'child_process';
@@ -62,7 +67,10 @@ export class CodexEngine implements IAgentEngine {
         const cwd = context.cwd ?? this.options.cwd ?? process.cwd();
         const binary = this.options.binaryPath ?? 'codex';
         const sandbox = this.options.sandbox ?? 'workspace-write';
-        const args = ['exec', '--json', '--sandbox', sandbox, '--skip-git-repo-check', input];
+        // -C/--cd 显式声明"working root"（同一类问题在 opencode 引擎上被真实用例踩中过：
+        // 只靠 spawn() 的 cwd 选项，工具自己内部的目录解析可能不认——codex --help 里这个参数
+        // 的说明原文就是 "Tell the agent to use the specified directory as its working root"）
+        const args = ['exec', '--json', '--sandbox', sandbox, '--skip-git-repo-check', '-C', cwd, input];
 
         this.logger.info(`[codex-engine] Starting "${binary} exec" (cwd: ${cwd}, sandbox: ${sandbox})`);
 

--- a/src/core/harness/opencode-engine.ts
+++ b/src/core/harness/opencode-engine.ts
@@ -23,6 +23,13 @@
  * - `error`（认证失败等场景实测确认）：`{"type":"error","timestamp":...,"sessionID":...,
  *   "error":{"name":"APIError","data":{"message":...,"statusCode":...}}}`，无 `part` 字段。
  * - 进程退出码：成功 0，认证/模型错误时非 0（沿用"非零退出码即失败"的通用判定）。
+ *
+ * 真实使用中发现的 bug（研发流程管理 ticket #67 联调反馈，非本文件原实测环境能复现——
+ * 复现环境本机后台已有一个 opencode server/session 在跑）：opencode 是 daemon 式架构，
+ * `opencode run` 可能自动发现并复用本机已在跑的 server，而不是在给定 cwd 里新起一个；
+ * 此时 `child_process.spawn()` 的 `cwd` 选项只影响新 spawn 出来的这个客户端进程，管不到
+ * 被复用的那个 server 进程，导致实际操作目录/需求都不对。修复：显式传 `--dir <cwd>`，
+ * 不管是新起的还是被复用的 server，都会被这个参数正确定向。
  */
 
 import { spawn } from 'child_process';
@@ -71,7 +78,10 @@ export class OpenCodeEngine implements IAgentEngine {
     async *run(input: string, context: EngineRunContext): AsyncGenerator<ExecutionStep> {
         const cwd = context.cwd ?? this.options.cwd ?? process.cwd();
         const binary = this.options.binaryPath ?? 'opencode';
-        const args = ['run', '--format', 'json'];
+        // 真实使用中发现：opencode 会自动发现/复用本机已在跑的 opencode server（daemon 式架构），
+        // 此时新 spawn 的进程只是连去那个已有 server，spawn() 的 cwd 选项管不到它——
+        // 必须显式传 --dir 告诉（新起的或被复用的）server 用哪个目录，不能只依赖进程级 cwd。
+        const args = ['run', '--format', 'json', '--dir', cwd];
         if (this.options.model) args.push('-m', this.options.model);
         args.push(input);
 

--- a/src/core/requirement-execution-service.ts
+++ b/src/core/requirement-execution-service.ts
@@ -10,6 +10,8 @@ import { OpenCodeEngine } from './harness/opencode-engine.js';
 import { PiEngine } from './harness/pi-engine.js';
 import type { IAgentEngine } from './harness/agent-engine.js';
 import { defaultAgentSpec, type AgentSpec } from './harness/agent-spec.js';
+import { cancelInterrupt } from './interrupt-coordinator.js';
+import { sessionEventStore } from './harness/session-store.js';
 
 /** coding agent 运行不使用 cmasterBot 自身的记忆系统 */
 const noopMemory: MemoryAccess = {
@@ -25,6 +27,14 @@ const STARTABLE_STATUSES: Requirement['status'][] = ['synced', 'queued', 'failed
 /** ExecutionEngineKind → requirement_runs.engine 列存的值（对齐 AgentEngineKind） */
 const RUN_ENGINE_LABEL: Record<ExecutionEngineKind, string> = {
     'claude-code': 'claude-agent-sdk',
+    codex: 'codex',
+    opencode: 'opencode',
+    pi: 'pi',
+};
+
+/** RUN_ENGINE_LABEL 的反查表，供 retry() 从历史 run 还原出 ExecutionEngineKind */
+const ENGINE_KIND_FROM_LABEL: Record<string, ExecutionEngineKind> = {
+    'claude-agent-sdk': 'claude-code',
     codex: 'codex',
     opencode: 'opencode',
     pi: 'pi',
@@ -67,6 +77,8 @@ export class RequirementExecutionService {
     private worktree: WorktreeManager;
     private logger: Logger;
     private createEngine: (engineKind: ExecutionEngineKind, spec: AgentSpec, logger: Logger) => IAgentEngine;
+    /** 运行中的 run（run.id → 中止句柄），供 cancel() 定位并中止；drive() 结束时自行清理 */
+    private activeRuns = new Map<string, { controller: AbortController; cancelled: boolean }>();
 
     constructor(deps: RequirementExecutionServiceDeps = {}) {
         this.projects = deps.projects ?? projectRepository;
@@ -117,6 +129,80 @@ export class RequirementExecutionService {
         return { runId: run.id, sessionId };
     }
 
+    /**
+     * 失败重试：默认复用同一 worktree（保留半成品与错误现场），沿用上次的引擎，
+     * retry_no 递增（spec §4.1/§4.4）。
+     */
+    async retry(requirementId: string, options: StartRunOptions = {}): Promise<{ runId: string; sessionId: string }> {
+        const requirement = this.requirements.getById(requirementId);
+        if (!requirement) throw new Error(`Requirement not found: ${requirementId}`);
+        if (requirement.status !== 'failed') {
+            throw new Error(`Requirement is not in a retryable state (current: ${requirement.status})`);
+        }
+        const project = this.projects.getById(requirement.projectId);
+        if (!project) throw new Error(`Project not found: ${requirement.projectId}`);
+
+        const [latestRun] = this.runs.listByRequirement(requirementId);
+        if (!latestRun) throw new Error(`No previous run found for requirement: ${requirementId}`);
+
+        await this.worktree.ensure(project, requirement); // 复用现场
+        const sessionId = nanoid();
+        const run = this.runs.incrementRetryFrom(latestRun, sessionId);
+        this.requirements.updateStatus(requirement.id, 'in_progress');
+
+        const engineKind = ENGINE_KIND_FROM_LABEL[latestRun.engine] ?? 'claude-code';
+        this.drive(project, requirement, run, { ...options, engine: engineKind }).catch(err => {
+            this.logger.error(`[requirement-execution] retry run ${run.id} crashed outside drive()'s own try/catch: ${(err as Error).message}`);
+        });
+
+        return { runId: run.id, sessionId };
+    }
+
+    /**
+     * 人工中止执行中的需求：中止引擎（abortSignal）+ 释放挂起的 interrupt（若有）。
+     * 找不到内存中的执行现场（如服务重启后的孤儿态，理论上启动扫描已标 failed）时兜底直接改状态。
+     */
+    async cancel(requirementId: string): Promise<void> {
+        const requirement = this.requirements.getById(requirementId);
+        if (!requirement) throw new Error(`Requirement not found: ${requirementId}`);
+        if (requirement.status !== 'in_progress' && requirement.status !== 'waiting_input') {
+            throw new Error(`Requirement is not in a cancellable state (current: ${requirement.status})`);
+        }
+        const [latestRun] = this.runs.listByRequirement(requirementId);
+        if (!latestRun) throw new Error(`No run found for requirement: ${requirementId}`);
+
+        const entry = this.activeRuns.get(latestRun.id);
+        if (entry) {
+            entry.cancelled = true;
+            cancelInterrupt(latestRun.sessionId);
+            entry.controller.abort();
+        } else {
+            this.runs.updateStatus(latestRun.id, 'cancelled', { finished: true });
+        }
+        this.requirements.updateStatus(requirementId, 'cancelled');
+    }
+
+    /**
+     * 人工核验通过、合并 PR 后调用：标记需求真正完成，自动清理 worktree + 本地分支
+     * （spec §4.3）。PR 合并本身在 GitHub 上完成，本方法只记录决定 + 做清理，不代为合并。
+     */
+    async merge(requirementId: string): Promise<void> {
+        const requirement = this.requirements.getById(requirementId);
+        if (!requirement) throw new Error(`Requirement not found: ${requirementId}`);
+        if (requirement.status !== 'implemented') {
+            throw new Error(`Requirement is not in a mergeable state (current: ${requirement.status})`);
+        }
+        const project = this.projects.getById(requirement.projectId);
+        if (!project) throw new Error(`Project not found: ${requirement.projectId}`);
+
+        this.requirements.updateStatus(requirement.id, 'merged');
+        try {
+            await this.worktree.remove(project, requirement);
+        } catch (err) {
+            this.logger.warn(`[requirement-execution] cleanup worktree after merge failed (non-fatal): ${(err as Error).message}`);
+        }
+    }
+
     private async drive(
         project: Project,
         requirement: Requirement,
@@ -136,6 +222,20 @@ export class RequirementExecutionService {
         const engine = this.createEngine(options.engine ?? 'claude-code', spec, this.logger);
         const task = `实现需求 ${requirement.reqKey}：${requirement.title}`;
 
+        const controller = new AbortController();
+        this.activeRuns.set(run.id, { controller, cancelled: false });
+
+        // 执行时间线回放（spec §6.2）：RequirementExecutionService 不走 AgentHarness，
+        // 自己把每个 ExecutionStep 写进 session_events，供前端静态回放。
+        // best-effort：写入失败不应中断执行。
+        const emitEvent = (type: 'session_start' | 'session_end' | 'agent_step', payload: Record<string, unknown>) => {
+            try {
+                sessionEventStore.append({ sessionId: run.sessionId, timestamp: Date.now(), type, payload });
+            } catch { /* non-fatal */ }
+        };
+
+        emitEvent('session_start', { specId: spec.id, specName: spec.name, task, requirementId: requirement.id, engine: options.engine ?? 'claude-code' });
+
         let awaitingResume = false;
         try {
             for await (const step of engine.run(task, {
@@ -143,7 +243,18 @@ export class RequirementExecutionService {
                 memory: noopMemory,
                 cwd: run.worktreePath ?? undefined,
                 approvalMode: options.approvalMode ?? 'auto',
+                abortSignal: controller.signal,
             })) {
+                emitEvent('agent_step', {
+                    type: step.type,
+                    content: step.content,
+                    toolName: step.toolName,
+                    toolInput: step.toolInput,
+                    interruptId: step.interruptId,
+                    interruptKind: step.interruptKind,
+                    interruptReason: step.interruptReason,
+                });
+
                 if (step.type === 'interrupt') {
                     awaitingResume = true;
                     this.requirements.updateStatus(requirement.id, 'waiting_input');
@@ -157,11 +268,22 @@ export class RequirementExecutionService {
                 }
             }
 
+            emitEvent('session_end', { status: 'succeeded' });
             this.runs.updateStatus(run.id, 'succeeded', { finished: true });
             this.requirements.updateStatus(requirement.id, 'implemented');
         } catch (err) {
-            this.runs.updateStatus(run.id, 'failed', { errorMessage: (err as Error).message, finished: true });
-            this.requirements.updateStatus(requirement.id, 'failed');
+            // cancel() 已经把状态改成 cancelled 了；这里只是让 catch 分支保持终态一致，不覆盖成 failed
+            if (this.activeRuns.get(run.id)?.cancelled) {
+                emitEvent('session_end', { status: 'cancelled' });
+                this.runs.updateStatus(run.id, 'cancelled', { errorMessage: 'Cancelled by user', finished: true });
+                this.requirements.updateStatus(requirement.id, 'cancelled');
+            } else {
+                emitEvent('session_end', { status: 'failed', error: (err as Error).message });
+                this.runs.updateStatus(run.id, 'failed', { errorMessage: (err as Error).message, finished: true });
+                this.requirements.updateStatus(requirement.id, 'failed');
+            }
+        } finally {
+            this.activeRuns.delete(run.id);
         }
     }
 }

--- a/src/gateway/routes/requirements.ts
+++ b/src/gateway/routes/requirements.ts
@@ -3,13 +3,14 @@ import { requirementRepository, type RequirementStatus } from '../../core/requir
 import { requirementRunRepository } from '../../core/requirement-run-repository.js';
 import { requirementSyncService } from '../../core/requirement-sync-service.js';
 import { requirementExecutionService, type ExecutionEngineKind } from '../../core/requirement-execution-service.js';
+import { sessionEventStore } from '../../core/harness/session-store.js';
 import type { GatewayDeps } from '../route-deps.js';
 
 /**
- * 研发流程管理模块：需求同步 / 手动创建 / 列表 / 发起研发 / run 查询路由。
- * 实施地图 #61 ticket #63（同步层）+ #64（执行层基座）。
- * 回答中断复用既有 `/api/sessions/:id/interrupt-response`（键控用的就是 requirement_run.session_id）；
- * 重试/取消/核验合并留给后续 ticket。
+ * 研发流程管理模块：需求同步 / 手动创建 / 列表 / 发起研发 / 重试 / 取消 / 核验合并 /
+ * run 查询 / 执行时间线路由。实施地图 #61 ticket #63（同步层）+ #64（执行层基座）+
+ * #67（前端配套补齐后端）。回答中断复用既有 `/api/sessions/:id/interrupt-response`
+ * （键控用的就是 requirement_run.session_id）。
  */
 export async function registerRequirementRoutes(app: FastifyInstance, deps: GatewayDeps): Promise<void> {
     // 手动触发同步（spec §2.5：仅手动触发，不做定时任务）
@@ -98,5 +99,85 @@ export async function registerRequirementRoutes(app: FastifyInstance, deps: Gate
     // run 列表与详情（执行记录回放的入口，静态浏览用）
     app.get<{ Params: { id: string } }>('/api/requirements/:id/runs', async (request) => {
         return requirementRunRepository.listByRequirement(request.params.id);
+    });
+
+    // 某次 run 的执行时间线（session_events 静态回放，不做实时节奏动画，spec §6.2）
+    app.get<{ Params: { id: string; runId: string } }>(
+        '/api/requirements/:id/runs/:runId/events',
+        async (request, reply) => {
+            const run = requirementRunRepository.getById(request.params.runId);
+            if (!run || run.requirementId !== request.params.id) {
+                reply.status(404);
+                return { error: 'Run not found' };
+            }
+            return { events: sessionEventStore.getEvents(run.sessionId) };
+        }
+    );
+
+    // 失败重试（默认复用同一 worktree 现场，沿用上次引擎，spec §4.1/§4.4）
+    app.post<{ Params: { id: string }; Body: { approvalMode?: 'auto' | 'ask-on-risky' } }>(
+        '/api/requirements/:id/retry',
+        async (request, reply) => {
+            try {
+                const result = await requirementExecutionService.retry(request.params.id, {
+                    approvalMode: request.body?.approvalMode,
+                });
+                reply.status(202);
+                return result;
+            } catch (error: any) {
+                deps.logger.error(`Retry requirement execution error: ${error.message}`);
+                if (error.message?.startsWith('Requirement not found') || error.message?.startsWith('Project not found')
+                    || error.message?.startsWith('No previous run found')) {
+                    reply.status(404);
+                    return { error: error.message };
+                }
+                if (error.message?.includes('retryable state')) {
+                    reply.status(409);
+                    return { error: error.message };
+                }
+                reply.status(500);
+                return { error: error.message };
+            }
+        }
+    );
+
+    // 人工中止执行中的需求
+    app.post<{ Params: { id: string } }>('/api/requirements/:id/cancel', async (request, reply) => {
+        try {
+            await requirementExecutionService.cancel(request.params.id);
+            return { success: true };
+        } catch (error: any) {
+            deps.logger.error(`Cancel requirement execution error: ${error.message}`);
+            if (error.message?.startsWith('Requirement not found') || error.message?.startsWith('No run found')) {
+                reply.status(404);
+                return { error: error.message };
+            }
+            if (error.message?.includes('cancellable state')) {
+                reply.status(409);
+                return { error: error.message };
+            }
+            reply.status(500);
+            return { error: error.message };
+        }
+    });
+
+    // 人工核验通过、PR 已在 GitHub 上合并后调用：标记需求完成 + 自动清理 worktree（spec §4.3）
+    app.post<{ Params: { id: string } }>('/api/requirements/:id/merge', async (request, reply) => {
+        try {
+            await requirementExecutionService.merge(request.params.id);
+            return { success: true };
+        } catch (error: any) {
+            deps.logger.error(`Merge requirement error: ${error.message}`);
+            if (error.message?.startsWith('Requirement not found') || error.message?.startsWith('Project not found')) {
+                reply.status(404);
+                return { error: error.message };
+            }
+            if (error.message?.includes('mergeable state')) {
+                reply.status(409);
+                return { error: error.message };
+            }
+            reply.status(500);
+            return { error: error.message };
+        }
     });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -247,7 +247,8 @@ export type SessionEventType =
     | 'grader_evaluation'   // D6: Grader 评分结果持久化
     | 'grader_revision'     // D6: Grader 修订循环持久化
     | 'interrupt_raised'    // 研发流程管理：人机中断发起（question/approval）
-    | 'interrupt_resolved'; // 研发流程管理：人机中断已解决
+    | 'interrupt_resolved'  // 研发流程管理：人机中断已解决
+    | 'agent_step';         // 研发流程管理：完整 ExecutionStep 快照（执行时间线静态回放用）
 
 export interface SessionEvent {
     id: string;

--- a/tests/codex-engine.test.ts
+++ b/tests/codex-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { writeFileSync, mkdtempSync, chmodSync, rmSync, readFileSync } from 'fs';
+import { writeFileSync, mkdtempSync, mkdirSync, chmodSync, rmSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { CodexEngine } from '../src/core/harness/codex-engine.js';
@@ -51,13 +51,25 @@ describe('CodexEngine', () => {
         expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
     });
 
-    it('拼装的 CLI 参数包含 exec/--json/--sandbox/--skip-git-repo-check 与 prompt（不含 -a/--ask-for-approval，实测确认 exec 不支持该参数）', async () => {
+    it('拼装的 CLI 参数包含 exec/--json/--sandbox/-C/--skip-git-repo-check 与 prompt（不含 -a/--ask-for-approval，实测确认 exec 不支持该参数）', async () => {
         const argsFile = path.join(tmpDir, 'args.json');
         process.env.FAKE_CODEX_ARGS_FILE = argsFile;
         const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sandbox: 'read-only' });
         await drain(engine.run('implement X', { sessionId: 's8', memory: mockMemory, cwd: tmpDir }));
         const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
-        expect(args).toEqual(['exec', '--json', '--sandbox', 'read-only', '--skip-git-repo-check', 'implement X']);
+        expect(args).toEqual(['exec', '--json', '--sandbox', 'read-only', '--skip-git-repo-check', '-C', tmpDir, 'implement X']);
+    });
+
+    it('-C 显式传给 CLI，不依赖进程级 cwd（防御性修复，同一类 bug 在 opencode 引擎上被真实踩中过）', async () => {
+        const argsFile = path.join(tmpDir, 'args.json');
+        process.env.FAKE_CODEX_ARGS_FILE = argsFile;
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const otherDir = path.join(tmpDir, 'a-different-project-dir');
+        mkdirSync(otherDir);
+        await drain(engine.run('task', { sessionId: 's8b', memory: mockMemory, cwd: otherDir }));
+        const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+        expect(args).toContain('-C');
+        expect(args[args.indexOf('-C') + 1]).toBe(otherDir);
     });
 
     it('解析真实实测过的事件形状：配置回显 → meta，task_started → meta（实施地图 #61 ticket #65 实测记录）', async () => {

--- a/tests/opencode-engine.test.ts
+++ b/tests/opencode-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { writeFileSync, mkdtempSync, chmodSync, rmSync, readFileSync } from 'fs';
+import { writeFileSync, mkdtempSync, mkdirSync, chmodSync, rmSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { OpenCodeEngine } from '../src/core/harness/opencode-engine.js';
@@ -48,13 +48,25 @@ describe('OpenCodeEngine', () => {
         expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
     });
 
-    it('拼装的 CLI 参数包含 run/--format/json 与 prompt', async () => {
+    it('拼装的 CLI 参数包含 run/--format/json/--dir 与 prompt', async () => {
         const argsFile = path.join(tmpDir, 'args.json');
         process.env.FAKE_OPENCODE_ARGS_FILE = argsFile;
         const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath, model: 'opencode/deepseek-v4-flash-free' });
         await drain(engine.run('implement X', { sessionId: 's1', memory: mockMemory, cwd: tmpDir }));
         const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
-        expect(args).toEqual(['run', '--format', 'json', '-m', 'opencode/deepseek-v4-flash-free', 'implement X']);
+        expect(args).toEqual(['run', '--format', 'json', '--dir', tmpDir, '-m', 'opencode/deepseek-v4-flash-free', 'implement X']);
+    });
+
+    it('--dir 显式传给 CLI，不依赖 opencode 自己发现/复用已在跑的 server（真实联调踩过的 bug）', async () => {
+        const argsFile = path.join(tmpDir, 'args.json');
+        process.env.FAKE_OPENCODE_ARGS_FILE = argsFile;
+        const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
+        const otherDir = path.join(tmpDir, 'a-different-project-dir');
+        mkdirSync(otherDir);
+        await drain(engine.run('task', { sessionId: 's1b', memory: mockMemory, cwd: otherDir }));
+        const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+        expect(args).toContain('--dir');
+        expect(args[args.indexOf('--dir') + 1]).toBe(otherDir);
     });
 
     it('真实成功路径（实测，纯文本回复）：step_start → text → step_finish', async () => {

--- a/tests/requirement-execution-service.test.ts
+++ b/tests/requirement-execution-service.test.ts
@@ -7,6 +7,8 @@ import { RequirementExecutionService } from '../src/core/requirement-execution-s
 import type { WorktreeManager } from '../src/core/worktree-manager.js';
 import type { IAgentEngine } from '../src/core/harness/agent-engine.js';
 import type { ExecutionStep } from '../src/types.js';
+import { sessionEventStore } from '../src/core/harness/session-store.js';
+import { nanoid } from 'nanoid';
 
 function createTestDb(): DatabaseSync {
     const db = new DatabaseSync(':memory:');
@@ -138,6 +140,33 @@ describe('RequirementExecutionService', () => {
         expect(requirements.getById(requirement.id)!.status).toBe('implemented');
     });
 
+    it('drive(): 把每个 ExecutionStep 写进 session_events（agent_step），供前端执行时间线回放', async () => {
+        const service = makeService(() => engineYielding([
+            { type: 'content', content: 'working...', timestamp: new Date() },
+            { type: 'action', content: '调用 Bash', toolName: 'Bash', toolInput: { command: 'ls' }, timestamp: new Date() },
+            { type: 'observation', content: 'file1', timestamp: new Date() },
+            { type: 'answer', content: 'done', timestamp: new Date() },
+        ]));
+
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#events1', source: 'github', sourceKey: 'events1', title: 'Add feature',
+        });
+        const project = projects.getById(projectId)!;
+        const sessionId = `sess-events-${nanoid()}`; // session_events 是真实持久化的表，用随机 id 避免重复跑测试时累积
+        const run = runs.create({ requirementId: requirement.id, projectId, engine: 'claude-agent-sdk', sessionId });
+
+        await (service as any).drive(project, requirement, run, {});
+
+        const events = sessionEventStore.getEvents(sessionId);
+        expect(events.some(e => e.type === 'session_start')).toBe(true);
+        expect(events.some(e => e.type === 'session_end' && (e.payload as any).status === 'succeeded')).toBe(true);
+
+        const stepEvents = events.filter(e => e.type === 'agent_step');
+        expect(stepEvents).toHaveLength(4);
+        expect(stepEvents.map(e => (e.payload as any).type)).toEqual(['content', 'action', 'observation', 'answer']);
+        expect((stepEvents[1].payload as any).toolName).toBe('Bash');
+    });
+
     it('drive(): interrupt 步骤 → 需求/run 转 waiting_input，恢复后转回 in_progress/running，结束后 implemented', async () => {
         const service = makeService(() => engineYielding([
             { type: 'content', content: 'thinking...', timestamp: new Date() },
@@ -264,5 +293,97 @@ describe('RequirementExecutionService', () => {
         const { runId } = await service.start(requirement.id, { engine: engineKind });
         expect(createEngine).toHaveBeenCalledWith(engineKind, expect.anything(), expect.anything());
         expect(runs.getById(runId)!.engine).toBe(engineKind);
+    });
+
+    it('retry() 复用 worktree、沿用上次引擎、retry_no 递增，需求从 failed 转回 in_progress→implemented', async () => {
+        const createEngine = vi.fn(() => engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]));
+        const service = makeService(createEngine);
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#r1', source: 'github', sourceKey: 'r1', title: 'Add feature',
+        });
+        await service.start(requirement.id, { engine: 'codex' });
+        await new Promise(r => setTimeout(r, 0));
+        expect(requirements.getById(requirement.id)!.status).toBe('implemented');
+
+        // 手动模拟"这次执行失败了"，再重试
+        requirements.updateStatus(requirement.id, 'failed');
+        createEngine.mockClear();
+        const { runId: retryRunId } = await service.retry(requirement.id);
+        await new Promise(r => setTimeout(r, 0));
+
+        expect(createEngine).toHaveBeenCalledWith('codex', expect.anything(), expect.anything());
+        expect(worktree.ensure).toHaveBeenCalledTimes(2); // start 一次，retry 一次
+        const retryRun = runs.getById(retryRunId)!;
+        expect(retryRun.retryNo).toBe(1);
+        expect(requirements.getById(requirement.id)!.status).toBe('implemented');
+    });
+
+    it('retry() 拒绝非 failed 状态', async () => {
+        const service = makeService(() => engineYielding([]));
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#r2', source: 'github', sourceKey: 'r2', title: 'Add feature',
+        });
+        await expect(service.retry(requirement.id)).rejects.toThrow(/retryable state/);
+    });
+
+    it('cancel() 中止运行中的 run：requirement/run 转 cancelled（不是 failed），引擎收到 abortSignal', async () => {
+        let sawAbort = false;
+        const service = makeService(() => ({
+            kind: 'claude-agent-sdk',
+            capabilities: { interactiveApproval: true, resume: false },
+            run: async function* (_input: string, context: any) {
+                yield { type: 'content', content: 'working...', timestamp: new Date() };
+                await new Promise<void>((resolve, reject) => {
+                    context.abortSignal?.addEventListener('abort', () => {
+                        sawAbort = true;
+                        reject(new Error('aborted'));
+                    }, { once: true });
+                });
+            },
+        }));
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#c1', source: 'github', sourceKey: 'c1', title: 'Add feature',
+        });
+        requirements.updateStatus(requirement.id, 'queued');
+
+        const { runId } = await service.start(requirement.id);
+        await new Promise(r => setTimeout(r, 0));
+        expect(requirements.getById(requirement.id)!.status).toBe('in_progress');
+
+        await service.cancel(requirement.id);
+        await new Promise(r => setTimeout(r, 0));
+
+        expect(sawAbort).toBe(true);
+        expect(requirements.getById(requirement.id)!.status).toBe('cancelled');
+        expect(runs.getById(runId)!.status).toBe('cancelled');
+    });
+
+    it('cancel() 拒绝非活跃状态', async () => {
+        const service = makeService(() => engineYielding([]));
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#c2', source: 'github', sourceKey: 'c2', title: 'Add feature',
+        });
+        await expect(service.cancel(requirement.id)).rejects.toThrow(/cancellable state/);
+    });
+
+    it('merge() 把 implemented 需求标为 merged 并清理 worktree', async () => {
+        const service = makeService(() => engineYielding([]));
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#m1', source: 'github', sourceKey: 'm1', title: 'Add feature',
+        });
+        requirements.updateStatus(requirement.id, 'implemented');
+
+        await service.merge(requirement.id);
+
+        expect(requirements.getById(requirement.id)!.status).toBe('merged');
+        expect(worktree.remove).toHaveBeenCalled();
+    });
+
+    it('merge() 拒绝非 implemented 状态', async () => {
+        const service = makeService(() => engineYielding([]));
+        const requirement = requirements.create({
+            projectId, reqKey: 'cmasterBot#m2', source: 'github', sourceKey: 'm2', title: 'Add feature',
+        });
+        await expect(service.merge(requirement.id)).rejects.toThrow(/mergeable state/);
     });
 });

--- a/web/src/app/projects/page.tsx
+++ b/web/src/app/projects/page.tsx
@@ -1,0 +1,625 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2, Plus, RefreshCw } from "lucide-react";
+import { fetchApi } from "@/lib/api";
+
+// ─────────────────────────── 领域模型（对齐后端 repository） ───────────────────────────
+
+type RequirementStatus =
+    | "synced" | "queued" | "in_progress" | "waiting_input"
+    | "implemented" | "merged" | "failed" | "cancelled";
+
+type ExecutionEngineKind = "claude-code" | "codex" | "opencode" | "pi";
+
+interface Project {
+    id: string;
+    name: string;
+    dir: string;
+    description: string | null;
+    syncSource: string;
+    lastSyncedAt: string | null;
+    maxConcurrentRuns: number;
+}
+
+interface Requirement {
+    id: string;
+    projectId: string;
+    reqKey: string;
+    source: string;
+    sourceKey: string;
+    title: string;
+    description: string | null;
+    labels: string[];
+    status: RequirementStatus;
+    sourceUrl: string | null;
+    sourceClosed: boolean;
+    updatedAt: string;
+}
+
+interface RequirementRun {
+    id: string;
+    requirementId: string;
+    engine: string;
+    status: "running" | "waiting_input" | "succeeded" | "failed" | "cancelled";
+    retryNo: number;
+    prUrl: string | null;
+    errorMessage: string | null;
+    sessionId: string;
+    startedAt: string;
+    finishedAt: string | null;
+}
+
+interface AgentStepPayload {
+    type: string;
+    content?: string;
+    toolName?: string;
+    toolInput?: Record<string, unknown>;
+    interruptId?: string;
+    interruptReason?: string;
+}
+
+interface SessionEvent {
+    id: string;
+    sessionId: string;
+    timestamp: number;
+    type: string;
+    payload: Record<string, unknown>;
+}
+
+const STATUS_COLUMNS: RequirementStatus[] = [
+    "synced", "queued", "in_progress", "waiting_input",
+    "implemented", "merged", "failed", "cancelled",
+];
+
+const STATUS_META: Record<RequirementStatus, { label: string; cls: string }> = {
+    synced: { label: "已同步", cls: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300" },
+    queued: { label: "已排队", cls: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" },
+    in_progress: { label: "实施中", cls: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300" },
+    waiting_input: { label: "等待回答", cls: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300" },
+    implemented: { label: "待核验", cls: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" },
+    merged: { label: "已完成", cls: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300" },
+    failed: { label: "失败", cls: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" },
+    cancelled: { label: "已取消", cls: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400" },
+};
+
+const AGENTS: ExecutionEngineKind[] = ["claude-code", "codex", "opencode", "pi"];
+const STARTABLE_STATUSES: RequirementStatus[] = ["synced", "queued"];
+const BOARD_POLL_MS = 3000;
+const SHEET_POLL_MS = 3000;
+
+const STEP_ICON: Record<string, string> = {
+    meta: "ⓘ", thought: "💭", action: "⚙", observation: "👁",
+    content: "💬", answer: "✅", interrupt: "❓",
+};
+
+function StatusBadge({ status }: { status: RequirementStatus }) {
+    const meta = STATUS_META[status];
+    return <Badge variant="outline" className={`border-transparent ${meta.cls}`}>{meta.label}</Badge>;
+}
+
+function Timeline({ events }: { events: SessionEvent[] }) {
+    const steps = events.filter((e) => e.type === "agent_step");
+    if (steps.length === 0) {
+        return <p className="text-sm text-muted-foreground">暂无执行记录。</p>;
+    }
+    return (
+        <ol className="space-y-2">
+            {steps.map((e) => {
+                const p = e.payload as unknown as AgentStepPayload;
+                const isInterrupt = p.type === "interrupt";
+                return (
+                    <li
+                        key={e.id}
+                        className={`flex gap-2 rounded-md border p-2 text-sm ${isInterrupt ? "border-amber-400 bg-amber-50 dark:bg-amber-950/30" : "border-border"}`}
+                    >
+                        <span className="shrink-0">{STEP_ICON[p.type] ?? "•"}</span>
+                        <div className="min-w-0 flex-1">
+                            <div className="break-words">
+                                {p.toolName && (
+                                    <span className="mr-1 rounded bg-muted px-1 font-mono text-xs">{p.toolName}</span>
+                                )}
+                                {p.content || (isInterrupt ? p.interruptReason : "")}
+                            </div>
+                            <div className="mt-0.5 text-[10px] text-muted-foreground">
+                                {new Date(e.timestamp).toLocaleTimeString()}
+                            </div>
+                        </div>
+                    </li>
+                );
+            })}
+        </ol>
+    );
+}
+
+function QuestionCard({ onAnswer }: { onAnswer: (text: string) => Promise<void> }) {
+    const [text, setText] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    return (
+        <div className="rounded-lg border-2 border-amber-400 bg-amber-50 p-3 dark:bg-amber-950/30">
+            <div className="mb-2 flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-300">
+                ❓ Agent 需要你的回答
+            </div>
+            <Textarea
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder="输入你的回答…"
+                className="mb-2 bg-background"
+                rows={2}
+                disabled={submitting}
+            />
+            <Button
+                size="sm"
+                disabled={!text.trim() || submitting}
+                onClick={async () => {
+                    setSubmitting(true);
+                    try {
+                        await onAnswer(text);
+                        setText("");
+                    } finally {
+                        setSubmitting(false);
+                    }
+                }}
+            >
+                {submitting ? <Loader2 className="size-4 animate-spin" /> : "提交回答，继续执行"}
+            </Button>
+        </div>
+    );
+}
+
+function NewProjectDialog({ open, onOpenChange, onCreated }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onCreated: (project: Project) => void;
+}) {
+    const [name, setName] = useState("");
+    const [dir, setDir] = useState("");
+    const [description, setDescription] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const submit = async () => {
+        if (!name.trim() || !dir.trim()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            const project = await fetchApi<Project>("/api/projects", {
+                method: "POST",
+                body: JSON.stringify({ name: name.trim(), dir: dir.trim(), description: description.trim() || undefined }),
+            });
+            onCreated(project);
+            setName(""); setDir(""); setDescription("");
+            onOpenChange(false);
+        } catch (err: any) {
+            setError(err.message ?? "创建失败");
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>新建项目</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-3">
+                    <div className="space-y-1">
+                        <Label htmlFor="project-name">项目名（req_key 前缀，唯一）</Label>
+                        <Input id="project-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="cmasterBot" />
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="project-dir">主分支目录（绝对路径）</Label>
+                        <Input id="project-dir" value={dir} onChange={(e) => setDir(e.target.value)} placeholder="/Users/you/work/cmasterBot" />
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="project-desc">描述（可选）</Label>
+                        <Textarea id="project-desc" value={description} onChange={(e) => setDescription(e.target.value)} rows={2} />
+                    </div>
+                    {error && <p className="text-sm text-destructive">{error}</p>}
+                </div>
+                <DialogFooter>
+                    <Button disabled={!name.trim() || !dir.trim() || submitting} onClick={submit}>
+                        {submitting ? <Loader2 className="size-4 animate-spin" /> : "创建"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function NewRequirementDialog({ open, onOpenChange, projectId, onCreated }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    projectId: string;
+    onCreated: () => void;
+}) {
+    const [title, setTitle] = useState("");
+    const [description, setDescription] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const submit = async () => {
+        if (!title.trim()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            await fetchApi(`/api/projects/${projectId}/requirements`, {
+                method: "POST",
+                body: JSON.stringify({ title: title.trim(), description: description.trim() || undefined }),
+            });
+            setTitle(""); setDescription("");
+            onOpenChange(false);
+            onCreated();
+        } catch (err: any) {
+            setError(err.message ?? "创建失败");
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>手动创建需求</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-3">
+                    <div className="space-y-1">
+                        <Label htmlFor="req-title">标题</Label>
+                        <Input id="req-title" value={title} onChange={(e) => setTitle(e.target.value)} />
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="req-desc">描述（可选）</Label>
+                        <Textarea id="req-desc" value={description} onChange={(e) => setDescription(e.target.value)} rows={3} />
+                    </div>
+                    {error && <p className="text-sm text-destructive">{error}</p>}
+                </div>
+                <DialogFooter>
+                    <Button disabled={!title.trim() || submitting} onClick={submit}>
+                        {submitting ? <Loader2 className="size-4 animate-spin" /> : "创建"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function RequirementDetailSheet({ requirement, onOpenChange, onChanged }: {
+    requirement: Requirement | null;
+    onOpenChange: (open: boolean) => void;
+    onChanged: () => void;
+}) {
+    const [agent, setAgent] = useState<ExecutionEngineKind>("claude-code");
+    const [runs, setRuns] = useState<RequirementRun[]>([]);
+    const [events, setEvents] = useState<SessionEvent[]>([]);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const latestRun = runs[0] ?? null;
+
+    const loadDetail = useCallback(async () => {
+        if (!requirement) return;
+        try {
+            const runList = await fetchApi<RequirementRun[]>(`/api/requirements/${requirement.id}/runs`);
+            setRuns(runList);
+            const latest = runList[0];
+            if (latest) {
+                const { events: evts } = await fetchApi<{ events: SessionEvent[] }>(
+                    `/api/requirements/${requirement.id}/runs/${latest.id}/events`
+                );
+                setEvents(evts);
+            } else {
+                setEvents([]);
+            }
+        } catch {
+            // 静默失败：不打断详情面板的其他交互
+        }
+    }, [requirement]);
+
+    useEffect(() => {
+        setRuns([]); setEvents([]); setError(null);
+        if (!requirement) return;
+        loadDetail();
+        const timer = setInterval(loadDetail, SHEET_POLL_MS);
+        return () => clearInterval(timer);
+    }, [requirement, loadDetail]);
+
+    if (!requirement) return null;
+
+    const runAction = async (fn: () => Promise<unknown>) => {
+        setBusy(true);
+        setError(null);
+        try {
+            await fn();
+            await loadDetail();
+            onChanged();
+        } catch (err: any) {
+            setError(err.message ?? "操作失败");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <Sheet open={!!requirement} onOpenChange={onOpenChange}>
+            <SheetContent className="w-[480px] overflow-y-auto sm:max-w-[480px]">
+                <SheetHeader>
+                    <SheetTitle className="flex items-center gap-2">
+                        <span className="font-mono text-sm text-muted-foreground">{requirement.reqKey}</span>
+                        <StatusBadge status={requirement.status} />
+                    </SheetTitle>
+                </SheetHeader>
+                <div className="space-y-3 px-4 pb-6">
+                    <h3 className="font-medium">{requirement.title}</h3>
+                    {requirement.description && (
+                        <p className="whitespace-pre-wrap text-sm text-muted-foreground">{requirement.description}</p>
+                    )}
+                    <div className="flex flex-wrap items-center gap-1">
+                        {requirement.labels.map((l) => <Badge key={l} variant="secondary" className="text-[10px]">{l}</Badge>)}
+                        {requirement.sourceUrl && (
+                            <a href={requirement.sourceUrl} target="_blank" rel="noreferrer" className="text-xs text-blue-600 hover:underline dark:text-blue-400">
+                                查看来源
+                            </a>
+                        )}
+                        {requirement.sourceClosed && <span className="text-xs text-red-500">（远程已关闭）</span>}
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                        {STARTABLE_STATUSES.includes(requirement.status) && (
+                            <span className="inline-flex items-center gap-1">
+                                <Select value={agent} onValueChange={(v) => setAgent(v as ExecutionEngineKind)}>
+                                    <SelectTrigger size="sm" className="h-8 w-[140px]"><SelectValue /></SelectTrigger>
+                                    <SelectContent>
+                                        {AGENTS.map((a) => (
+                                            <SelectItem key={a} value={a}>
+                                                {a}{a !== "claude-code" ? "（无人值守）" : ""}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <Button size="sm" disabled={busy} onClick={() => runAction(() =>
+                                    fetchApi(`/api/requirements/${requirement.id}/start`, { method: "POST", body: JSON.stringify({ engine: agent }) })
+                                )}>
+                                    发起研发
+                                </Button>
+                            </span>
+                        )}
+                        {requirement.status === "failed" && (
+                            <Button size="sm" disabled={busy} onClick={() => runAction(() =>
+                                fetchApi(`/api/requirements/${requirement.id}/retry`, { method: "POST" })
+                            )}>
+                                重试
+                            </Button>
+                        )}
+                        {(requirement.status === "in_progress" || requirement.status === "waiting_input") && (
+                            <Button size="sm" variant="outline" disabled={busy} onClick={() => runAction(() =>
+                                fetchApi(`/api/requirements/${requirement.id}/cancel`, { method: "POST" })
+                            )}>
+                                取消
+                            </Button>
+                        )}
+                        {requirement.status === "implemented" && (
+                            <Button size="sm" variant="outline" disabled={busy} onClick={() => runAction(() =>
+                                fetchApi(`/api/requirements/${requirement.id}/merge`, { method: "POST" })
+                            )}>
+                                ✓ 核验通过，合并 PR
+                            </Button>
+                        )}
+                        {latestRun?.prUrl && (
+                            <a href={latestRun.prUrl} target="_blank" rel="noreferrer" className="text-xs text-blue-600 hover:underline dark:text-blue-400">
+                                查看 PR
+                            </a>
+                        )}
+                    </div>
+                    {latestRun && (
+                        <p className="text-xs text-muted-foreground">
+                            引擎：{latestRun.engine}{latestRun.retryNo > 0 ? ` · 第 ${latestRun.retryNo + 1} 次尝试` : ""}
+                            {latestRun.errorMessage ? ` · ${latestRun.errorMessage}` : ""}
+                        </p>
+                    )}
+                    {error && <p className="text-sm text-destructive">{error}</p>}
+
+                    {requirement.status === "waiting_input" && latestRun && (
+                        <QuestionCard onAnswer={(text) => runAction(() =>
+                            fetchApi(`/api/sessions/${latestRun.sessionId}/interrupt-response`, {
+                                method: "POST",
+                                body: JSON.stringify({ approved: true, response: text }),
+                            })
+                        )} />
+                    )}
+
+                    <Separator />
+                    <div className="text-sm font-medium">执行过程</div>
+                    <Timeline events={events} />
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+export default function ProjectsPage() {
+    const [projects, setProjects] = useState<Project[]>([]);
+    const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+    const [requirements, setRequirements] = useState<Requirement[]>([]);
+    const [sheetRequirement, setSheetRequirement] = useState<Requirement | null>(null);
+    const [syncing, setSyncing] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [newProjectOpen, setNewProjectOpen] = useState(false);
+    const [newRequirementOpen, setNewRequirementOpen] = useState(false);
+
+    const activeProject = projects.find((p) => p.id === activeProjectId) ?? null;
+
+    const loadProjects = useCallback(async () => {
+        try {
+            const list = await fetchApi<Project[]>("/api/projects");
+            setProjects(list);
+            setActiveProjectId((current) => current && list.some((p) => p.id === current) ? current : (list[0]?.id ?? null));
+        } catch (err: any) {
+            setError(err.message ?? "加载项目失败");
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const loadRequirements = useCallback(async () => {
+        if (!activeProjectId) { setRequirements([]); return; }
+        try {
+            const list = await fetchApi<Requirement[]>(`/api/projects/${activeProjectId}/requirements`);
+            setRequirements(list);
+        } catch (err: any) {
+            setError(err.message ?? "加载需求失败");
+        }
+    }, [activeProjectId]);
+
+    useEffect(() => { loadProjects(); }, [loadProjects]);
+
+    useEffect(() => {
+        loadRequirements();
+        const timer = setInterval(loadRequirements, BOARD_POLL_MS);
+        return () => clearInterval(timer);
+    }, [loadRequirements]);
+
+    // Sheet 打开时展示的需求要跟着看板轮询到的最新状态走
+    useEffect(() => {
+        if (!sheetRequirement) return;
+        const updated = requirements.find((r) => r.id === sheetRequirement.id);
+        if (updated && updated.status !== sheetRequirement.status) setSheetRequirement(updated);
+    }, [requirements, sheetRequirement]);
+
+    const handleSync = async () => {
+        if (!activeProjectId) return;
+        setSyncing(true);
+        setError(null);
+        try {
+            await fetchApi(`/api/projects/${activeProjectId}/sync`, { method: "POST" });
+            await loadRequirements();
+        } catch (err: any) {
+            setError(err.message ?? "同步失败");
+        } finally {
+            setSyncing(false);
+        }
+    };
+
+    if (loading) {
+        return <div className="flex h-[calc(100vh-3rem)] items-center justify-center text-muted-foreground"><Loader2 className="size-5 animate-spin" /></div>;
+    }
+
+    if (!activeProject) {
+        return (
+            <div className="flex h-[calc(100vh-3rem)] flex-col items-center justify-center gap-3 text-muted-foreground">
+                <p>还没有项目，创建一个开始使用研发流程管理。</p>
+                <Button onClick={() => setNewProjectOpen(true)}><Plus className="mr-1 size-4" />新建项目</Button>
+                <NewProjectDialog open={newProjectOpen} onOpenChange={setNewProjectOpen} onCreated={(p) => { setProjects((ps) => [p, ...ps]); setActiveProjectId(p.id); }} />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex h-[calc(100vh-3rem)] flex-col">
+            <div className="flex items-center gap-3 border-b p-3">
+                <Select value={activeProject.id} onValueChange={setActiveProjectId}>
+                    <SelectTrigger className="h-9 w-[200px]"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                        {projects.map((p) => <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>)}
+                    </SelectContent>
+                </Select>
+                <span className="truncate text-xs text-muted-foreground">
+                    {activeProject.dir} · {activeProject.syncSource}
+                    {activeProject.lastSyncedAt && ` · 上次同步 ${new Date(activeProject.lastSyncedAt).toLocaleString()}`}
+                </span>
+                <div className="ml-auto flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => setNewProjectOpen(true)}>
+                        <Plus className="mr-1 size-4" />新建项目
+                    </Button>
+                    <Button size="sm" variant="outline" onClick={() => setNewRequirementOpen(true)}>
+                        + 手动创建需求
+                    </Button>
+                    <Button size="sm" disabled={syncing} onClick={handleSync}>
+                        {syncing ? <Loader2 className="mr-1 size-4 animate-spin" /> : <RefreshCw className="mr-1 size-4" />}
+                        同步需求
+                    </Button>
+                </div>
+            </div>
+
+            {error && <div className="border-b bg-destructive/10 px-3 py-1.5 text-sm text-destructive">{error}</div>}
+
+            <div className="flex flex-1 gap-3 overflow-x-auto p-3">
+                {STATUS_COLUMNS.map((status) => {
+                    const items = requirements.filter((r) => r.status === status);
+                    return (
+                        <div key={status} className="flex w-60 shrink-0 flex-col rounded-lg bg-muted/40">
+                            <div className="flex items-center gap-2 p-2 text-sm font-medium">
+                                <StatusBadge status={status} />
+                                <span className="text-muted-foreground">{items.length}</span>
+                            </div>
+                            <ScrollArea className="flex-1 px-2 pb-2">
+                                {items.map((r) => (
+                                    <Card key={r.id} className="mb-2 cursor-pointer py-3 hover:border-primary" onClick={() => setSheetRequirement(r)}>
+                                        <CardContent className="px-3">
+                                            <div className="font-mono text-xs text-muted-foreground">{r.reqKey}</div>
+                                            <div className="mt-1 text-sm leading-snug">{r.title}</div>
+                                            {r.labels.length > 0 && (
+                                                <div className="mt-2 flex flex-wrap items-center gap-1">
+                                                    {r.labels.map((l) => <Badge key={l} variant="secondary" className="text-[10px]">{l}</Badge>)}
+                                                </div>
+                                            )}
+                                            {r.status === "waiting_input" && (
+                                                <div className="mt-2 rounded bg-amber-100 px-2 py-1 text-xs text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+                                                    ❓ 有问题等你回答
+                                                </div>
+                                            )}
+                                        </CardContent>
+                                    </Card>
+                                ))}
+                            </ScrollArea>
+                        </div>
+                    );
+                })}
+            </div>
+
+            <RequirementDetailSheet
+                requirement={sheetRequirement}
+                onOpenChange={(open) => !open && setSheetRequirement(null)}
+                onChanged={loadRequirements}
+            />
+            <NewProjectDialog
+                open={newProjectOpen}
+                onOpenChange={setNewProjectOpen}
+                onCreated={(p) => { setProjects((ps) => [p, ...ps]); setActiveProjectId(p.id); }}
+            />
+            {activeProjectId && (
+                <NewRequirementDialog
+                    open={newRequirementOpen}
+                    onOpenChange={setNewRequirementOpen}
+                    projectId={activeProjectId}
+                    onCreated={loadRequirements}
+                />
+            )}
+        </div>
+    );
+}

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -28,6 +28,7 @@ import {
   ShieldCheck,
   Search,
   X,
+  GitBranch,
 } from "lucide-react";
 
 
@@ -215,6 +216,14 @@ const data: SidebarData = {
       icon: Bot,
       items: [
         { title: "Agent 管理台", url: "/agents", badge: "NEW" },
+      ],
+    },
+    {
+      title: "研发流程",
+      url: "/projects",
+      icon: GitBranch,
+      items: [
+        { title: "项目看板", url: "/projects", badge: "NEW" },
       ],
     },
     {


### PR DESCRIPTION
## Summary

实施地图 [研发流程管理模块 实施地图 #61](https://github.com/yiyisf/masterBot/issues/61) 的 ticket [前端 /projects 看板页 #67](https://github.com/yiyisf/masterBot/issues/67)——**地图的最后一张 ticket**。合并后整个「研发流程管理」模块四阶段全部落地。

### 前端

- `/projects` 页面（`web/src/app/projects/page.tsx`）：原型验证胜出的「状态看板 Kanban」变体（`prototype/projects-page-58` 分支，未合入，仅作参考）按生产标准重写：
  - 8 态状态机分列看板（synced/queued/in_progress/waiting_input/implemented/merged/failed/cancelled）
  - 需求卡片：req_key（等宽）+ 标题 + labels；`waiting_input` 高亮"❓ 有问题等你回答"
  - 点卡片 → 右侧 480px Sheet 抽屉：详情 + 操作（agent 选择器发起研发 / 失败重试 / 执行中取消 / `implemented` 态核验合并）+ `waiting_input` 内联问答（textarea 提交）+ 执行时间线静态回放
  - 顶栏：项目切换（Select）+ 项目目录/来源信息 + 新建项目 + 手动建需求 + 同步需求
  - 看板与 Sheet 详情均轮询刷新（3s 间隔，无 SSE），对齐 spec §6.2"静态浏览，不做实时节奏动画"
- 导航注册：`sidebar.tsx` 新增"研发流程"分组

### 后端（补齐 ticket #64 未覆盖的路由）

- `RequirementExecutionService` 新增：
  - `retry()`：复用同一 worktree 现场、沿用上次引擎、`retry_no` 递增
  - `cancel()`：用 `AbortController` 追踪运行中的 run 并中止，同时 `cancelInterrupt()` 释放挂起的人机问答；中止后状态转 `cancelled`（不是 `failed`）
  - `merge()`：人工核验通过后标记 `merged` + 自动清理 worktree（spec §4.3）
- 新路由：`POST /api/requirements/:id/retry`、`POST /api/requirements/:id/cancel`、`POST /api/requirements/:id/merge`、`GET /api/requirements/:id/runs/:runId/events`

### 顺带修复：ticket #64 遗留的"回放数据从未写入"缺口

`RequirementExecutionService.drive()` 直接驱动 `IAgentEngine`，不走 `AgentHarness`，而 `session_events` 的写入逻辑全部挂在 `AgentHarness.emit()` 上——这意味着此前**没有任何代码把执行步骤写进 `session_events`**，"执行时间线回放"这个功能实际上永远是空的，直到这次做前端时才发现。现在 `drive()` 自己把每个 `ExecutionStep` 写成新的 `agent_step` 事件类型（连同已有的 `session_start`/`session_end`），前端 `Timeline` 组件据此渲染真实回放。

## Test plan

- [x] `npx vitest run`（后端）全绿，392 个用例，本地重复 3 次确认无 flaky（新增约 6 个：retry/cancel/merge 各自的成功+拒绝路径、session_events 回放数据写入验证）
- [x] `npx tsc --noEmit` + `npm run build`（后端 + 前端 web/）均无错误
- [x] **真实端到端联调**（本机起后端 3000 + 前端 3001，用真实临时 git 仓库）：创建项目 → 手动建需求 → 发起研发（真实 `ClaudeAgentSdkEngine`，实际尝试连接 Anthropic API）→ 取消执行 → 核实 `session_events` 时间线正确记录了 `session_start`/`agent_step`/`session_end` 三类真实事件
- [ ] **浏览器交互（未完成）**：本环境 Claude in Chrome 扩展未连接，无法做点击/表单提交的可视化验证。已用真实后端联调 + 类型检查/构建覆盖尽可能多的正确性面，但页面的实际交互体验（Dialog/Sheet/Select 等组件的可用性）没有过真人视觉走查，请在合并前自己过一遍

按 wayfinder 实施地图约定，本 ticket resolve = 本 PR 合并进 master；合并后我会在 ticket #67 上记录决议并关闭，同时因为这是地图的最后一张 ticket，会把地图 #61 本身也标记完成。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>