### PR TITLE
feat(dev-workflow): 三引擎（codex/opencode/pi）原生会话续接接入

### DIFF
--- a/src/core/harness/agent-engine.ts
+++ b/src/core/harness/agent-engine.ts
@@ -23,7 +23,7 @@ export type AgentEngineKind = 'native' | 'claude-agent-sdk' | 'codex' | 'opencod
 /**
  * 引擎能力声明（研发流程管理模块，spec §5.2）。
  * interactiveApproval：执行中能否编程式向人提问/请求审批（codex exec = false）。
- * resume：能否跨进程恢复会话（v1 全部 false；未来 Claude `--resume` 等）。
+ * resume：能否跨进程恢复会话（codex/opencode/pi 均支持原生会话续接，spec: 两阶段自动化 #85）。
  */
 export interface EngineCapabilities {
     interactiveApproval: boolean;
@@ -41,6 +41,11 @@ export interface EngineRunContext {
     cwd?: string;
     /** 审批模式：'auto' 沙箱自动判定（默认）；'ask-on-risky' 危险操作转人工审批（spec §5.4）*/
     approvalMode?: 'auto' | 'ask-on-risky';
+    /**
+     * 上一轮 run() 捕获的会话续接凭据（capabilities.resume=true 的引擎专用）。
+     * 传入时引擎应续接同一会话而非新建；未传或引擎不支持 resume 时忽略。
+     */
+    resumeToken?: string;
 }
 
 export interface IAgentEngine {

--- a/src/core/harness/codex-engine.ts
+++ b/src/core/harness/codex-engine.ts
@@ -31,10 +31,24 @@
  * `codex exec --help` 同样暴露 `-C/--cd <DIR>`（"Tell the agent to use the specified
  * directory as its working root"），说明 codex 内部可能不是单纯依赖进程级 cwd 判定工作目录。
  * 之前只靠 `child_process.spawn()` 的 `cwd` 选项，现在显式加上 `-C`，两边双保险。
+ *
+ * Resume 接入（两阶段自动化 spec #85，实测记录见地图 ticket #75）：
+ * - `--json` 输出**不含**会话 id；id 只在 `~/.codex/sessions/<yyyy/mm/dd>/rollout-*-<uuid>.jsonl`
+ *   的文件名（或文件首行 `session_meta.payload.id`）里，run() 结束后按 cwd 匹配 + 时间窗反查。
+ * - resume 命令形态：所有 flags 必须在 `resume` 子命令**之前**，形如
+ *   `codex exec --json --sandbox <mode> -C <cwd> resume <uuid> "<prompt>"`；resume 轮 sandbox
+ *   默认回显 read-only，必须显式重传 `--sandbox`。
+ * - **关键坑**：传入不存在的 uuid 不报错——exit 0，静默新建一个不带上下文的新会话。
+ *   本引擎在使用调用方传入的 resumeToken 前会先校验对应 rollout 文件是否存在，不存在则
+ *   直接抛错，不让"丢现场"被误判为"续接成功"。
  */
 
 import { spawn } from 'child_process';
 import { createInterface } from 'readline';
+import { readdir, readFile, stat } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+import os from 'os';
 import type { ExecutionStep, Logger } from '../../types.js';
 import type { IAgentEngine, EngineRunContext, EngineCapabilities } from './agent-engine.js';
 
@@ -45,6 +59,8 @@ export interface CodexEngineOptions {
     binaryPath?: string;
     /** 沙箱策略（默认 workspace-write，与 spec §5.3 一致）*/
     sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+    /** `~/.codex/sessions` 根目录覆盖（测试用，指向临时目录）*/
+    sessionsRoot?: string;
 }
 
 interface CodexJsonLine {
@@ -58,21 +74,41 @@ interface CodexJsonLine {
 export class CodexEngine implements IAgentEngine {
     readonly kind = 'codex' as const;
     // codex exec 非交互模式无编程式转人工的接口（-a/--ask-for-approval 只在交互式顶层命令下有效，
-    // 已实测确认 `codex exec --help` 不暴露该参数）；不做 PTY 文本匹配兜底（spec §5.5）；v1 无 resume
-    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: false };
+    // 已实测确认 `codex exec --help` 不暴露该参数）；不做 PTY 文本匹配兜底（spec §5.5）。
+    // resume=true：接 codex 原生会话续接（见文件头注释，实测记录 #75）
+    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: true };
 
     constructor(private logger: Logger, private options: CodexEngineOptions = {}) {}
+
+    private get sessionsRoot(): string {
+        return this.options.sessionsRoot ?? path.join(os.homedir(), '.codex', 'sessions');
+    }
 
     async *run(input: string, context: EngineRunContext): AsyncGenerator<ExecutionStep> {
         const cwd = context.cwd ?? this.options.cwd ?? process.cwd();
         const binary = this.options.binaryPath ?? 'codex';
         const sandbox = this.options.sandbox ?? 'workspace-write';
+
+        // 续接：resumeToken 必须先校验 rollout 文件仍存在，否则 codex 会静默新建一个不带
+        // 上下文的新会话（exit 0，无任何报错信号）——那样"丢现场"会被误判为"续接成功"。
+        if (context.resumeToken) {
+            const exists = await this._rolloutFileExists(context.resumeToken);
+            if (!exists) {
+                throw new Error(`codex resume 失败：会话 ${context.resumeToken} 对应的 rollout 文件不存在（可能已被清理），无法安全续接`);
+            }
+        }
+
         // -C/--cd 显式声明"working root"（同一类问题在 opencode 引擎上被真实用例踩中过：
         // 只靠 spawn() 的 cwd 选项，工具自己内部的目录解析可能不认——codex --help 里这个参数
-        // 的说明原文就是 "Tell the agent to use the specified directory as its working root"）
-        const args = ['exec', '--json', '--sandbox', sandbox, '--skip-git-repo-check', '-C', cwd, input];
+        // 的说明原文就是 "Tell the agent to use the specified directory as its working root"）。
+        // resume 子命令的 flags 必须前置（含 --sandbox，resume 轮默认回显 read-only 必须重传）。
+        const configFlags = ['--json', '--sandbox', sandbox, '--skip-git-repo-check', '-C', cwd];
+        const args = context.resumeToken
+            ? ['exec', ...configFlags, 'resume', context.resumeToken, input]
+            : ['exec', ...configFlags, input];
+        const runStartedAt = Date.now();
 
-        this.logger.info(`[codex-engine] Starting "${binary} exec" (cwd: ${cwd}, sandbox: ${sandbox})`);
+        this.logger.info(`[codex-engine] Starting "${binary} exec${context.resumeToken ? ' resume' : ''}" (cwd: ${cwd}, sandbox: ${sandbox})`);
 
         const child = spawn(binary, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
 
@@ -124,9 +160,76 @@ export class CodexEngine implements IAgentEngine {
         if (exitCode !== 0) {
             throw new Error(`codex exec exited with code ${exitCode}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`);
         }
+
+        // 成功结束后反查本轮 rollout uuid 作为 resumeToken（--json 输出本身不含会话 id）
+        const resumeToken = await this._findResumeToken(cwd, runStartedAt);
+        if (resumeToken) {
+            yield { type: 'meta', content: '💾 codex 会话已记录，可续接', resumeToken, timestamp: new Date() };
+        }
     }
 
     // ─────────────────────────────── private ───────────────────────────────
+
+    /** 按 cwd + 时间窗扫描 sessions 目录，反查本轮 run 对应的 rollout uuid */
+    private async _findResumeToken(cwd: string, sinceMs: number): Promise<string | undefined> {
+        try {
+            const candidates = await this._listRolloutFiles();
+            let best: { file: string; mtime: number; id: string } | undefined;
+            for (const file of candidates) {
+                let st;
+                try {
+                    st = await stat(file);
+                } catch { continue; }
+                if (st.mtimeMs < sinceMs - 2000) continue; // 允许 2s 时钟误差
+                const meta = await this._readSessionMeta(file);
+                if (!meta || meta.cwd !== cwd) continue;
+                if (!best || st.mtimeMs > best.mtime) best = { file, mtime: st.mtimeMs, id: meta.id };
+            }
+            return best?.id;
+        } catch {
+            return undefined; // best-effort：反查失败不影响主流程（下轮就没有 resume 能力而已）
+        }
+    }
+
+    /** 校验调用方传入的 resumeToken 对应的 rollout 文件是否仍存在（伪 id 防御） */
+    private async _rolloutFileExists(resumeToken: string): Promise<boolean> {
+        const candidates = await this._listRolloutFiles();
+        return candidates.some(f => f.includes(resumeToken));
+    }
+
+    private async _listRolloutFiles(): Promise<string[]> {
+        const root = this.sessionsRoot;
+        if (!existsSync(root)) return [];
+        const results: string[] = [];
+        const walk = async (dir: string, depth: number) => {
+            let entries;
+            try {
+                entries = await readdir(dir, { withFileTypes: true });
+            } catch { return; }
+            for (const entry of entries) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory() && depth < 3) await walk(full, depth + 1);
+                else if (entry.isFile() && entry.name.endsWith('.jsonl')) results.push(full);
+            }
+        };
+        await walk(root, 0);
+        return results;
+    }
+
+    private async _readSessionMeta(file: string): Promise<{ id: string; cwd: string } | undefined> {
+        try {
+            const content = await readFile(file, 'utf-8');
+            const firstLine = content.split('\n', 1)[0];
+            if (!firstLine) return undefined;
+            const parsed = JSON.parse(firstLine);
+            if (parsed?.type === 'session_meta' && parsed?.payload?.id && parsed?.payload?.cwd) {
+                return { id: parsed.payload.id, cwd: parsed.payload.cwd };
+            }
+            return undefined;
+        } catch {
+            return undefined;
+        }
+    }
 
     private *_translateLine(raw: string): Generator<ExecutionStep> {
         let parsed: CodexJsonLine;

--- a/src/core/harness/opencode-engine.ts
+++ b/src/core/harness/opencode-engine.ts
@@ -30,6 +30,15 @@
  * 此时 `child_process.spawn()` 的 `cwd` 选项只影响新 spawn 出来的这个客户端进程，管不到
  * 被复用的那个 server 进程，导致实际操作目录/需求都不对。修复：显式传 `--dir <cwd>`，
  * 不管是新起的还是被复用的 server，都会被这个参数正确定向。
+ *
+ * Resume 接入（两阶段自动化 spec #85，实测记录见地图 ticket #76，opencode CLI 1.17.18）：
+ * - resumeToken 就是 JSONL 每行都带的顶层 `sessionID`，无需像 codex 那样反查文件，运行中
+ *   捕获第一行出现的即可。
+ * - resume 命令：`opencode run --session <id>`，**必须复用首轮相同的 `--dir`**。
+ * - **关键坑**：resume 时 `--dir` 与会话原目录不一致会导致进程无输出、无报错地挂死
+ *   （非 daemon 复用场景实测复现）。伪造 id 会显式报错（`Session not found`），这点比 codex
+ *   更友好；但目录不一致这个坑报错机制救不了，只能靠进程级看门狗兜底——resume 场景下若
+ *   watchdogMs 内收不到任何一行输出，主动 kill 并抛出清晰错误。
  */
 
 import { spawn } from 'child_process';
@@ -44,6 +53,8 @@ export interface OpenCodeEngineOptions {
     binaryPath?: string;
     /** provider/model，格式 "provider/model"（默认由 opencode 自身配置决定）*/
     model?: string;
+    /** resume 场景下的看门狗超时（ms，默认 120000）：目录不一致会挂死且不报错，只能靠超时兜底 */
+    resumeWatchdogMs?: number;
 }
 
 interface OpenCodePart {
@@ -70,8 +81,9 @@ interface OpenCodeJsonLine {
 export class OpenCodeEngine implements IAgentEngine {
     readonly kind = 'opencode' as const;
     // v1 用一次性非交互模式（opencode run），无编程式转人工接口；opencode serve 的双向
-    // 通道留作后续增强（见文件头注释）；不做 PTY 文本匹配兜底；v1 无 resume
-    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: false };
+    // 通道留作后续增强（见文件头注释）；不做 PTY 文本匹配兜底。
+    // resume=true：接 opencode 原生 --session 续接（见文件头注释，实测记录 #76）
+    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: true };
 
     constructor(private logger: Logger, private options: OpenCodeEngineOptions = {}) {}
 
@@ -81,11 +93,13 @@ export class OpenCodeEngine implements IAgentEngine {
         // 真实使用中发现：opencode 会自动发现/复用本机已在跑的 opencode server（daemon 式架构），
         // 此时新 spawn 的进程只是连去那个已有 server，spawn() 的 cwd 选项管不到它——
         // 必须显式传 --dir 告诉（新起的或被复用的）server 用哪个目录，不能只依赖进程级 cwd。
+        // resume 时必须复用首轮相同的 --dir（目录不一致会挂死，见文件头注释）。
         const args = ['run', '--format', 'json', '--dir', cwd];
+        if (context.resumeToken) args.push('--session', context.resumeToken);
         if (this.options.model) args.push('-m', this.options.model);
         args.push(input);
 
-        this.logger.info(`[opencode-engine] Starting "${binary} run" (cwd: ${cwd})`);
+        this.logger.info(`[opencode-engine] Starting "${binary} run"${context.resumeToken ? ' --session' : ''} (cwd: ${cwd})`);
 
         const child = spawn(binary, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
 
@@ -111,11 +125,29 @@ export class OpenCodeEngine implements IAgentEngine {
             child.on('close', (code, signal) => { exitCode = code; exitSignal = signal; resolve(); });
         });
 
+        // resume 场景专属看门狗：目录不一致时进程无输出无报错地挂死（实测确认），报错机制救不了，
+        // 只能靠"多久没收到一行输出就主动判定为挂死"兜底。首轮（无 resumeToken）不受影响。
+        let watchdogTimedOut = false;
+        let watchdogTimer: NodeJS.Timeout | undefined;
+        const armWatchdog = () => {
+            if (!context.resumeToken) return;
+            clearTimeout(watchdogTimer);
+            watchdogTimer = setTimeout(() => {
+                watchdogTimedOut = true;
+                child.kill();
+            }, this.options.resumeWatchdogMs ?? 120_000);
+        };
+        armWatchdog();
+
+        let resumeToken: string | undefined;
+
         if (child.stdout) {
             const rl = createInterface({ input: child.stdout });
             try {
                 for await (const line of rl) {
+                    armWatchdog();
                     if (!line.trim()) continue;
+                    if (!resumeToken) resumeToken = this._extractSessionId(line);
                     yield* this._translateLine(line);
                 }
             } finally {
@@ -124,14 +156,31 @@ export class OpenCodeEngine implements IAgentEngine {
         }
 
         await closePromise;
+        clearTimeout(watchdogTimer);
         if (context.abortSignal) context.abortSignal.removeEventListener('abort', onAbort);
 
+        if (watchdogTimedOut) {
+            throw new Error(`opencode resume 挂死：${this.options.resumeWatchdogMs ?? 120_000}ms 内无任何输出（很可能是 --dir 与会话原目录不一致导致进程无输出无报错地挂死，见 opencode-engine.ts 文件头注释）`);
+        }
         if (spawnError) throw spawnError;
         if (exitSignal) {
             throw new Error(`opencode run terminated by signal ${exitSignal}${context.abortSignal?.aborted ? ' (aborted)' : ''}`);
         }
         if (exitCode !== 0) {
             throw new Error(`opencode run exited with code ${exitCode}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`);
+        }
+
+        if (resumeToken) {
+            yield { type: 'meta', content: '💾 opencode 会话已记录，可续接', resumeToken, timestamp: new Date() };
+        }
+    }
+
+    private _extractSessionId(raw: string): string | undefined {
+        try {
+            const parsed = JSON.parse(raw) as OpenCodeJsonLine;
+            return typeof parsed.sessionID === 'string' ? parsed.sessionID : undefined;
+        } catch {
+            return undefined;
         }
     }
 

--- a/src/core/harness/pi-engine.ts
+++ b/src/core/harness/pi-engine.ts
@@ -27,10 +27,21 @@
  *   `message_update` 里的 toolcall_* 增量事件干净得多，直接用这一对映射 action/observation。
  * - `agent_end`：整个 agent 循环结束（可能包含多个 turn），携带完整 `messages[]`；只用作
  *   收尾标记，不重复提取内容（已经在各个 message_end 里发过了）。
+ *
+ * Resume 接入（两阶段自动化 spec #85，实测记录见地图 ticket #77，pi 0.80.6）：
+ * - pi 有原生轻量续接参数，无需 `--mode rpc`：`--session <id>` 直接续接，配合固定
+ *   `--session-dir <dir>`；resumeToken 取首行 `session` 事件的 `id` 字段（比 codex 友好，
+ *   不用扫目录反查）。
+ * - **关键**：续接必须用 `--session`，不能用 `--session-id`——后者传伪 id 时会静默新建
+ *   一个不带上下文的空会话（exit 0，等同 codex 的坑）；`--session` 传伪 id 则显式
+ *   `exit 1` + stderr `No session found matching '…'`，失败可判。
+ * - 已知坑仍在（与非 resume 场景一致）：API 认证/网络失败时退出码仍是 0，失败信号只在
+ *   `message_end.stopReason === "error"` 里，续接后同样需要检测。
  */
 
 import { spawn } from 'child_process';
 import { createInterface } from 'readline';
+import path from 'path';
 import type { ExecutionStep, Logger } from '../../types.js';
 import type { IAgentEngine, EngineRunContext, EngineCapabilities } from './agent-engine.js';
 
@@ -45,6 +56,11 @@ export interface PiEngineOptions {
     model?: string;
     /** 工具白名单（默认不传，使用 pi 默认工具集：read/bash/edit/write）*/
     tools?: string[];
+    /**
+     * 会话存储目录（--session-dir，固定传递以保证首轮与 resume 轮指向同一位置）。
+     * 默认 `<cwd>/.cmaster-pi-sessions`（按需求 worktree 隔离，实测建议按实例隔离）。
+     */
+    sessionDir?: string;
 }
 
 interface PiTextContentPart {
@@ -77,32 +93,42 @@ interface PiJsonLine {
     result?: { content?: Array<{ type: string; text?: string }> };
     isError?: boolean;
     cwd?: string;
+    /** session 事件携带的会话 id，用作 resumeToken（实测记录 #77） */
+    id?: string;
     [key: string]: unknown;
 }
 
 interface TranslateState {
     hasError: boolean;
     errorMessage?: string;
+    /** 首行 session 事件捕获的会话 id，作为 resumeToken */
+    sessionId?: string;
 }
 
 export class PiEngine implements IAgentEngine {
     readonly kind = 'pi' as const;
     // v1 用一次性非交互模式（--mode json -p），无编程式转人工接口；--mode rpc 的双向
-    // 通道留作后续增强（见文件头注释）；不做 PTY 文本匹配兜底；v1 无 resume
-    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: false };
+    // 通道留作后续增强（见文件头注释）。
+    // resume=true：接 pi 原生 --session 续接（见文件头注释，实测记录 #77）
+    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: true };
 
     constructor(private logger: Logger, private options: PiEngineOptions = {}) {}
 
     async *run(input: string, context: EngineRunContext): AsyncGenerator<ExecutionStep> {
         const cwd = context.cwd ?? this.options.cwd ?? process.cwd();
         const binary = this.options.binaryPath ?? 'pi';
+        const sessionDir = this.options.sessionDir ?? path.join(cwd, '.cmaster-pi-sessions');
         const args = ['--mode', 'json', '-p'];
         if (this.options.provider) args.push('--provider', this.options.provider);
         if (this.options.model) args.push('--model', this.options.model);
         if (this.options.tools && this.options.tools.length > 0) args.push('--tools', this.options.tools.join(','));
+        // --session-dir 固定传递，保证首轮与 resume 轮指向同一位置；resume 用 --session
+        // （不用 --session-id，那个参数伪 id 会静默新建，见文件头注释）
+        args.push('--session-dir', sessionDir);
+        if (context.resumeToken) args.push('--session', context.resumeToken);
         args.push(input);
 
-        this.logger.info(`[pi-engine] Starting "${binary} -p" (cwd: ${cwd})`);
+        this.logger.info(`[pi-engine] Starting "${binary} -p"${context.resumeToken ? ' --session' : ''} (cwd: ${cwd})`);
 
         const child = spawn(binary, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
 
@@ -156,6 +182,10 @@ export class PiEngine implements IAgentEngine {
         if (state.hasError) {
             throw new Error(`pi reported an error: ${state.errorMessage ?? 'unknown error'}`);
         }
+
+        if (state.sessionId) {
+            yield { type: 'meta', content: '💾 pi 会话已记录，可续接', resumeToken: state.sessionId, timestamp: new Date() };
+        }
     }
 
     // ─────────────────────────────── private ───────────────────────────────
@@ -172,6 +202,7 @@ export class PiEngine implements IAgentEngine {
 
         switch (parsed.type) {
             case 'session':
+                if (typeof parsed.id === 'string' && !state.sessionId) state.sessionId = parsed.id;
                 yield { type: 'meta', content: `🚀 pi 会话已启动（cwd: ${parsed.cwd ?? '-'}）`, timestamp: now() };
                 break;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,12 @@ export interface ExecutionStep {
     droppedCount?: number;
     // Phase 26: Harness instance tracking（供前端关联子任务面板）
     harnessInstanceId?: string;
+    /**
+     * 研发流程两阶段自动化：引擎侧会话续接凭据（capabilities.resume=true 时，run() 结束前
+     * 在最后一个 meta step 上携带）。codex=rollout uuid，opencode/pi=首行 session id。
+     * 调用方（RequirementExecutionService）捕获后存入 requirement_runs.resume_token。
+     */
+    resumeToken?: string;
     timestamp: Date;
 }
 

--- a/tests/codex-engine.test.ts
+++ b/tests/codex-engine.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { writeFileSync, mkdtempSync, mkdirSync, chmodSync, rmSync, readFileSync } from 'fs';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, mkdirSync, chmodSync, rmSync, readFileSync, utimesSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { CodexEngine } from '../src/core/harness/codex-engine.js';
@@ -10,6 +10,8 @@ const mockMemory: MemoryAccess = { get: async () => undefined, set: async () => 
 
 let tmpDir: string;
 let fakeBinPath: string;
+/** 大部分测试无关 resume 反查，指向一个空目录，避免误扫到本机真实 ~/.codex/sessions */
+let emptySessionsRoot: string;
 
 async function drain(gen: AsyncGenerator<ExecutionStep>): Promise<ExecutionStep[]> {
     const steps: ExecutionStep[] = [];
@@ -32,6 +34,7 @@ if (stderrOut) process.stderr.write(stderrOut);
 process.exitCode = parseInt(process.env.FAKE_CODEX_EXIT_CODE || '0', 10);
 `);
     chmodSync(fakeBinPath, 0o755);
+    emptySessionsRoot = mkdtempSync(path.join(tmpdir(), 'fake-codex-sessions-empty-'));
 });
 
 afterAll(() => {
@@ -46,15 +49,15 @@ afterEach(() => {
 });
 
 describe('CodexEngine', () => {
-    it('capabilities: interactiveApproval=false, resume=false（显式降级，spec §5.5）', () => {
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
-        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
+    it('capabilities: interactiveApproval=false（显式降级，spec §5.5），resume=true（原生会话续接，spec #85）', () => {
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
+        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: true });
     });
 
     it('拼装的 CLI 参数包含 exec/--json/--sandbox/-C/--skip-git-repo-check 与 prompt（不含 -a/--ask-for-approval，实测确认 exec 不支持该参数）', async () => {
         const argsFile = path.join(tmpDir, 'args.json');
         process.env.FAKE_CODEX_ARGS_FILE = argsFile;
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sandbox: 'read-only' });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sandbox: 'read-only', sessionsRoot: emptySessionsRoot });
         await drain(engine.run('implement X', { sessionId: 's8', memory: mockMemory, cwd: tmpDir }));
         const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
         expect(args).toEqual(['exec', '--json', '--sandbox', 'read-only', '--skip-git-repo-check', '-C', tmpDir, 'implement X']);
@@ -63,7 +66,7 @@ describe('CodexEngine', () => {
     it('-C 显式传给 CLI，不依赖进程级 cwd（防御性修复，同一类 bug 在 opencode 引擎上被真实踩中过）', async () => {
         const argsFile = path.join(tmpDir, 'args.json');
         process.env.FAKE_CODEX_ARGS_FILE = argsFile;
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const otherDir = path.join(tmpDir, 'a-different-project-dir');
         mkdirSync(otherDir);
         await drain(engine.run('task', { sessionId: 's8b', memory: mockMemory, cwd: otherDir }));
@@ -79,7 +82,7 @@ describe('CodexEngine', () => {
             JSON.stringify({ id: '0', msg: { type: 'task_started', model_context_window: 272000 } }),
         ].join('\n') + '\n';
 
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('do the task', { sessionId: 's1', memory: mockMemory }));
 
         expect(steps).toHaveLength(2);
@@ -94,7 +97,7 @@ describe('CodexEngine', () => {
             JSON.stringify({ id: '0', msg: { type: 'error', message: 'unexpected status 402' } }),
         ].join('\n') + '\n';
 
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('task', { sessionId: 's2', memory: mockMemory }));
 
         expect(steps.some(s => s.type === 'meta' && s.content.includes('重试中'))).toBe(true);
@@ -115,7 +118,7 @@ describe('CodexEngine', () => {
             JSON.stringify({ id: '0', msg: { type: 'token_count', info: null } }),
         ].join('\n') + '\n';
 
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('Just reply with the single word: pong.', { sessionId: 's1b', memory: mockMemory }));
 
         // 配置回显 1 条 meta（prompt 回显不产出）+ task_started 1 条 meta + agent_message 1 条
@@ -130,7 +133,7 @@ describe('CodexEngine', () => {
 
     it('未识别的事件类型不静默丢弃，降级为 meta 透出原始 payload', async () => {
         process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'some_future_event', foo: 'bar' } }) + '\n';
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('task', { sessionId: 's3', memory: mockMemory }));
         expect(steps).toHaveLength(1);
         expect(steps[0].content).toContain('some_future_event');
@@ -142,7 +145,7 @@ describe('CodexEngine', () => {
             'not json at all',
             JSON.stringify({ id: '0', msg: { type: 'task_started', model_context_window: 1000 } }),
         ].join('\n') + '\n';
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('task', { sessionId: 's3b', memory: mockMemory }));
         expect(steps).toHaveLength(1);
         expect(steps[0].content).toContain('1000');
@@ -156,7 +159,7 @@ describe('CodexEngine', () => {
             JSON.stringify({ id: '0', msg: { type: 'task_complete', last_agent_message: '完成了' } }),
         ].join('\n') + '\n';
 
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('task', { sessionId: 's4', memory: mockMemory }));
 
         expect(steps.find(s => s.type === 'thought')?.content).toBe('思考中...');
@@ -170,7 +173,7 @@ describe('CodexEngine', () => {
     it('非零退出码抛错，携带 stderr', async () => {
         process.env.FAKE_CODEX_EXIT_CODE = '1';
         process.env.FAKE_CODEX_STDERR = 'boom';
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         await expect(drain(engine.run('task', { sessionId: 's5', memory: mockMemory })))
             .rejects.toThrow(/exited with code 1/);
     });
@@ -193,5 +196,73 @@ describe('CodexEngine', () => {
         controller.abort();
         // kill 后进程以信号终止（非 0 退出码），run() 应该 reject 而不是永久挂起
         await expect(runPromise).rejects.toThrow();
+    });
+
+    // ─────────────────────────── Resume（两阶段自动化 spec #85，实测记录 #75）───────────────────────────
+
+    describe('resume', () => {
+        let sessionsRoot: string;
+
+        function writeRollout(uuid: string, cwd: string, mtimeMs: number): void {
+            const dayDir = path.join(sessionsRoot, '2026', '07', '12');
+            mkdirSync(dayDir, { recursive: true });
+            const file = path.join(dayDir, `rollout-2026-07-12T10-00-00-${uuid}.jsonl`);
+            writeFileSync(file, JSON.stringify({
+                timestamp: '2026-07-12T02:00:00.000Z',
+                type: 'session_meta',
+                payload: { id: uuid, timestamp: '2026-07-12T02:00:00.000Z', cwd, originator: 'codex_cli_rs', cli_version: '0.39.0' },
+            }) + '\n');
+            const now = new Date(mtimeMs);
+            utimesSync(file, now, now);
+        }
+
+        beforeEach(() => {
+            // 每个用例独立的 sessionsRoot，避免上一个用例写的 rollout 文件在时间窗内被下一个误认
+            sessionsRoot = mkdtempSync(path.join(tmpdir(), 'fake-codex-sessions-'));
+        });
+
+        it('成功结束后按 cwd + 时间窗反查 rollout uuid，作为最后一步 meta 的 resumeToken 携带', async () => {
+            process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'agent_message', message: 'ok' } }) + '\n';
+            const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot });
+            const runStart = Date.now();
+            writeRollout('019f553e-aaaa-bbbb-cccc-000000000001', tmpDir, runStart + 500);
+
+            const steps = await drain(engine.run('task', { sessionId: 'sr1', memory: mockMemory, cwd: tmpDir }));
+            const resumeStep = steps.find(s => s.resumeToken);
+            expect(resumeStep?.resumeToken).toBe('019f553e-aaaa-bbbb-cccc-000000000001');
+        });
+
+        it('cwd 不匹配的 rollout 文件不会被误认成本轮会话', async () => {
+            process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'agent_message', message: 'ok' } }) + '\n';
+            const otherDir = path.join(tmpDir, 'unrelated-project');
+            mkdirSync(otherDir, { recursive: true });
+            const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot });
+            const runStart = Date.now();
+            writeRollout('019f553e-aaaa-bbbb-cccc-000000000002', otherDir, runStart + 500);
+
+            const steps = await drain(engine.run('task', { sessionId: 'sr2', memory: mockMemory, cwd: tmpDir }));
+            expect(steps.some(s => s.resumeToken)).toBe(false);
+        });
+
+        it('resume 时 flags 前置于 resume 子命令，携带 --sandbox 重传（resume 轮默认回显 read-only）', async () => {
+            const argsFile = path.join(tmpDir, 'resume-args.json');
+            process.env.FAKE_CODEX_ARGS_FILE = argsFile;
+            process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'agent_message', message: 'ok' } }) + '\n';
+            const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot });
+            const uuid = '019f553e-aaaa-bbbb-cccc-000000000003';
+            writeRollout(uuid, tmpDir, Date.now() - 60000); // 早于本轮 run，只用于校验存在性，不参与本轮反查
+
+            await drain(engine.run('刚才的暗号是什么？', { sessionId: 'sr3', memory: mockMemory, cwd: tmpDir, resumeToken: uuid }));
+            const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+            expect(args).toEqual(['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', '-C', tmpDir, 'resume', uuid, '刚才的暗号是什么？']);
+        });
+
+        it('resumeToken 对应的 rollout 文件不存在时直接抛错，不静默新建（codex 已知坑：伪 id exit 0）', async () => {
+            const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot });
+            await expect(drain(engine.run('task', {
+                sessionId: 'sr4', memory: mockMemory, cwd: tmpDir,
+                resumeToken: '00000000-0000-0000-0000-000000000000',
+            }))).rejects.toThrow(/rollout 文件不存在/);
+        });
     });
 });

--- a/tests/opencode-engine.test.ts
+++ b/tests/opencode-engine.test.ts
@@ -43,9 +43,9 @@ afterEach(() => {
 });
 
 describe('OpenCodeEngine', () => {
-    it('capabilities: interactiveApproval=false（v1 一次性非交互模式，opencode serve 双向通道留后续）, resume=false', () => {
+    it('capabilities: interactiveApproval=false（v1 一次性非交互模式，opencode serve 双向通道留后续）, resume=true（原生 --session 续接，spec #85）', () => {
         const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
-        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
+        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: true });
     });
 
     it('拼装的 CLI 参数包含 run/--format/json/--dir 与 prompt', async () => {
@@ -80,11 +80,13 @@ describe('OpenCodeEngine', () => {
         const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
         const steps = await drain(engine.run('reply pong', { sessionId: 's2', memory: mockMemory }));
 
-        // step-start 不产出步骤；text → content；step-finish(reason=stop) → meta
-        expect(steps).toHaveLength(2);
+        // step-start 不产出步骤；text → content；step-finish(reason=stop) → meta；
+        // 成功结束后追加一条携带 resumeToken 的 meta（sessionID 全程都是 's'）
+        expect(steps).toHaveLength(3);
         expect(steps[0]).toMatchObject({ type: 'content', content: 'pong' });
         expect(steps[1]).toMatchObject({ type: 'meta' });
         expect(steps[1].content).toContain('stop');
+        expect(steps[2].resumeToken).toBe('s');
     });
 
     it('真实成功路径（实测，含工具调用）：tool_use（glob）拆成 action+observation，step_finish(reason=tool-calls) 不产出步骤', async () => {
@@ -113,8 +115,10 @@ describe('OpenCodeEngine', () => {
         const observation = steps.find(s => s.type === 'observation');
         expect(observation?.content).toContain('a.txt');
         expect(steps.find(s => s.type === 'content')?.content).toBe('Found 2 files.');
-        // tool-calls 阶段的 step_finish 不产出 meta（只有最终 stop 阶段才产出）
-        expect(steps.filter(s => s.type === 'meta')).toHaveLength(1);
+        // tool-calls 阶段的 step_finish 不产出 meta（只有最终 stop 阶段才产出）；
+        // 排除成功结束后追加的 resumeToken meta，业务性的 meta 只有 1 条
+        expect(steps.filter(s => s.type === 'meta' && !s.resumeToken)).toHaveLength(1);
+        expect(steps.some(s => s.resumeToken === 's')).toBe(true);
     });
 
     it('error 事件（实测确认，无 part 包装）：answer + meta', async () => {
@@ -137,9 +141,11 @@ describe('OpenCodeEngine', () => {
         }) + '\n';
         const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
         const steps = await drain(engine.run('task', { sessionId: 's5', memory: mockMemory }));
-        expect(steps).toHaveLength(1);
-        expect(steps[0].content).toContain('some-future-part');
-        expect(steps[0].content).toContain('bar');
+        // 成功结束后追加一条 resumeToken meta（sessionID='s'），业务性输出只有 1 条
+        const businessSteps = steps.filter(s => !s.resumeToken);
+        expect(businessSteps).toHaveLength(1);
+        expect(businessSteps[0].content).toContain('some-future-part');
+        expect(businessSteps[0].content).toContain('bar');
     });
 
     it('工具执行失败（state.status=error）产出带 ❌ 前缀的 observation', async () => {
@@ -177,5 +183,52 @@ describe('OpenCodeEngine', () => {
         const runPromise = drain(engine.run('task', { sessionId: 's9', memory: mockMemory, abortSignal: controller.signal }));
         controller.abort();
         await expect(runPromise).rejects.toThrow();
+    });
+
+    // ─────────────────────────── Resume（两阶段自动化 spec #85，实测记录 #76）───────────────────────────
+
+    describe('resume', () => {
+        it('传入 resumeToken 时 CLI 参数包含 --session，且仍复用相同 --dir', async () => {
+            const argsFile = path.join(tmpDir, 'resume-args.json');
+            process.env.FAKE_OPENCODE_ARGS_FILE = argsFile;
+            process.env.FAKE_OPENCODE_OUTPUT = JSON.stringify({ type: 'text', timestamp: 1, sessionID: 'ses_abc', part: { type: 'text', text: '暗号' } }) + '\n';
+            const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
+            await drain(engine.run('刚才的暗号是什么？', { sessionId: 'sr1', memory: mockMemory, cwd: tmpDir, resumeToken: 'ses_abc' }));
+            const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+            expect(args).toEqual(['run', '--format', 'json', '--dir', tmpDir, '--session', 'ses_abc', '刚才的暗号是什么？']);
+        });
+
+        it('resumeToken 直接取自 JSONL 每行都带的 sessionID，无需像 codex 那样反查文件', async () => {
+            process.env.FAKE_OPENCODE_OUTPUT = JSON.stringify({ type: 'text', timestamp: 1, sessionID: 'ses_xyz', part: { type: 'text', text: 'ok' } }) + '\n';
+            const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
+            const steps = await drain(engine.run('task', { sessionId: 'sr2', memory: mockMemory }));
+            expect(steps.find(s => s.resumeToken)?.resumeToken).toBe('ses_xyz');
+        });
+
+        it('resume 时看门狗超时兜底：目录不一致会挂死且不报错，watchdogMs 内无任何输出则主动判定失败', async () => {
+            const hangScript = path.join(tmpDir, 'hang-opencode.cjs');
+            writeFileSync(hangScript, `#!/usr/bin/env node\n// 模拟 --dir 不一致：既不输出也不退出\n`);
+            chmodSync(hangScript, 0o755);
+
+            const engine = new OpenCodeEngine(mockLogger, { binaryPath: hangScript, resumeWatchdogMs: 100 });
+            await expect(drain(engine.run('task', {
+                sessionId: 'sr3', memory: mockMemory, cwd: tmpDir, resumeToken: 'ses_stale',
+            }))).rejects.toThrow(/挂死/);
+        });
+
+        it('首轮（无 resumeToken）不受看门狗影响：即使输出较慢也不会被误杀', async () => {
+            const delayedScript = path.join(tmpDir, 'delayed-opencode.cjs');
+            writeFileSync(delayedScript, `#!/usr/bin/env node
+setTimeout(() => {
+    process.stdout.write(${JSON.stringify(JSON.stringify({ type: 'text', timestamp: 1, sessionID: 's', part: { type: 'text', text: 'ok' } }) + '\n')});
+    process.exit(0);
+}, 50);
+`);
+            chmodSync(delayedScript, 0o755);
+            // resumeWatchdogMs 故意设得比延迟还短：首轮不应受影响（看门狗只在 resumeToken 场景生效）
+            const engine = new OpenCodeEngine(mockLogger, { binaryPath: delayedScript, resumeWatchdogMs: 10 });
+            const steps = await drain(engine.run('task', { sessionId: 'sr4', memory: mockMemory }));
+            expect(steps.some(s => s.type === 'content' && s.content === 'ok')).toBe(true);
+        });
     });
 });

--- a/tests/opencode-engine.test.ts
+++ b/tests/opencode-engine.test.ts
@@ -207,7 +207,10 @@ describe('OpenCodeEngine', () => {
 
         it('resume 时看门狗超时兜底：目录不一致会挂死且不报错，watchdogMs 内无任何输出则主动判定失败', async () => {
             const hangScript = path.join(tmpDir, 'hang-opencode.cjs');
-            writeFileSync(hangScript, `#!/usr/bin/env node\n// 模拟 --dir 不一致：既不输出也不退出\n`);
+            // 模拟 --dir 不一致：既不输出也不退出——必须真的挂起进程（而不是让脚本自然
+            // 执行完退出），否则本用例在 CI 上会和看门狗定时器赛跑，脚本自己先退出就
+            // 让断言失败（真实踩过：本地偶尔通过，CI 上稳定失败）
+            writeFileSync(hangScript, `#!/usr/bin/env node\nsetInterval(() => {}, 1000);\n`);
             chmodSync(hangScript, 0o755);
 
             const engine = new OpenCodeEngine(mockLogger, { binaryPath: hangScript, resumeWatchdogMs: 100 });

--- a/tests/pi-engine.test.ts
+++ b/tests/pi-engine.test.ts
@@ -43,9 +43,9 @@ afterEach(() => {
 });
 
 describe('PiEngine', () => {
-    it('capabilities: interactiveApproval=false（v1 一次性非交互模式，--mode rpc 双向通道留后续）, resume=false', () => {
+    it('capabilities: interactiveApproval=false（v1 一次性非交互模式，--mode rpc 双向通道留后续）, resume=true（原生 --session 续接，spec #85）', () => {
         const engine = new PiEngine(mockLogger, { binaryPath: fakeBinPath });
-        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
+        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: true });
     });
 
     it('拼装的 CLI 参数包含 --mode json -p、--provider/--model/--tools 与 prompt', async () => {
@@ -59,6 +59,7 @@ describe('PiEngine', () => {
         expect(args).toEqual([
             '--mode', 'json', '-p',
             '--provider', 'mistral', '--model', 'mistral-large-latest', '--tools', 'read,grep',
+            '--session-dir', path.join(tmpDir, '.cmaster-pi-sessions'),
             'implement X',
         ]);
     });
@@ -82,10 +83,12 @@ describe('PiEngine', () => {
         const engine = new PiEngine(mockLogger, { binaryPath: fakeBinPath });
         const steps = await drain(engine.run('reply pong', { sessionId: 's2', memory: mockMemory }));
 
-        expect(steps).toHaveLength(2);
+        // session 启动 meta + pong content + 成功结束后追加的 resumeToken meta（id='x'）
+        expect(steps).toHaveLength(3);
         expect(steps[0]).toMatchObject({ type: 'meta' });
         expect(steps[0].content).toContain('/private/tmp/pi-probe');
         expect(steps[1]).toMatchObject({ type: 'content', content: 'pong' });
+        expect(steps[2].resumeToken).toBe('x');
     });
 
     it('真实成功路径（实测，含工具调用）：tool_execution_start/end → action/observation，多轮 message_end 各自产出 content', async () => {
@@ -203,5 +206,51 @@ describe('PiEngine', () => {
         const runPromise = drain(engine.run('task', { sessionId: 's10', memory: mockMemory, abortSignal: controller.signal }));
         controller.abort();
         await expect(runPromise).rejects.toThrow();
+    });
+
+    // ─────────────────────────── Resume（两阶段自动化 spec #85，实测记录 #77）───────────────────────────
+
+    describe('resume', () => {
+        it('传入 resumeToken 时 CLI 参数包含 --session-dir 与 --session', async () => {
+            const argsFile = path.join(tmpDir, 'resume-args.json');
+            process.env.FAKE_PI_ARGS_FILE = argsFile;
+            process.env.FAKE_PI_OUTPUT = JSON.stringify({
+                type: 'message_end',
+                message: { role: 'assistant', content: [{ type: 'text', text: '紫色大象88' }], stopReason: 'stop' },
+            }) + '\n';
+            const engine = new PiEngine(mockLogger, { binaryPath: fakeBinPath, provider: 'mistral', model: 'devstral-medium-latest' });
+            await drain(engine.run('刚才的暗号是什么？', { sessionId: 'sr1', memory: mockMemory, cwd: tmpDir, resumeToken: '019f5548-b50a-abcd' }));
+            const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+            expect(args).toEqual([
+                '--mode', 'json', '-p',
+                '--provider', 'mistral', '--model', 'devstral-medium-latest',
+                '--session-dir', path.join(tmpDir, '.cmaster-pi-sessions'),
+                '--session', '019f5548-b50a-abcd',
+                '刚才的暗号是什么？',
+            ]);
+        });
+
+        it('resumeToken 直接取自首行 session 事件的 id 字段，无需扫目录反查', async () => {
+            process.env.FAKE_PI_OUTPUT = [
+                JSON.stringify({ type: 'session', version: 3, id: '019f5548-real-session', timestamp: 't', cwd: tmpDir }),
+                JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }], stopReason: 'stop' } }),
+            ].join('\n') + '\n';
+            const engine = new PiEngine(mockLogger, { binaryPath: fakeBinPath });
+            const steps = await drain(engine.run('task', { sessionId: 'sr2', memory: mockMemory, cwd: tmpDir }));
+            expect(steps.find(s => s.resumeToken)?.resumeToken).toBe('019f5548-real-session');
+        });
+
+        it('--session 传伪 id 时 pi 显式 exit 1 + stderr「No session found」，透传为可判的错误', async () => {
+            const stderrScript = path.join(tmpDir, 'fake-pi-stderr.cjs');
+            writeFileSync(stderrScript, `#!/usr/bin/env node
+process.stderr.write("No session found matching '00000000-stale'");
+process.exitCode = 1;
+`);
+            chmodSync(stderrScript, 0o755);
+            const engine = new PiEngine(mockLogger, { binaryPath: stderrScript });
+            await expect(drain(engine.run('task', {
+                sessionId: 'sr3', memory: mockMemory, cwd: tmpDir, resumeToken: '00000000-stale',
+            }))).rejects.toThrow(/No session found/);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- codex/opencode/pi 三引擎 `capabilities.resume` 升级为 `true`；`EngineRunContext` 新增 `resumeToken`；run() 成功结束前在最后一条 `meta` step 携带捕获到的 resumeToken（`ExecutionStep.resumeToken` 新字段）。
- 各引擎实现严格对齐地图 [#74](https://github.com/yiyisf/masterBot/issues/74) 的三份实测结论（[codex #75](https://github.com/yiyisf/masterBot/issues/75) / [opencode #76](https://github.com/yiyisf/masterBot/issues/76) / [pi #77](https://github.com/yiyisf/masterBot/issues/77)）：
  - **codex**：反查 `~/.codex/sessions` rollout 文件（cwd+时间窗匹配）；resume 时 flags 前置、显式重传 `--sandbox`；使用前校验 rollout 文件存在（防伪 id 静默新建）。
  - **opencode**：resumeToken 直接读 JSONL 的 `sessionID`；resume 用 `--session` + 必须复用首轮 `--dir`；新增 resume 场景专属看门狗（目录不一致会挂死不报错）。
  - **pi**：resumeToken 取首行 `session` 事件 `id`；resume 用 `--session`（非 `--session-id`）+ 固定 `--session-dir`。

纵向切片 3/6，来自 spec [#85](https://github.com/yiyisf/masterBot/issues/85)。对应实施 ticket：[#87](https://github.com/yiyisf/masterBot/issues/87)。「标记块协议 + 待回答问题分派」（#88）依赖本切片提供的 resumeToken 机制。

## Test plan
- [x] `npx vitest run` — 405 tests passed（三引擎各自新增 resume 相关单测：args 拼装、resumeToken 捕获、伪 id/目录不一致等边界防御）
- [x] `npx tsc --noEmit`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)