### PR TITLE
feat(dev-workflow): 两阶段自动化数据模型基础（schema + repository）

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -346,6 +346,22 @@ export function initDatabase(): DatabaseSync {
         CREATE UNIQUE INDEX IF NOT EXISTS uq_req_dedup     ON requirements(project_id, source, source_key);
         CREATE INDEX IF NOT EXISTS idx_req_project_status  ON requirements(project_id, status);
 
+        CREATE TABLE IF NOT EXISTS pending_questions (
+            id              TEXT PRIMARY KEY,
+            requirement_id  TEXT NOT NULL,
+            run_id          TEXT NOT NULL,
+            session_id      TEXT NOT NULL,
+            phase           TEXT NOT NULL,
+            questions       TEXT NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'pending',
+            answers         TEXT,
+            created_at      TEXT NOT NULL,
+            answered_at     TEXT,
+            FOREIGN KEY (requirement_id) REFERENCES requirements(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_pending_q_requirement ON pending_questions(requirement_id);
+        CREATE INDEX IF NOT EXISTS idx_pending_q_status      ON pending_questions(status);
+
         CREATE TABLE IF NOT EXISTS requirement_runs (
             id              TEXT PRIMARY KEY,
             requirement_id  TEXT NOT NULL,
@@ -445,6 +461,33 @@ export function initDatabase(): DatabaseSync {
         }
         if (!taskColNames.has('trace_id')) {
             db.prepare('ALTER TABLE tasks ADD COLUMN trace_id TEXT').run();
+        }
+    }
+
+    // Auto-migration: 研发流程两阶段自动化 — requirements 表新增 4 列（spec: dev-workflow two-phase）
+    {
+        const reqColumns = db.prepare('PRAGMA table_info(requirements)').all() as Array<{ name: string }>;
+        const reqColNames = new Set(reqColumns.map(c => c.name));
+        if (!reqColNames.has('phase')) {
+            db.prepare('ALTER TABLE requirements ADD COLUMN phase TEXT').run();
+        }
+        if (!reqColNames.has('analysis_spec')) {
+            db.prepare('ALTER TABLE requirements ADD COLUMN analysis_spec TEXT').run();
+        }
+        if (!reqColNames.has('parent_id')) {
+            db.prepare('ALTER TABLE requirements ADD COLUMN parent_id TEXT').run();
+        }
+        if (!reqColNames.has('card_no')) {
+            db.prepare('ALTER TABLE requirements ADD COLUMN card_no INTEGER').run();
+        }
+    }
+    db.exec('CREATE INDEX IF NOT EXISTS idx_req_parent ON requirements(parent_id, card_no)');
+
+    // Auto-migration: 研发流程两阶段自动化 — requirement_runs 表新增 resume_token 列
+    {
+        const runColumns = db.prepare('PRAGMA table_info(requirement_runs)').all() as Array<{ name: string }>;
+        if (!runColumns.some(c => c.name === 'resume_token')) {
+            db.prepare('ALTER TABLE requirement_runs ADD COLUMN resume_token TEXT').run();
         }
     }
 

--- a/src/core/pending-questions-repository.ts
+++ b/src/core/pending-questions-repository.ts
@@ -1,0 +1,132 @@
+import { nanoid } from 'nanoid';
+import { db } from './database.js';
+import type { RequirementPhase } from './requirement-repository.js';
+
+/** 一道待回答问题的结构，claude-code ask_user 与非交互引擎标记块解析出的问题共用同一形状 */
+export interface PendingQuestion {
+    id: string;
+    question: string;
+    context?: string;
+    options?: Array<{ label: string; description?: string }>;
+    recommended?: number;
+    multiSelect?: boolean;
+}
+
+export type PendingQuestionSetStatus = 'pending' | 'answered' | 'cancelled';
+
+export interface PendingQuestionSet {
+    id: string;
+    requirementId: string;
+    runId: string;
+    sessionId: string;
+    phase: RequirementPhase;
+    questions: PendingQuestion[];
+    status: PendingQuestionSetStatus;
+    answers: string[] | null;
+    createdAt: string;
+    answeredAt: string | null;
+}
+
+interface PendingQuestionSetRow {
+    id: string;
+    requirement_id: string;
+    run_id: string;
+    session_id: string;
+    phase: string;
+    questions: string;
+    status: string;
+    answers: string | null;
+    created_at: string;
+    answered_at: string | null;
+}
+
+function rowToSet(row: PendingQuestionSetRow): PendingQuestionSet {
+    return {
+        id: row.id,
+        requirementId: row.requirement_id,
+        runId: row.run_id,
+        sessionId: row.session_id,
+        phase: row.phase as RequirementPhase,
+        questions: JSON.parse(row.questions),
+        status: row.status as PendingQuestionSetStatus,
+        answers: row.answers ? JSON.parse(row.answers) : null,
+        createdAt: row.created_at,
+        answeredAt: row.answered_at,
+    };
+}
+
+export interface CreatePendingQuestionSetInput {
+    requirementId: string;
+    runId: string;
+    sessionId: string;
+    phase: RequirementPhase;
+    questions: PendingQuestion[];
+}
+
+/**
+ * pending_questions 唯一真源（spec: 统一「待回答问题」协议）：无论底层引擎是否支持
+ * 编程式中断，问题都落这张表；页面与回答 API 只读写这张表，不读 session_events。
+ */
+export class PendingQuestionsRepository {
+    private db: typeof db;
+
+    constructor(database?: typeof db) {
+        this.db = database ?? db;
+    }
+
+    create(input: CreatePendingQuestionSetInput): PendingQuestionSet {
+        const id = nanoid();
+        const now = new Date().toISOString();
+        this.db.prepare(
+            `INSERT INTO pending_questions (id, requirement_id, run_id, session_id, phase, questions, status, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)`
+        ).run(
+            id,
+            input.requirementId,
+            input.runId,
+            input.sessionId,
+            input.phase,
+            JSON.stringify(input.questions),
+            now
+        );
+        return this.getById(id)!;
+    }
+
+    getById(id: string): PendingQuestionSet | null {
+        const row = this.db.prepare('SELECT * FROM pending_questions WHERE id = ?').get(id) as PendingQuestionSetRow | undefined;
+        return row ? rowToSet(row) : null;
+    }
+
+    /** 一个需求当前（最新）的待回答问题集，供页面/回答 API 定位 */
+    getLatestByRequirement(requirementId: string): PendingQuestionSet | null {
+        // created_at（ISO 字符串）在同一毫秒内建多组问题时会打平，rowid 兜底保证取到最新一条
+        const row = this.db.prepare(
+            'SELECT * FROM pending_questions WHERE requirement_id = ? ORDER BY created_at DESC, rowid DESC LIMIT 1'
+        ).get(requirementId) as PendingQuestionSetRow | undefined;
+        return row ? rowToSet(row) : null;
+    }
+
+    /** 跨需求查询处于 pending 的问题集（如启动扫描、看板未答题角标） */
+    listPending(): PendingQuestionSet[] {
+        const rows = this.db.prepare("SELECT * FROM pending_questions WHERE status = 'pending' ORDER BY created_at")
+            .all() as unknown as PendingQuestionSetRow[];
+        return rows.map(rowToSet);
+    }
+
+    markAnswered(id: string, answers: string[]): PendingQuestionSet | null {
+        const now = new Date().toISOString();
+        this.db.prepare(
+            "UPDATE pending_questions SET status = 'answered', answers = ?, answered_at = ? WHERE id = ?"
+        ).run(JSON.stringify(answers), now, id);
+        return this.getById(id);
+    }
+
+    markCancelled(id: string): void {
+        const now = new Date().toISOString();
+        this.db.prepare(
+            "UPDATE pending_questions SET status = 'cancelled', answered_at = ? WHERE id = ?"
+        ).run(now, id);
+    }
+}
+
+export const pendingQuestionsRepository = new PendingQuestionsRepository();

--- a/src/core/requirement-repository.ts
+++ b/src/core/requirement-repository.ts
@@ -6,10 +6,22 @@ export type RequirementStatus =
     | 'queued'
     | 'in_progress'
     | 'waiting_input'
+    | 'analyzed'
     | 'implemented'
     | 'merged'
     | 'failed'
     | 'cancelled';
+
+/** 两阶段自动化：需求当前处于哪个阶段（NULL = 旧单阶段直通路径） */
+export type RequirementPhase = 'analysis' | 'implementation';
+
+/** 分析产出的结构化规格（目标/范围/验收），由 grilling+to-spec skill 产出后落库 */
+export interface AnalysisSpec {
+    goal?: string;
+    scope?: string;
+    acceptance?: string;
+    [key: string]: unknown;
+}
 
 export interface Requirement {
     id: string;
@@ -23,6 +35,14 @@ export interface Requirement {
     status: RequirementStatus;
     sourceUrl: string | null;
     sourceClosed: boolean;
+    /** 当前阶段，NULL = 旧单阶段直通路径 */
+    phase: RequirementPhase | null;
+    /** 分析规格 JSON，NULL = 尚未分析完成或走的旧路径 */
+    analysisSpec: AnalysisSpec | null;
+    /** 父需求 id，NULL = 非卡片（普通需求） */
+    parentId: string | null;
+    /** 卡片在父需求下的串行执行序号，NULL = 非卡片 */
+    cardNo: number | null;
     createdAt: string;
     updatedAt: string;
 }
@@ -39,6 +59,10 @@ interface RequirementRow {
     status: string;
     source_url: string | null;
     source_closed: number;
+    phase: string | null;
+    analysis_spec: string | null;
+    parent_id: string | null;
+    card_no: number | null;
     created_at: string;
     updated_at: string;
 }
@@ -56,6 +80,10 @@ function rowToRequirement(row: RequirementRow): Requirement {
         status: row.status as RequirementStatus,
         sourceUrl: row.source_url,
         sourceClosed: Boolean(row.source_closed),
+        phase: (row.phase as RequirementPhase | null) ?? null,
+        analysisSpec: row.analysis_spec ? JSON.parse(row.analysis_spec) : null,
+        parentId: row.parent_id,
+        cardNo: row.card_no,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
     };
@@ -175,6 +203,71 @@ export class RequirementRepository {
         const now = new Date().toISOString();
         this.db.prepare('UPDATE requirements SET source_closed = ?, updated_at = ? WHERE id = ?')
             .run(closed ? 1 : 0, now, id);
+    }
+
+    /** 两阶段自动化：进入/切换阶段（analysis/implementation），不改动状态 */
+    updatePhase(id: string, phase: RequirementPhase): void {
+        const now = new Date().toISOString();
+        this.db.prepare('UPDATE requirements SET phase = ?, updated_at = ? WHERE id = ?')
+            .run(phase, now, id);
+    }
+
+    /** 分析阶段完成后落库结构化规格；analyzed 状态下页面可再次调用本方法保存核验中的编辑 */
+    updateAnalysisSpec(id: string, spec: AnalysisSpec): void {
+        const now = new Date().toISOString();
+        this.db.prepare('UPDATE requirements SET analysis_spec = ?, updated_at = ? WHERE id = ?')
+            .run(JSON.stringify(spec), now, id);
+    }
+
+    /**
+     * 拆卡：把一张实现卡片建成父需求的子 requirement（spec: 卡 = 子 requirement，
+     * parentId + cardNo 串行顺序，无依赖图）。cardNo 由调用方按 to-tickets 的输出顺序传入。
+     */
+    createCard(input: { parentId: string; projectId: string; reqKey: string; source: string; sourceKey: string; title: string; cardNo: number }): Requirement {
+        const id = nanoid();
+        const now = new Date().toISOString();
+        this.db.prepare(
+            `INSERT INTO requirements (id, project_id, req_key, source, source_key, title, status, source_closed, parent_id, card_no, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, 'queued', 0, ?, ?, ?, ?)`
+        ).run(
+            id,
+            input.projectId,
+            input.reqKey,
+            input.source,
+            input.sourceKey,
+            input.title,
+            input.parentId,
+            input.cardNo,
+            now,
+            now
+        );
+        return this.getById(id)!;
+    }
+
+    /** 一张父需求下的全部卡片，按执行顺序（card_no 升序）返回 */
+    listCardsByParent(parentId: string): Requirement[] {
+        const rows = this.db.prepare('SELECT * FROM requirements WHERE parent_id = ? ORDER BY card_no ASC')
+            .all(parentId) as unknown as RequirementRow[];
+        return rows.map(rowToRequirement);
+    }
+
+    /** 核验阶段编辑卡片标题 */
+    updateCardTitle(id: string, title: string): void {
+        const now = new Date().toISOString();
+        this.db.prepare('UPDATE requirements SET title = ?, updated_at = ? WHERE id = ?')
+            .run(title, now, id);
+    }
+
+    /** 核验阶段调整卡片执行顺序 */
+    updateCardOrder(id: string, cardNo: number): void {
+        const now = new Date().toISOString();
+        this.db.prepare('UPDATE requirements SET card_no = ?, updated_at = ? WHERE id = ?')
+            .run(cardNo, now, id);
+    }
+
+    /** 核验阶段删除一张尚未执行的卡片 */
+    deleteCard(id: string): boolean {
+        return this.delete(id);
     }
 
     delete(id: string): boolean {

--- a/src/core/requirement-run-repository.ts
+++ b/src/core/requirement-run-repository.ts
@@ -16,6 +16,8 @@ export interface RequirementRun {
     prUrl: string | null;
     errorMessage: string | null;
     tokenCost: Record<string, unknown> | null;
+    /** 引擎侧会话续接凭据（codex=rollout uuid / opencode/pi=首行 session id），供问答后原生续接 */
+    resumeToken: string | null;
     startedAt: string;
     finishedAt: string | null;
 }
@@ -33,6 +35,7 @@ interface RequirementRunRow {
     pr_url: string | null;
     error_message: string | null;
     token_cost: string | null;
+    resume_token: string | null;
     started_at: string;
     finished_at: string | null;
 }
@@ -51,6 +54,7 @@ function rowToRun(row: RequirementRunRow): RequirementRun {
         prUrl: row.pr_url,
         errorMessage: row.error_message,
         tokenCost: row.token_cost ? JSON.parse(row.token_cost) : null,
+        resumeToken: row.resume_token,
         startedAt: row.started_at,
         finishedAt: row.finished_at,
     };
@@ -132,6 +136,11 @@ export class RequirementRunRepository {
 
     setTokenCost(id: string, tokenCost: Record<string, unknown>): void {
         this.db.prepare('UPDATE requirement_runs SET token_cost = ? WHERE id = ?').run(JSON.stringify(tokenCost), id);
+    }
+
+    /** 引擎 run() 结束后捕获的会话续接凭据，供回答分派时判断走 resume 续接 */
+    setResumeToken(id: string, resumeToken: string): void {
+        this.db.prepare('UPDATE requirement_runs SET resume_token = ? WHERE id = ?').run(resumeToken, id);
     }
 
     incrementRetryFrom(previousRun: RequirementRun, sessionId: string): RequirementRun {

--- a/tests/pending-questions-repository.test.ts
+++ b/tests/pending-questions-repository.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { PendingQuestionsRepository, type PendingQuestion } from '../src/core/pending-questions-repository.js';
+
+function createTestDb(): DatabaseSync {
+    const db = new DatabaseSync(':memory:');
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS pending_questions (
+            id              TEXT PRIMARY KEY,
+            requirement_id  TEXT NOT NULL,
+            run_id          TEXT NOT NULL,
+            session_id      TEXT NOT NULL,
+            phase           TEXT NOT NULL,
+            questions       TEXT NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'pending',
+            answers         TEXT,
+            created_at      TEXT NOT NULL,
+            answered_at     TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_pending_q_requirement ON pending_questions(requirement_id);
+        CREATE INDEX IF NOT EXISTS idx_pending_q_status      ON pending_questions(status);
+    `);
+    return db;
+}
+
+const oneQuestion: PendingQuestion[] = [{
+    id: 'q1',
+    question: 'PDF 的版式基准是什么？',
+    context: '周报目前是网页自适应布局',
+    options: [
+        { label: 'A4 纵向，跟随现有打印样式', description: '复用 print.css' },
+        { label: 'A4 横向，表格优先' },
+    ],
+    recommended: 0,
+}];
+
+describe('PendingQuestionsRepository', () => {
+    let repo: PendingQuestionsRepository;
+
+    beforeEach(() => {
+        repo = new PendingQuestionsRepository(createTestDb() as any);
+    });
+
+    it('creates a question set defaulting to pending / answers null', () => {
+        const set = repo.create({ requirementId: 'req1', runId: 'run1', sessionId: 's1', phase: 'analysis', questions: oneQuestion });
+        expect(set.status).toBe('pending');
+        expect(set.answers).toBeNull();
+        expect(set.answeredAt).toBeNull();
+        expect(set.questions).toEqual(oneQuestion);
+    });
+
+    it('getLatestByRequirement 返回该需求最新的一组问题（逐题作答场景下每轮各建一组）', () => {
+        repo.create({ requirementId: 'req1', runId: 'run1', sessionId: 's1', phase: 'analysis', questions: oneQuestion });
+        const second = repo.create({ requirementId: 'req1', runId: 'run1', sessionId: 's1', phase: 'analysis', questions: [{ id: 'q2', question: '导出入口放在哪里？' }] });
+
+        const latest = repo.getLatestByRequirement('req1');
+        expect(latest!.id).toBe(second.id);
+    });
+
+    it('markAnswered 落库答案并转 answered', () => {
+        const set = repo.create({ requirementId: 'req1', runId: 'run1', sessionId: 's1', phase: 'analysis', questions: oneQuestion });
+        const updated = repo.markAnswered(set.id, ['A4 纵向，跟随现有打印样式']);
+        expect(updated!.status).toBe('answered');
+        expect(updated!.answers).toEqual(['A4 纵向，跟随现有打印样式']);
+        expect(updated!.answeredAt).not.toBeNull();
+    });
+
+    it('markCancelled 转 cancelled（SSE 断连场景）', () => {
+        const set = repo.create({ requirementId: 'req1', runId: 'run1', sessionId: 's1', phase: 'implementation', questions: oneQuestion });
+        repo.markCancelled(set.id);
+        expect(repo.getById(set.id)!.status).toBe('cancelled');
+    });
+
+    it('listPending 只返回 pending 状态的问题集，跨需求', () => {
+        const a = repo.create({ requirementId: 'req1', runId: 'run1', sessionId: 's1', phase: 'analysis', questions: oneQuestion });
+        const b = repo.create({ requirementId: 'req2', runId: 'run2', sessionId: 's2', phase: 'analysis', questions: oneQuestion });
+        repo.markAnswered(a.id, ['x']);
+
+        const pending = repo.listPending();
+        expect(pending.map(p => p.id)).toEqual([b.id]);
+    });
+});

--- a/tests/requirement-repository.test.ts
+++ b/tests/requirement-repository.test.ts
@@ -24,12 +24,17 @@ function createTestDb(): DatabaseSync {
             status         TEXT NOT NULL DEFAULT 'synced',
             source_url     TEXT,
             source_closed  INTEGER NOT NULL DEFAULT 0,
+            phase          TEXT,
+            analysis_spec  TEXT,
+            parent_id      TEXT,
+            card_no        INTEGER,
             created_at     TEXT NOT NULL,
             updated_at     TEXT NOT NULL
         );
         CREATE UNIQUE INDEX IF NOT EXISTS uq_req_key      ON requirements(req_key);
         CREATE UNIQUE INDEX IF NOT EXISTS uq_req_dedup    ON requirements(project_id, source, source_key);
         CREATE INDEX IF NOT EXISTS idx_req_project_status ON requirements(project_id, status);
+        CREATE INDEX IF NOT EXISTS idx_req_parent          ON requirements(parent_id, card_no);
     `);
     db.exec(`INSERT INTO projects (id, name, dir, created_at, updated_at) VALUES ('p1', 'cmasterBot', '/repo', '2026-01-01', '2026-01-01')`);
     db.exec(`INSERT INTO projects (id, name, dir, created_at, updated_at) VALUES ('p2', 'otherRepo', '/repo2', '2026-01-01', '2026-01-01')`);
@@ -155,5 +160,65 @@ describe('RequirementRepository', () => {
         expect(repo.getById(stuck1.id)!.status).toBe('failed');
         expect(repo.getById(stuck2.id)!.status).toBe('failed');
         expect(repo.getById(untouched.id)!.status).toBe('synced');
+    });
+
+    // ─────────────────────────── 两阶段自动化：phase / analysisSpec / 卡片 ───────────────────────────
+
+    it('新建的需求 phase/analysisSpec/parentId/cardNo 均为 null（旧单阶段直通路径零迁移）', () => {
+        const req = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        expect(req.phase).toBeNull();
+        expect(req.analysisSpec).toBeNull();
+        expect(req.parentId).toBeNull();
+        expect(req.cardNo).toBeNull();
+    });
+
+    it('updatePhase 切换阶段，不影响 status', () => {
+        const req = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        repo.updateStatus(req.id, 'in_progress');
+        repo.updatePhase(req.id, 'analysis');
+        const updated = repo.getById(req.id)!;
+        expect(updated.phase).toBe('analysis');
+        expect(updated.status).toBe('in_progress');
+    });
+
+    it('updateAnalysisSpec 落库结构化规格，可重复调用覆盖（核验阶段编辑）', () => {
+        const req = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: 'A' });
+        repo.updateAnalysisSpec(req.id, { goal: '导出 PDF', scope: '详情页按钮' });
+        expect(repo.getById(req.id)!.analysisSpec).toEqual({ goal: '导出 PDF', scope: '详情页按钮' });
+
+        repo.updateAnalysisSpec(req.id, { goal: '导出 PDF（修订）', scope: '详情页按钮', acceptance: '5 秒内出件' });
+        expect(repo.getById(req.id)!.analysisSpec).toEqual({ goal: '导出 PDF（修订）', scope: '详情页按钮', acceptance: '5 秒内出件' });
+    });
+
+    it('createCard 建子 requirement，listCardsByParent 按 card_no 升序返回', () => {
+        const parent = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: '父需求' });
+        const card2 = repo.createCard({ parentId: parent.id, projectId: 'p1', reqKey: 'cmasterBot#1-card-2', source: 'manual', sourceKey: 'card-2', title: '卡片 2', cardNo: 2 });
+        const card1 = repo.createCard({ parentId: parent.id, projectId: 'p1', reqKey: 'cmasterBot#1-card-1', source: 'manual', sourceKey: 'card-1', title: '卡片 1', cardNo: 1 });
+
+        expect(card1.parentId).toBe(parent.id);
+        expect(card1.status).toBe('queued');
+
+        const cards = repo.listCardsByParent(parent.id);
+        expect(cards.map(c => c.id)).toEqual([card1.id, card2.id]);
+    });
+
+    it('updateCardTitle / updateCardOrder 支持核验阶段编辑', () => {
+        const parent = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: '父需求' });
+        const card = repo.createCard({ parentId: parent.id, projectId: 'p1', reqKey: 'cmasterBot#1-card-1', source: 'manual', sourceKey: 'card-1', title: '旧标题', cardNo: 1 });
+
+        repo.updateCardTitle(card.id, '新标题');
+        repo.updateCardOrder(card.id, 3);
+        const updated = repo.getById(card.id)!;
+        expect(updated.title).toBe('新标题');
+        expect(updated.cardNo).toBe(3);
+    });
+
+    it('deleteCard 删除尚未执行的卡片，不影响其余卡片', () => {
+        const parent = repo.create({ projectId: 'p1', reqKey: 'cmasterBot#1', source: 'github', sourceKey: '1', title: '父需求' });
+        const card1 = repo.createCard({ parentId: parent.id, projectId: 'p1', reqKey: 'cmasterBot#1-card-1', source: 'manual', sourceKey: 'card-1', title: '卡片 1', cardNo: 1 });
+        const card2 = repo.createCard({ parentId: parent.id, projectId: 'p1', reqKey: 'cmasterBot#1-card-2', source: 'manual', sourceKey: 'card-2', title: '卡片 2', cardNo: 2 });
+
+        expect(repo.deleteCard(card1.id)).toBe(true);
+        expect(repo.listCardsByParent(parent.id).map(c => c.id)).toEqual([card2.id]);
     });
 });

--- a/tests/requirement-run-repository.test.ts
+++ b/tests/requirement-run-repository.test.ts
@@ -18,6 +18,7 @@ function createTestDb(): DatabaseSync {
             pr_url          TEXT,
             error_message   TEXT,
             token_cost      TEXT,
+            resume_token    TEXT,
             started_at      TEXT NOT NULL,
             finished_at     TEXT
         );
@@ -131,5 +132,13 @@ describe('RequirementRunRepository', () => {
         expect(fetched1.errorMessage).toBe('服务重启，执行中断');
         expect(fetched1.finishedAt).not.toBeNull();
         expect(repo.getById(untouched.id)!.status).toBe('succeeded');
+    });
+
+    it('新建的 run resumeToken 为 null，setResumeToken 后可读取（问答分派用）', () => {
+        const run = repo.create({ requirementId: 'r1', projectId: 'p1', engine: 'codex', sessionId: 's1' });
+        expect(run.resumeToken).toBeNull();
+
+        repo.setResumeToken(run.id, '019f553e-576a-78e1-a34c-465152fae76b');
+        expect(repo.getById(run.id)!.resumeToken).toBe('019f553e-576a-78e1-a34c-465152fae76b');
     });
 });


### PR DESCRIPTION
## Summary
- `requirements` 表新增 `phase`/`analysis_spec`/`parent_id`/`card_no` 四列（均 nullable，存量数据零迁移）+ `analyzed` 状态；`requirement_runs` 新增 `resume_token` 列。
- 新建 `pending_questions` 表 + `PendingQuestionsRepository`：待回答问题的唯一真源（分析/实现阶段共用）。
- `RequirementRepository` 扩展卡片 CRUD：`createCard`/`listCardsByParent`/`updateCardTitle`/`updateCardOrder`/`deleteCard`，以及 `updatePhase`/`updateAnalysisSpec`。

纵向切片 1/6，来自 spec [#85](https://github.com/yiyisf/masterBot/issues/85)（研发流程两阶段自动化，设计过程见地图 [#74](https://github.com/yiyisf/masterBot/issues/74)）。对应实施 ticket：[#91](https://github.com/yiyisf/masterBot/issues/91)。其余 5 张 ticket（#86 编排 / #87 引擎 resume / #88 问答协议 / #89 skills 注入 / #90 前端）依赖本切片。

## Test plan
- [x] `npx vitest run` — 415 tests passed（新增 repository 单测覆盖新方法，沿用现有 fake-DB 模式）
- [x] `npx tsc --noEmit`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)