### PR TITLE
feat(dev-workflow): 两阶段自动化编排（startAnalysis/startImplementation）

### DIFF
--- a/src/core/requirement-execution-service.ts
+++ b/src/core/requirement-execution-service.ts
@@ -46,6 +46,23 @@ export interface StartRunOptions {
     approvalMode?: 'auto' | 'ask-on-risky';
 }
 
+export interface StartAnalysisOptions extends StartRunOptions {
+    /**
+     * 显式重新分析（spec: 两阶段自动化 #85）：允许从 analyzed/failed/implemented 状态重新发起分析，
+     * 并作废尚未 implemented 的卡片（标记 cancelled，不删除；已实现卡片的代码留在 worktree 不受影响）。
+     */
+    reanalyze?: boolean;
+}
+
+/** 分析/实现阶段进入 startable 判定所允许的父需求状态 */
+const ANALYSIS_STARTABLE_STATUSES: Requirement['status'][] = ['synced', 'queued', 'failed'];
+/** 显式重新分析允许的状态：不能在执行中途或已合并/取消时重新分析 */
+const REANALYZE_BLOCKED_STATUSES: Requirement['status'][] = ['in_progress', 'waiting_input', 'merged', 'cancelled'];
+/** 实现阶段可继续（首次进入或从失败续跑）的父需求状态 */
+const IMPLEMENTATION_RESUMABLE_STATUSES: Requirement['status'][] = ['analyzed', 'failed'];
+/** 卡片被认为"已处理，无需再驱动"的终态（implemented=已完成，cancelled=人工跳过） */
+const CARD_TERMINAL_STATUSES: Requirement['status'][] = ['implemented', 'cancelled'];
+
 export interface RequirementExecutionServiceDeps {
     projects?: ProjectRepository;
     requirements?: RequirementRepository;
@@ -159,6 +176,161 @@ export class RequirementExecutionService {
     }
 
     /**
+     * 发起需求分析阶段（spec: 两阶段自动化 #85）：驱动 agent 走 grilling+to-spec 流程理解需求、
+     * 必要时提问，成功结束后需求转 analyzed（人工核验点，不是 implemented）。
+     * reanalyze=true 时允许从 analyzed/failed/implemented 状态重新发起，并作废尚未 implemented
+     * 的卡片（标记 cancelled；已实现卡片的代码留在 worktree，不受影响，不删除）。
+     */
+    async startAnalysis(requirementId: string, options: StartAnalysisOptions = {}): Promise<{ runId: string; sessionId: string }> {
+        const requirement = this.requirements.getById(requirementId);
+        if (!requirement) throw new Error(`Requirement not found: ${requirementId}`);
+
+        if (options.reanalyze) {
+            if (REANALYZE_BLOCKED_STATUSES.includes(requirement.status)) {
+                throw new Error(`Requirement cannot be reanalyzed in its current state (current: ${requirement.status})`);
+            }
+            for (const card of this.requirements.listCardsByParent(requirement.id)) {
+                if (!CARD_TERMINAL_STATUSES.includes(card.status)) {
+                    this.requirements.updateStatus(card.id, 'cancelled');
+                }
+            }
+        } else if (!ANALYSIS_STARTABLE_STATUSES.includes(requirement.status)) {
+            throw new Error(`Requirement is not in an analyzable state (current: ${requirement.status})`);
+        }
+
+        const project = this.projects.getById(requirement.projectId);
+        if (!project) throw new Error(`Project not found: ${requirement.projectId}`);
+
+        const engineKind = options.engine ?? 'claude-code';
+        const { path: worktreePath, branch } = await this.worktree.ensure(project, requirement);
+        const sessionId = nanoid();
+        const run = this.runs.create({
+            requirementId: requirement.id,
+            projectId: project.id,
+            engine: RUN_ENGINE_LABEL[engineKind],
+            sessionId,
+            worktreePath,
+            branch,
+        });
+        this.requirements.updatePhase(requirement.id, 'analysis');
+        this.requirements.updateStatus(requirement.id, 'in_progress');
+
+        // 调度层 prompt 是薄薄一层：需求上下文 + 强制调用指定 skill 的硬指令（skill 承载真正的
+        // 分析流程方法论；平台钉版注入 .agents/skills + 模板细节留给 #89）
+        const task = [
+            `分析需求 ${requirement.reqKey}：${requirement.title}`,
+            requirement.description ?? '',
+            '本任务必须先调用 grilling 与 to-spec skill 并遵循其流程完成需求分析；若需要澄清，调用 ask_user 工具向人类提问。',
+        ].filter(Boolean).join('\n\n');
+
+        this.executeAgentRun(project, requirement, run, options, { task, phase: 'analysis', onSuccessStatus: 'analyzed' }).catch(err => {
+            this.logger.error(`[requirement-execution] analysis run ${run.id} crashed outside its own try/catch: ${(err as Error).message}`);
+        });
+
+        return { runId: run.id, sessionId };
+    }
+
+    /**
+     * 发起（或续跑）拆卡实现阶段（spec: 两阶段自动化 #85）：按 card_no 顺序逐张驱动卡片
+     * （子 requirement），共用父需求的 worktree，全部完成后父需求转 implemented（沿用现有
+     * 人工核验合并 merge() 流程，统一开一个 PR）。
+     *
+     * 可重复调用以实现"从失败卡续跑"：每次调用都会跳过已 implemented/cancelled（人工跳过）的
+     * 卡片，从第一张未完成的卡片继续——包括上次失败在其上的那张（自然构成重试）。跳过某张卡片
+     * 请先调用 skipCard()，再调用本方法继续后续卡片。
+     */
+    async startImplementation(requirementId: string, options: StartRunOptions = {}): Promise<{ requirementId: string }> {
+        const requirement = this.requirements.getById(requirementId);
+        if (!requirement) throw new Error(`Requirement not found: ${requirementId}`);
+        if (!IMPLEMENTATION_RESUMABLE_STATUSES.includes(requirement.status)) {
+            throw new Error(`Requirement is not in an implementable state (current: ${requirement.status})`);
+        }
+        const project = this.projects.getById(requirement.projectId);
+        if (!project) throw new Error(`Project not found: ${requirement.projectId}`);
+
+        const cards = this.requirements.listCardsByParent(requirement.id);
+        if (cards.length === 0) {
+            throw new Error(`Requirement ${requirementId} has no cards to implement`);
+        }
+
+        // 共用父需求的 worktree（spec: 共用父 worktree 串行执行卡片，最终一个 PR）
+        const { path: worktreePath, branch } = await this.worktree.ensure(project, requirement);
+        this.requirements.updatePhase(requirement.id, 'implementation');
+        this.requirements.updateStatus(requirement.id, 'in_progress');
+
+        this.driveCardsSequentially(project, requirement, cards, worktreePath, branch, options).catch(err => {
+            this.logger.error(`[requirement-execution] implementation for ${requirement.id} crashed outside its own try/catch: ${(err as Error).message}`);
+        });
+
+        return { requirementId: requirement.id };
+    }
+
+    /**
+     * 人工「跳过此卡」：把一张失败/排队中的卡片标记为 cancelled（人工跳过，非引擎产出），
+     * 之后调用 startImplementation() 会自然跳过它，继续驱动下一张。
+     */
+    skipCard(cardId: string): void {
+        const card = this.requirements.getById(cardId);
+        if (!card) throw new Error(`Card not found: ${cardId}`);
+        if (!card.parentId) throw new Error(`Requirement ${cardId} is not a card`);
+        if (CARD_TERMINAL_STATUSES.includes(card.status)) {
+            throw new Error(`Card is already terminal (current: ${card.status})`);
+        }
+        this.requirements.updateStatus(cardId, 'cancelled');
+    }
+
+    /**
+     * 逐张驱动卡片；某卡失败/取消/等待回答则停在当卡（不推进后续卡片），把父需求状态同步为
+     * 该卡的终态，供页面据此判断下一步（重试/跳过/回答问题）。全部卡片终态为 implemented 时，
+     * 父需求转 implemented（走现有 merge() 流程）。
+     */
+    private async driveCardsSequentially(
+        project: Project,
+        parent: Requirement,
+        cards: Requirement[],
+        worktreePath: string,
+        branch: string,
+        options: StartRunOptions
+    ): Promise<void> {
+        for (const card of cards) {
+            const currentCard = this.requirements.getById(card.id) ?? card;
+            if (CARD_TERMINAL_STATUSES.includes(currentCard.status)) continue; // 已实现或人工跳过
+
+            this.requirements.updateStatus(parent.id, 'in_progress');
+
+            const engineKind = options.engine ?? 'claude-code';
+            const sessionId = nanoid();
+            const run = this.runs.create({
+                requirementId: card.id,
+                projectId: project.id,
+                engine: RUN_ENGINE_LABEL[engineKind],
+                sessionId,
+                worktreePath,
+                branch,
+            });
+            this.requirements.updatePhase(card.id, 'implementation');
+            this.requirements.updateStatus(card.id, 'in_progress');
+
+            const task = [
+                `实现卡片 ${card.reqKey}：${card.title}`,
+                card.description ?? '',
+                '本任务必须先调用 implement skill 并遵循其流程；若需要澄清或做出只有人类才能决定的选择，调用 ask_user 工具向人类提问。',
+            ].filter(Boolean).join('\n\n');
+
+            await this.executeAgentRun(project, card, run, options, { task, phase: 'implementation', onSuccessStatus: 'implemented' });
+
+            const finished = this.requirements.getById(card.id)!;
+            if (finished.status !== 'implemented') {
+                // 卡片停在 failed/cancelled/waiting_input：父需求同步为同一状态，不推进后续卡片
+                this.requirements.updateStatus(parent.id, finished.status);
+                return;
+            }
+        }
+
+        this.requirements.updateStatus(parent.id, 'implemented');
+    }
+
+    /**
      * 人工中止执行中的需求：中止引擎（abortSignal）+ 释放挂起的 interrupt（若有）。
      * 找不到内存中的执行现场（如服务重启后的孤儿态，理论上启动扫描已标 failed）时兜底直接改状态。
      */
@@ -203,24 +375,55 @@ export class RequirementExecutionService {
         }
     }
 
+    /**
+     * 旧单阶段 start()/retry() 用的直通入口：语义与改造前完全一致（onSuccessStatus 固定
+     * 'implemented'，不触碰 phase 列——旧路径的 phase 永远是 NULL，零迁移成本）。
+     */
     private async drive(
         project: Project,
         requirement: Requirement,
         run: RequirementRun,
         options: StartRunOptions
     ): Promise<void> {
+        const task = `实现需求 ${requirement.reqKey}：${requirement.title}`;
+        const systemPrompt = [
+            `你正在处理需求 ${requirement.reqKey}：${requirement.title}`,
+            requirement.description ?? '',
+            '请实现该需求、提交代码并开 PR。若需要澄清需求或做出只有人类才能决定的选择，调用 ask_user 工具向人类提问。',
+        ].filter(Boolean).join('\n\n');
+
+        await this.executeAgentRun(project, requirement, run, options, { task, systemPrompt, onSuccessStatus: 'implemented' });
+    }
+
+    /**
+     * 两阶段自动化共用的执行核心（spec #85）：驱动一次 IAgentEngine.run()，把 ExecutionStep
+     * 流写入 session_events（执行时间线回放），维护 requirement/run 的状态流转——
+     * interrupt → waiting_input，恢复 → in_progress，正常结束 → onSuccessStatus，异常 → failed，
+     * cancel() 触发 → cancelled。phase 若提供，会在开始驱动前写入 requirements.phase 列
+     * （旧单阶段 drive() 不传 phase，保持该列 NULL）。
+     */
+    private async executeAgentRun(
+        project: Project,
+        requirement: Requirement,
+        run: RequirementRun,
+        options: StartRunOptions,
+        config: {
+            task: string;
+            systemPrompt?: string;
+            phase?: 'analysis' | 'implementation';
+            onSuccessStatus: Requirement['status'];
+        }
+    ): Promise<void> {
+        if (config.phase) this.requirements.updatePhase(requirement.id, config.phase);
+
         const spec = defaultAgentSpec({
             id: `dev-workflow-${requirement.id}`,
             name: `研发流程执行 ${requirement.reqKey}`,
             engine: 'claude-agent-sdk',
-            systemPrompt: [
-                `你正在处理需求 ${requirement.reqKey}：${requirement.title}`,
-                requirement.description ?? '',
-                '请实现该需求、提交代码并开 PR。若需要澄清需求或做出只有人类才能决定的选择，调用 ask_user 工具向人类提问。',
-            ].filter(Boolean).join('\n\n'),
+            systemPrompt: config.systemPrompt ?? config.task,
         });
         const engine = this.createEngine(options.engine ?? 'claude-code', spec, this.logger);
-        const task = `实现需求 ${requirement.reqKey}：${requirement.title}`;
+        const task = config.task;
 
         const controller = new AbortController();
         this.activeRuns.set(run.id, { controller, cancelled: false });
@@ -270,7 +473,7 @@ export class RequirementExecutionService {
 
             emitEvent('session_end', { status: 'succeeded' });
             this.runs.updateStatus(run.id, 'succeeded', { finished: true });
-            this.requirements.updateStatus(requirement.id, 'implemented');
+            this.requirements.updateStatus(requirement.id, config.onSuccessStatus);
         } catch (err) {
             // cancel() 已经把状态改成 cancelled 了；这里只是让 catch 分支保持终态一致，不覆盖成 failed
             if (this.activeRuns.get(run.id)?.cancelled) {

--- a/tests/requirement-execution-service.test.ts
+++ b/tests/requirement-execution-service.test.ts
@@ -23,14 +23,16 @@ function createTestDb(): DatabaseSync {
             id TEXT PRIMARY KEY, project_id TEXT NOT NULL, req_key TEXT NOT NULL, source TEXT NOT NULL,
             source_key TEXT NOT NULL, title TEXT NOT NULL, description TEXT, labels TEXT,
             status TEXT NOT NULL DEFAULT 'synced', source_url TEXT, source_closed INTEGER NOT NULL DEFAULT 0,
+            phase TEXT, analysis_spec TEXT, parent_id TEXT, card_no INTEGER,
             created_at TEXT NOT NULL, updated_at TEXT NOT NULL
         );
         CREATE UNIQUE INDEX IF NOT EXISTS uq_req_key ON requirements(req_key);
         CREATE UNIQUE INDEX IF NOT EXISTS uq_req_dedup ON requirements(project_id, source, source_key);
+        CREATE INDEX IF NOT EXISTS idx_req_parent ON requirements(parent_id, card_no);
         CREATE TABLE IF NOT EXISTS requirement_runs (
             id TEXT PRIMARY KEY, requirement_id TEXT NOT NULL, project_id TEXT NOT NULL, engine TEXT NOT NULL,
             worktree_path TEXT, branch TEXT, session_id TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'running',
-            retry_no INTEGER NOT NULL DEFAULT 0, pr_url TEXT, error_message TEXT, token_cost TEXT,
+            retry_no INTEGER NOT NULL DEFAULT 0, pr_url TEXT, error_message TEXT, token_cost TEXT, resume_token TEXT,
             started_at TEXT NOT NULL, finished_at TEXT
         );
     `);
@@ -385,5 +387,225 @@ describe('RequirementExecutionService', () => {
             projectId, reqKey: 'cmasterBot#m2', source: 'github', sourceKey: 'm2', title: 'Add feature',
         });
         await expect(service.merge(requirement.id)).rejects.toThrow(/mergeable state/);
+    });
+
+    // ─────────────────────────── 两阶段自动化：startAnalysis / startImplementation（spec #85）───────────────────────────
+
+    describe('startAnalysis', () => {
+        it('建 worktree、建 run，phase=analysis，成功结束后转 analyzed（不是 implemented）', async () => {
+            const service = makeService(() => engineYielding([{ type: 'answer', content: 'spec drafted', timestamp: new Date() }]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#a1', source: 'github', sourceKey: 'a1', title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'queued');
+
+            const { runId } = await service.startAnalysis(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(worktree.ensure).toHaveBeenCalled();
+            expect(runs.getById(runId)!.status).toBe('succeeded');
+            const updated = requirements.getById(requirement.id)!;
+            expect(updated.status).toBe('analyzed');
+            expect(updated.phase).toBe('analysis');
+        });
+
+        it('拒绝非可分析状态（如 in_progress）', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#a2', source: 'github', sourceKey: 'a2', title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'in_progress');
+            await expect(service.startAnalysis(requirement.id)).rejects.toThrow(/analyzable state/);
+        });
+
+        it('interrupt 步骤 → waiting_input，恢复后 → in_progress，最终 analyzed', async () => {
+            const service = makeService(() => engineYielding([
+                { type: 'interrupt', interruptKind: 'question', interruptId: 'i1', content: 'q?', timestamp: new Date() },
+                { type: 'answer', content: 'spec drafted', timestamp: new Date() },
+            ]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#a3', source: 'github', sourceKey: 'a3', title: 'Add feature',
+            });
+            await service.startAnalysis(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+            expect(requirements.getById(requirement.id)!.status).toBe('analyzed');
+        });
+
+        it('reanalyze=false 时 analyzed 状态不可再次 startAnalysis（需显式 reanalyze）', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#a4', source: 'github', sourceKey: 'a4', title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'analyzed');
+            await expect(service.startAnalysis(requirement.id)).rejects.toThrow(/analyzable state/);
+        });
+
+        it('reanalyze=true 允许从 analyzed 重新发起，并把尚未 implemented 的卡片标记 cancelled（已实现卡片不受影响）', async () => {
+            const service = makeService(() => engineYielding([{ type: 'answer', content: 'redone', timestamp: new Date() }]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#a5', source: 'github', sourceKey: 'a5', title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'analyzed');
+            const doneCard = requirements.createCard({ parentId: requirement.id, projectId, reqKey: 'cmasterBot#a5-1', source: 'manual', sourceKey: 'a5-1', title: '卡1', cardNo: 1 });
+            requirements.updateStatus(doneCard.id, 'implemented');
+            const pendingCard = requirements.createCard({ parentId: requirement.id, projectId, reqKey: 'cmasterBot#a5-2', source: 'manual', sourceKey: 'a5-2', title: '卡2', cardNo: 2 });
+
+            await service.startAnalysis(requirement.id, { reanalyze: true });
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(doneCard.id)!.status).toBe('implemented'); // 已实现的不受影响
+            expect(requirements.getById(pendingCard.id)!.status).toBe('cancelled'); // 未实现的被作废
+            expect(requirements.getById(requirement.id)!.status).toBe('analyzed');
+        });
+
+        it('reanalyze=true 但需求处于 in_progress/waiting_input/merged/cancelled 时拒绝', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#a6', source: 'github', sourceKey: 'a6', title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'merged');
+            await expect(service.startAnalysis(requirement.id, { reanalyze: true })).rejects.toThrow(/cannot be reanalyzed/);
+        });
+    });
+
+    describe('startImplementation', () => {
+        function makeAnalyzedWithCards(cardCount: number, reqKeyPrefix: string) {
+            const requirement = requirements.create({
+                projectId, reqKey: `cmasterBot#${reqKeyPrefix}`, source: 'github', sourceKey: reqKeyPrefix, title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'analyzed');
+            const cards = Array.from({ length: cardCount }, (_, i) =>
+                requirements.createCard({
+                    parentId: requirement.id, projectId, reqKey: `cmasterBot#${reqKeyPrefix}-${i + 1}`,
+                    source: 'manual', sourceKey: `${reqKeyPrefix}-${i + 1}`, title: `卡片 ${i + 1}`, cardNo: i + 1,
+                }));
+            return { requirement, cards };
+        }
+
+        it('拒绝非可实现状态（如 synced）', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#i1', source: 'github', sourceKey: 'i1', title: 'Add feature',
+            });
+            await expect(service.startImplementation(requirement.id)).rejects.toThrow(/implementable state/);
+        });
+
+        it('无卡片时拒绝', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#i2', source: 'github', sourceKey: 'i2', title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'analyzed');
+            await expect(service.startImplementation(requirement.id)).rejects.toThrow(/no cards/);
+        });
+
+        it('按 card_no 顺序串行驱动全部卡片，全部完成后父需求转 implemented，共用同一 worktree', async () => {
+            const { requirement, cards } = makeAnalyzedWithCards(2, 'i3');
+            const service = makeService(() => engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]));
+
+            await service.startImplementation(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(cards[0].id)!.status).toBe('implemented');
+            expect(requirements.getById(cards[1].id)!.status).toBe('implemented');
+            expect(requirements.getById(requirement.id)!.status).toBe('implemented');
+            // ensure 只调用一次（父需求）——卡片共用同一 worktree，不各自新建
+            expect(worktree.ensure).toHaveBeenCalledTimes(1);
+        });
+
+        it('某卡失败时停在当卡：后续卡片不执行，父需求同步为 failed', async () => {
+            const { requirement, cards } = makeAnalyzedWithCards(3, 'i4');
+            let call = 0;
+            const service = makeService(() => {
+                call += 1;
+                if (call === 2) return engineThrowing('card 2 boom');
+                return engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]);
+            });
+
+            await service.startImplementation(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(cards[0].id)!.status).toBe('implemented');
+            expect(requirements.getById(cards[1].id)!.status).toBe('failed');
+            expect(requirements.getById(cards[2].id)!.status).toBe('queued'); // 未被驱动
+            expect(requirements.getById(requirement.id)!.status).toBe('failed');
+        });
+
+        it('从失败卡续跑：再次调用 startImplementation 会跳过已 implemented 的卡片，重试失败的那张', async () => {
+            const { requirement, cards } = makeAnalyzedWithCards(2, 'i5');
+            let firstAttemptCall = 0;
+            const service = makeService(() => {
+                firstAttemptCall += 1;
+                if (firstAttemptCall === 2) return engineThrowing('card 2 boom');
+                return engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]);
+            });
+            await service.startImplementation(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+            expect(requirements.getById(cards[1].id)!.status).toBe('failed');
+            expect(requirements.getById(requirement.id)!.status).toBe('failed');
+
+            // 重试：第二次调用换一个总是成功的引擎
+            const retryService = makeService(() => engineYielding([{ type: 'answer', content: 'done on retry', timestamp: new Date() }]));
+            await retryService.startImplementation(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(cards[0].id)!.status).toBe('implemented'); // 未被重复驱动，保持原状态
+            expect(requirements.getById(cards[1].id)!.status).toBe('implemented');
+            expect(requirements.getById(requirement.id)!.status).toBe('implemented');
+        });
+
+        it('skipCard() 跳过某张失败卡后续跑，直接推进到下一张，不重试被跳过的卡', async () => {
+            const { requirement, cards } = makeAnalyzedWithCards(2, 'i6');
+            let call = 0;
+            const service = makeService(() => {
+                call += 1;
+                if (call === 1) return engineThrowing('card 1 boom');
+                return engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]);
+            });
+            await service.startImplementation(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+            expect(requirements.getById(cards[0].id)!.status).toBe('failed');
+
+            service.skipCard(cards[0].id);
+            expect(requirements.getById(cards[0].id)!.status).toBe('cancelled');
+
+            await service.startImplementation(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(cards[0].id)!.status).toBe('cancelled'); // 保持跳过态，不被重试
+            expect(requirements.getById(cards[1].id)!.status).toBe('implemented');
+            expect(requirements.getById(requirement.id)!.status).toBe('implemented');
+        });
+    });
+
+    describe('skipCard', () => {
+        it('把失败/排队中的卡片标记 cancelled', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#sc1', source: 'github', sourceKey: 'sc1', title: 'Add feature',
+            });
+            const card = requirements.createCard({ parentId: requirement.id, projectId, reqKey: 'cmasterBot#sc1-1', source: 'manual', sourceKey: 'sc1-1', title: '卡1', cardNo: 1 });
+
+            service.skipCard(card.id);
+            expect(requirements.getById(card.id)!.status).toBe('cancelled');
+        });
+
+        it('拒绝对非卡片（无 parentId）调用', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#sc2', source: 'github', sourceKey: 'sc2', title: 'Add feature',
+            });
+            expect(() => service.skipCard(requirement.id)).toThrow(/is not a card/);
+        });
+
+        it('拒绝对已终态（implemented/cancelled）卡片调用', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#sc3', source: 'github', sourceKey: 'sc3', title: 'Add feature',
+            });
+            const card = requirements.createCard({ parentId: requirement.id, projectId, reqKey: 'cmasterBot#sc3-1', source: 'manual', sourceKey: 'sc3-1', title: '卡1', cardNo: 1 });
+            requirements.updateStatus(card.id, 'implemented');
+            expect(() => service.skipCard(card.id)).toThrow(/already terminal/);
+        });
     });
 });


### PR DESCRIPTION
## Summary

⚠️ **Stacked PR**：base 是 [#92 数据模型基础](https://github.com/yiyisf/masterBot/pull/92) 而非 master（本切片依赖其 phase/analysis_spec/parent_id/card_no 列与卡片 CRUD 方法，尚未合并）。#92 合并后建议 rebase 本分支到 master。

- `RequirementExecutionService` 新增 `startAnalysis()` / `startImplementation()`；`drive()` 重构为共用核心 `executeAgentRun()`（旧 `start()`/`retry()` 行为完全不变，仍不触碰 `phase` 列）。
- **startAnalysis**：驱动分析阶段 agent run，成功结束后转 `analyzed`（非 `implemented`）；`reanalyze=true` 可从 analyzed/failed/implemented 显式重新发起，作废尚未 implemented 的卡片。
- **startImplementation**：按 `card_no` 顺序串行驱动卡片，共用父需求 worktree；某卡失败/取消/等待回答则停在当卡；可重复调用实现"从失败卡续跑"（自动跳过已终态的卡片）。
- **skipCard**：把失败/排队中的卡片标记 cancelled，之后续跑自然跳过它。

为 spec [#85](https://github.com/yiyisf/masterBot/issues/85) 纵向切片 2/6，对应实施 ticket [#86](https://github.com/yiyisf/masterBot/issues/86)。解锁「标记块协议 + 待回答问题分派」（[#88](https://github.com/yiyisf/masterBot/issues/88)）与「.agents/skills 注入 + 阶段 prompt 模板」（[#89](https://github.com/yiyisf/masterBot/issues/89)）。

## Test plan
- [x] `npx vitest run` — 421 tests passed（新增 15 个用例：分析/实现阶段流转、reanalyze、卡片失败停当卡、续跑跳过已完成卡、skipCard）
- [x] `npx tsc --noEmit`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)