### PR TITLE
feat(dev-workflow): 标记块协议 + 待回答问题统一分派

### DIFF
--- a/src/core/harness/agent-engine.ts
+++ b/src/core/harness/agent-engine.ts
@@ -23,7 +23,7 @@ export type AgentEngineKind = 'native' | 'claude-agent-sdk' | 'codex' | 'opencod
 /**
  * 引擎能力声明（研发流程管理模块，spec §5.2）。
  * interactiveApproval：执行中能否编程式向人提问/请求审批（codex exec = false）。
- * resume：能否跨进程恢复会话（v1 全部 false；未来 Claude `--resume` 等）。
+ * resume：能否跨进程恢复会话（codex/opencode/pi 均支持原生会话续接，spec: 两阶段自动化 #85）。
  */
 export interface EngineCapabilities {
     interactiveApproval: boolean;
@@ -41,6 +41,11 @@ export interface EngineRunContext {
     cwd?: string;
     /** 审批模式：'auto' 沙箱自动判定（默认）；'ask-on-risky' 危险操作转人工审批（spec §5.4）*/
     approvalMode?: 'auto' | 'ask-on-risky';
+    /**
+     * 上一轮 run() 捕获的会话续接凭据（capabilities.resume=true 的引擎专用）。
+     * 传入时引擎应续接同一会话而非新建；未传或引擎不支持 resume 时忽略。
+     */
+    resumeToken?: string;
 }
 
 export interface IAgentEngine {

--- a/src/core/harness/codex-engine.ts
+++ b/src/core/harness/codex-engine.ts
@@ -31,10 +31,24 @@
  * `codex exec --help` 同样暴露 `-C/--cd <DIR>`（"Tell the agent to use the specified
  * directory as its working root"），说明 codex 内部可能不是单纯依赖进程级 cwd 判定工作目录。
  * 之前只靠 `child_process.spawn()` 的 `cwd` 选项，现在显式加上 `-C`，两边双保险。
+ *
+ * Resume 接入（两阶段自动化 spec #85，实测记录见地图 ticket #75）：
+ * - `--json` 输出**不含**会话 id；id 只在 `~/.codex/sessions/<yyyy/mm/dd>/rollout-*-<uuid>.jsonl`
+ *   的文件名（或文件首行 `session_meta.payload.id`）里，run() 结束后按 cwd 匹配 + 时间窗反查。
+ * - resume 命令形态：所有 flags 必须在 `resume` 子命令**之前**，形如
+ *   `codex exec --json --sandbox <mode> -C <cwd> resume <uuid> "<prompt>"`；resume 轮 sandbox
+ *   默认回显 read-only，必须显式重传 `--sandbox`。
+ * - **关键坑**：传入不存在的 uuid 不报错——exit 0，静默新建一个不带上下文的新会话。
+ *   本引擎在使用调用方传入的 resumeToken 前会先校验对应 rollout 文件是否存在，不存在则
+ *   直接抛错，不让"丢现场"被误判为"续接成功"。
  */
 
 import { spawn } from 'child_process';
 import { createInterface } from 'readline';
+import { readdir, readFile, stat } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+import os from 'os';
 import type { ExecutionStep, Logger } from '../../types.js';
 import type { IAgentEngine, EngineRunContext, EngineCapabilities } from './agent-engine.js';
 
@@ -45,6 +59,8 @@ export interface CodexEngineOptions {
     binaryPath?: string;
     /** 沙箱策略（默认 workspace-write，与 spec §5.3 一致）*/
     sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+    /** `~/.codex/sessions` 根目录覆盖（测试用，指向临时目录）*/
+    sessionsRoot?: string;
 }
 
 interface CodexJsonLine {
@@ -58,21 +74,41 @@ interface CodexJsonLine {
 export class CodexEngine implements IAgentEngine {
     readonly kind = 'codex' as const;
     // codex exec 非交互模式无编程式转人工的接口（-a/--ask-for-approval 只在交互式顶层命令下有效，
-    // 已实测确认 `codex exec --help` 不暴露该参数）；不做 PTY 文本匹配兜底（spec §5.5）；v1 无 resume
-    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: false };
+    // 已实测确认 `codex exec --help` 不暴露该参数）；不做 PTY 文本匹配兜底（spec §5.5）。
+    // resume=true：接 codex 原生会话续接（见文件头注释，实测记录 #75）
+    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: true };
 
     constructor(private logger: Logger, private options: CodexEngineOptions = {}) {}
+
+    private get sessionsRoot(): string {
+        return this.options.sessionsRoot ?? path.join(os.homedir(), '.codex', 'sessions');
+    }
 
     async *run(input: string, context: EngineRunContext): AsyncGenerator<ExecutionStep> {
         const cwd = context.cwd ?? this.options.cwd ?? process.cwd();
         const binary = this.options.binaryPath ?? 'codex';
         const sandbox = this.options.sandbox ?? 'workspace-write';
+
+        // 续接：resumeToken 必须先校验 rollout 文件仍存在，否则 codex 会静默新建一个不带
+        // 上下文的新会话（exit 0，无任何报错信号）——那样"丢现场"会被误判为"续接成功"。
+        if (context.resumeToken) {
+            const exists = await this._rolloutFileExists(context.resumeToken);
+            if (!exists) {
+                throw new Error(`codex resume 失败：会话 ${context.resumeToken} 对应的 rollout 文件不存在（可能已被清理），无法安全续接`);
+            }
+        }
+
         // -C/--cd 显式声明"working root"（同一类问题在 opencode 引擎上被真实用例踩中过：
         // 只靠 spawn() 的 cwd 选项，工具自己内部的目录解析可能不认——codex --help 里这个参数
-        // 的说明原文就是 "Tell the agent to use the specified directory as its working root"）
-        const args = ['exec', '--json', '--sandbox', sandbox, '--skip-git-repo-check', '-C', cwd, input];
+        // 的说明原文就是 "Tell the agent to use the specified directory as its working root"）。
+        // resume 子命令的 flags 必须前置（含 --sandbox，resume 轮默认回显 read-only 必须重传）。
+        const configFlags = ['--json', '--sandbox', sandbox, '--skip-git-repo-check', '-C', cwd];
+        const args = context.resumeToken
+            ? ['exec', ...configFlags, 'resume', context.resumeToken, input]
+            : ['exec', ...configFlags, input];
+        const runStartedAt = Date.now();
 
-        this.logger.info(`[codex-engine] Starting "${binary} exec" (cwd: ${cwd}, sandbox: ${sandbox})`);
+        this.logger.info(`[codex-engine] Starting "${binary} exec${context.resumeToken ? ' resume' : ''}" (cwd: ${cwd}, sandbox: ${sandbox})`);
 
         const child = spawn(binary, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
 
@@ -124,9 +160,76 @@ export class CodexEngine implements IAgentEngine {
         if (exitCode !== 0) {
             throw new Error(`codex exec exited with code ${exitCode}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`);
         }
+
+        // 成功结束后反查本轮 rollout uuid 作为 resumeToken（--json 输出本身不含会话 id）
+        const resumeToken = await this._findResumeToken(cwd, runStartedAt);
+        if (resumeToken) {
+            yield { type: 'meta', content: '💾 codex 会话已记录，可续接', resumeToken, timestamp: new Date() };
+        }
     }
 
     // ─────────────────────────────── private ───────────────────────────────
+
+    /** 按 cwd + 时间窗扫描 sessions 目录，反查本轮 run 对应的 rollout uuid */
+    private async _findResumeToken(cwd: string, sinceMs: number): Promise<string | undefined> {
+        try {
+            const candidates = await this._listRolloutFiles();
+            let best: { file: string; mtime: number; id: string } | undefined;
+            for (const file of candidates) {
+                let st;
+                try {
+                    st = await stat(file);
+                } catch { continue; }
+                if (st.mtimeMs < sinceMs - 2000) continue; // 允许 2s 时钟误差
+                const meta = await this._readSessionMeta(file);
+                if (!meta || meta.cwd !== cwd) continue;
+                if (!best || st.mtimeMs > best.mtime) best = { file, mtime: st.mtimeMs, id: meta.id };
+            }
+            return best?.id;
+        } catch {
+            return undefined; // best-effort：反查失败不影响主流程（下轮就没有 resume 能力而已）
+        }
+    }
+
+    /** 校验调用方传入的 resumeToken 对应的 rollout 文件是否仍存在（伪 id 防御） */
+    private async _rolloutFileExists(resumeToken: string): Promise<boolean> {
+        const candidates = await this._listRolloutFiles();
+        return candidates.some(f => f.includes(resumeToken));
+    }
+
+    private async _listRolloutFiles(): Promise<string[]> {
+        const root = this.sessionsRoot;
+        if (!existsSync(root)) return [];
+        const results: string[] = [];
+        const walk = async (dir: string, depth: number) => {
+            let entries;
+            try {
+                entries = await readdir(dir, { withFileTypes: true });
+            } catch { return; }
+            for (const entry of entries) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory() && depth < 3) await walk(full, depth + 1);
+                else if (entry.isFile() && entry.name.endsWith('.jsonl')) results.push(full);
+            }
+        };
+        await walk(root, 0);
+        return results;
+    }
+
+    private async _readSessionMeta(file: string): Promise<{ id: string; cwd: string } | undefined> {
+        try {
+            const content = await readFile(file, 'utf-8');
+            const firstLine = content.split('\n', 1)[0];
+            if (!firstLine) return undefined;
+            const parsed = JSON.parse(firstLine);
+            if (parsed?.type === 'session_meta' && parsed?.payload?.id && parsed?.payload?.cwd) {
+                return { id: parsed.payload.id, cwd: parsed.payload.cwd };
+            }
+            return undefined;
+        } catch {
+            return undefined;
+        }
+    }
 
     private *_translateLine(raw: string): Generator<ExecutionStep> {
         let parsed: CodexJsonLine;

--- a/src/core/harness/marker-blocks.ts
+++ b/src/core/harness/marker-blocks.ts
@@ -1,0 +1,101 @@
+/**
+ * 标记块协议解析器（spec #85，地图 #74 ticket #78 决策）：agent 回复文本中用自定义 fenced
+ * code block 输出问题/完成信号，平台按此解析——不依赖具体引擎的原生结构化输出格式，
+ * 跨 claude-code/codex/opencode/pi 四引擎统一。
+ *
+ * 协议：
+ * - ```cmaster:questions``` 块：JSON `{"questions": [...]}`，agent 需要人工回答时输出。
+ * - ```cmaster:done``` 块：JSON（阶段产物，如 {"analysisSpec": {...}, "cards": [...]}），
+ *   阶段/任务完成时输出。
+ *
+ * 取回复中最后一个匹配的标记块（agent 可能在思考过程中提及格式示例，只有最后一个才是
+ * 真正的信号）；两种标记块都没有出现视为协议违约，由调用方（RequirementExecutionService）
+ * 决定重试/失败。
+ */
+
+export type MarkerName = 'cmaster:questions' | 'cmaster:done';
+
+function markerRegex(marker: MarkerName): RegExp {
+    return new RegExp('```' + marker + '\\s*\\n([\\s\\S]*?)```', 'g');
+}
+
+/** 取文本中最后一个匹配标记块并解析为 JSON；未出现或 JSON 非法均返回 undefined（非法内容不抛错）*/
+export function extractMarkerBlock(text: string, marker: MarkerName): unknown | undefined {
+    const matches = [...text.matchAll(markerRegex(marker))];
+    if (matches.length === 0) return undefined;
+    const last = matches[matches.length - 1][1].trim();
+    try {
+        return JSON.parse(last);
+    } catch {
+        return undefined;
+    }
+}
+
+export interface PendingQuestionLike {
+    id: string;
+    question: string;
+    context?: string;
+    options?: Array<{ label: string; description?: string }>;
+    recommended?: number;
+    multiSelect?: boolean;
+}
+
+export interface QuestionsBlock {
+    questions: PendingQuestionLike[];
+}
+
+export interface DoneBlock {
+    analysisSpec?: { goal?: string; scope?: string; acceptance?: string; [key: string]: unknown };
+    cards?: Array<{ title: string }>;
+    [key: string]: unknown;
+}
+
+/** 校验+narrow：取到的 JSON 必须形如 { questions: [...] } 且非空数组，否则视为未取到 */
+export function extractQuestionsBlock(text: string): QuestionsBlock | undefined {
+    const parsed = extractMarkerBlock(text, 'cmaster:questions');
+    if (!parsed || typeof parsed !== 'object') return undefined;
+    const questions = (parsed as Record<string, unknown>).questions;
+    if (!Array.isArray(questions) || questions.length === 0) return undefined;
+    return { questions: questions as PendingQuestionLike[] };
+}
+
+/** done 块允许是空对象 `{}`（如单卡实现完成，没有额外产物）——只要标记块本身存在即可 */
+export function extractDoneBlock(text: string): DoneBlock | undefined {
+    const parsed = extractMarkerBlock(text, 'cmaster:done');
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    return parsed as DoneBlock;
+}
+
+export type ParsedMarker =
+    | { type: 'questions'; questions: PendingQuestionLike[] }
+    | { type: 'done'; data: DoneBlock };
+
+/**
+ * 找文本中最后一个标记块（不区分是 questions 还是 done），据此判断 agent 最终想表达的信号——
+ * 两种标记块各自独立提取（extractQuestionsBlock/extractDoneBlock）都只知道"某种类型最后一次
+ * 出现在哪"，不知道两种类型相互之间谁更晚；例如 agent 先问了一个问题（questions）又改口直接
+ * 完成了（done），此时应以 done 为准，反之亦然——只有看两者在文本里的相对位置才能判断。
+ */
+export function extractLastMarker(text: string): ParsedMarker | undefined {
+    const combined = /```(cmaster:questions|cmaster:done)\s*\n([\s\S]*?)```/g;
+    const matches = [...text.matchAll(combined)];
+    if (matches.length === 0) return undefined;
+
+    const [, marker, body] = matches[matches.length - 1];
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(body.trim());
+    } catch {
+        return undefined;
+    }
+
+    if (marker === 'cmaster:questions') {
+        if (!parsed || typeof parsed !== 'object') return undefined;
+        const questions = (parsed as Record<string, unknown>).questions;
+        if (!Array.isArray(questions) || questions.length === 0) return undefined;
+        return { type: 'questions', questions: questions as PendingQuestionLike[] };
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    return { type: 'done', data: parsed as DoneBlock };
+}

--- a/src/core/harness/opencode-engine.ts
+++ b/src/core/harness/opencode-engine.ts
@@ -30,6 +30,15 @@
  * 此时 `child_process.spawn()` 的 `cwd` 选项只影响新 spawn 出来的这个客户端进程，管不到
  * 被复用的那个 server 进程，导致实际操作目录/需求都不对。修复：显式传 `--dir <cwd>`，
  * 不管是新起的还是被复用的 server，都会被这个参数正确定向。
+ *
+ * Resume 接入（两阶段自动化 spec #85，实测记录见地图 ticket #76，opencode CLI 1.17.18）：
+ * - resumeToken 就是 JSONL 每行都带的顶层 `sessionID`，无需像 codex 那样反查文件，运行中
+ *   捕获第一行出现的即可。
+ * - resume 命令：`opencode run --session <id>`，**必须复用首轮相同的 `--dir`**。
+ * - **关键坑**：resume 时 `--dir` 与会话原目录不一致会导致进程无输出、无报错地挂死
+ *   （非 daemon 复用场景实测复现）。伪造 id 会显式报错（`Session not found`），这点比 codex
+ *   更友好；但目录不一致这个坑报错机制救不了，只能靠进程级看门狗兜底——resume 场景下若
+ *   watchdogMs 内收不到任何一行输出，主动 kill 并抛出清晰错误。
  */
 
 import { spawn } from 'child_process';
@@ -44,6 +53,8 @@ export interface OpenCodeEngineOptions {
     binaryPath?: string;
     /** provider/model，格式 "provider/model"（默认由 opencode 自身配置决定）*/
     model?: string;
+    /** resume 场景下的看门狗超时（ms，默认 120000）：目录不一致会挂死且不报错，只能靠超时兜底 */
+    resumeWatchdogMs?: number;
 }
 
 interface OpenCodePart {
@@ -70,8 +81,9 @@ interface OpenCodeJsonLine {
 export class OpenCodeEngine implements IAgentEngine {
     readonly kind = 'opencode' as const;
     // v1 用一次性非交互模式（opencode run），无编程式转人工接口；opencode serve 的双向
-    // 通道留作后续增强（见文件头注释）；不做 PTY 文本匹配兜底；v1 无 resume
-    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: false };
+    // 通道留作后续增强（见文件头注释）；不做 PTY 文本匹配兜底。
+    // resume=true：接 opencode 原生 --session 续接（见文件头注释，实测记录 #76）
+    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: true };
 
     constructor(private logger: Logger, private options: OpenCodeEngineOptions = {}) {}
 
@@ -81,11 +93,13 @@ export class OpenCodeEngine implements IAgentEngine {
         // 真实使用中发现：opencode 会自动发现/复用本机已在跑的 opencode server（daemon 式架构），
         // 此时新 spawn 的进程只是连去那个已有 server，spawn() 的 cwd 选项管不到它——
         // 必须显式传 --dir 告诉（新起的或被复用的）server 用哪个目录，不能只依赖进程级 cwd。
+        // resume 时必须复用首轮相同的 --dir（目录不一致会挂死，见文件头注释）。
         const args = ['run', '--format', 'json', '--dir', cwd];
+        if (context.resumeToken) args.push('--session', context.resumeToken);
         if (this.options.model) args.push('-m', this.options.model);
         args.push(input);
 
-        this.logger.info(`[opencode-engine] Starting "${binary} run" (cwd: ${cwd})`);
+        this.logger.info(`[opencode-engine] Starting "${binary} run"${context.resumeToken ? ' --session' : ''} (cwd: ${cwd})`);
 
         const child = spawn(binary, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
 
@@ -111,11 +125,29 @@ export class OpenCodeEngine implements IAgentEngine {
             child.on('close', (code, signal) => { exitCode = code; exitSignal = signal; resolve(); });
         });
 
+        // resume 场景专属看门狗：目录不一致时进程无输出无报错地挂死（实测确认），报错机制救不了，
+        // 只能靠"多久没收到一行输出就主动判定为挂死"兜底。首轮（无 resumeToken）不受影响。
+        let watchdogTimedOut = false;
+        let watchdogTimer: NodeJS.Timeout | undefined;
+        const armWatchdog = () => {
+            if (!context.resumeToken) return;
+            clearTimeout(watchdogTimer);
+            watchdogTimer = setTimeout(() => {
+                watchdogTimedOut = true;
+                child.kill();
+            }, this.options.resumeWatchdogMs ?? 120_000);
+        };
+        armWatchdog();
+
+        let resumeToken: string | undefined;
+
         if (child.stdout) {
             const rl = createInterface({ input: child.stdout });
             try {
                 for await (const line of rl) {
+                    armWatchdog();
                     if (!line.trim()) continue;
+                    if (!resumeToken) resumeToken = this._extractSessionId(line);
                     yield* this._translateLine(line);
                 }
             } finally {
@@ -124,14 +156,31 @@ export class OpenCodeEngine implements IAgentEngine {
         }
 
         await closePromise;
+        clearTimeout(watchdogTimer);
         if (context.abortSignal) context.abortSignal.removeEventListener('abort', onAbort);
 
+        if (watchdogTimedOut) {
+            throw new Error(`opencode resume 挂死：${this.options.resumeWatchdogMs ?? 120_000}ms 内无任何输出（很可能是 --dir 与会话原目录不一致导致进程无输出无报错地挂死，见 opencode-engine.ts 文件头注释）`);
+        }
         if (spawnError) throw spawnError;
         if (exitSignal) {
             throw new Error(`opencode run terminated by signal ${exitSignal}${context.abortSignal?.aborted ? ' (aborted)' : ''}`);
         }
         if (exitCode !== 0) {
             throw new Error(`opencode run exited with code ${exitCode}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`);
+        }
+
+        if (resumeToken) {
+            yield { type: 'meta', content: '💾 opencode 会话已记录，可续接', resumeToken, timestamp: new Date() };
+        }
+    }
+
+    private _extractSessionId(raw: string): string | undefined {
+        try {
+            const parsed = JSON.parse(raw) as OpenCodeJsonLine;
+            return typeof parsed.sessionID === 'string' ? parsed.sessionID : undefined;
+        } catch {
+            return undefined;
         }
     }
 

--- a/src/core/harness/pi-engine.ts
+++ b/src/core/harness/pi-engine.ts
@@ -27,10 +27,21 @@
  *   `message_update` 里的 toolcall_* 增量事件干净得多，直接用这一对映射 action/observation。
  * - `agent_end`：整个 agent 循环结束（可能包含多个 turn），携带完整 `messages[]`；只用作
  *   收尾标记，不重复提取内容（已经在各个 message_end 里发过了）。
+ *
+ * Resume 接入（两阶段自动化 spec #85，实测记录见地图 ticket #77，pi 0.80.6）：
+ * - pi 有原生轻量续接参数，无需 `--mode rpc`：`--session <id>` 直接续接，配合固定
+ *   `--session-dir <dir>`；resumeToken 取首行 `session` 事件的 `id` 字段（比 codex 友好，
+ *   不用扫目录反查）。
+ * - **关键**：续接必须用 `--session`，不能用 `--session-id`——后者传伪 id 时会静默新建
+ *   一个不带上下文的空会话（exit 0，等同 codex 的坑）；`--session` 传伪 id 则显式
+ *   `exit 1` + stderr `No session found matching '…'`，失败可判。
+ * - 已知坑仍在（与非 resume 场景一致）：API 认证/网络失败时退出码仍是 0，失败信号只在
+ *   `message_end.stopReason === "error"` 里，续接后同样需要检测。
  */
 
 import { spawn } from 'child_process';
 import { createInterface } from 'readline';
+import path from 'path';
 import type { ExecutionStep, Logger } from '../../types.js';
 import type { IAgentEngine, EngineRunContext, EngineCapabilities } from './agent-engine.js';
 
@@ -45,6 +56,11 @@ export interface PiEngineOptions {
     model?: string;
     /** 工具白名单（默认不传，使用 pi 默认工具集：read/bash/edit/write）*/
     tools?: string[];
+    /**
+     * 会话存储目录（--session-dir，固定传递以保证首轮与 resume 轮指向同一位置）。
+     * 默认 `<cwd>/.cmaster-pi-sessions`（按需求 worktree 隔离，实测建议按实例隔离）。
+     */
+    sessionDir?: string;
 }
 
 interface PiTextContentPart {
@@ -77,32 +93,42 @@ interface PiJsonLine {
     result?: { content?: Array<{ type: string; text?: string }> };
     isError?: boolean;
     cwd?: string;
+    /** session 事件携带的会话 id，用作 resumeToken（实测记录 #77） */
+    id?: string;
     [key: string]: unknown;
 }
 
 interface TranslateState {
     hasError: boolean;
     errorMessage?: string;
+    /** 首行 session 事件捕获的会话 id，作为 resumeToken */
+    sessionId?: string;
 }
 
 export class PiEngine implements IAgentEngine {
     readonly kind = 'pi' as const;
     // v1 用一次性非交互模式（--mode json -p），无编程式转人工接口；--mode rpc 的双向
-    // 通道留作后续增强（见文件头注释）；不做 PTY 文本匹配兜底；v1 无 resume
-    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: false };
+    // 通道留作后续增强（见文件头注释）。
+    // resume=true：接 pi 原生 --session 续接（见文件头注释，实测记录 #77）
+    readonly capabilities: EngineCapabilities = { interactiveApproval: false, resume: true };
 
     constructor(private logger: Logger, private options: PiEngineOptions = {}) {}
 
     async *run(input: string, context: EngineRunContext): AsyncGenerator<ExecutionStep> {
         const cwd = context.cwd ?? this.options.cwd ?? process.cwd();
         const binary = this.options.binaryPath ?? 'pi';
+        const sessionDir = this.options.sessionDir ?? path.join(cwd, '.cmaster-pi-sessions');
         const args = ['--mode', 'json', '-p'];
         if (this.options.provider) args.push('--provider', this.options.provider);
         if (this.options.model) args.push('--model', this.options.model);
         if (this.options.tools && this.options.tools.length > 0) args.push('--tools', this.options.tools.join(','));
+        // --session-dir 固定传递，保证首轮与 resume 轮指向同一位置；resume 用 --session
+        // （不用 --session-id，那个参数伪 id 会静默新建，见文件头注释）
+        args.push('--session-dir', sessionDir);
+        if (context.resumeToken) args.push('--session', context.resumeToken);
         args.push(input);
 
-        this.logger.info(`[pi-engine] Starting "${binary} -p" (cwd: ${cwd})`);
+        this.logger.info(`[pi-engine] Starting "${binary} -p"${context.resumeToken ? ' --session' : ''} (cwd: ${cwd})`);
 
         const child = spawn(binary, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
 
@@ -156,6 +182,10 @@ export class PiEngine implements IAgentEngine {
         if (state.hasError) {
             throw new Error(`pi reported an error: ${state.errorMessage ?? 'unknown error'}`);
         }
+
+        if (state.sessionId) {
+            yield { type: 'meta', content: '💾 pi 会话已记录，可续接', resumeToken: state.sessionId, timestamp: new Date() };
+        }
     }
 
     // ─────────────────────────────── private ───────────────────────────────
@@ -172,6 +202,7 @@ export class PiEngine implements IAgentEngine {
 
         switch (parsed.type) {
             case 'session':
+                if (typeof parsed.id === 'string' && !state.sessionId) state.sessionId = parsed.id;
                 yield { type: 'meta', content: `🚀 pi 会话已启动（cwd: ${parsed.cwd ?? '-'}）`, timestamp: now() };
                 break;
 

--- a/src/core/requirement-execution-service.ts
+++ b/src/core/requirement-execution-service.ts
@@ -10,10 +10,12 @@ import { OpenCodeEngine } from './harness/opencode-engine.js';
 import { PiEngine } from './harness/pi-engine.js';
 import type { IAgentEngine } from './harness/agent-engine.js';
 import { defaultAgentSpec, type AgentSpec } from './harness/agent-spec.js';
-import { cancelInterrupt } from './interrupt-coordinator.js';
+import { cancelInterrupt, hasPendingInterrupt, resolveInterrupt } from './interrupt-coordinator.js';
 import { sessionEventStore } from './harness/session-store.js';
 import { buildAnalysisPrompt, buildImplementPrompt, type DevWorkflowPromptOverrides } from './harness/dev-workflow-prompts.js';
 import { devWorkflowPromptTemplateRepository } from './dev-workflow-prompt-template-repository.js';
+import { extractLastMarker } from './harness/marker-blocks.js';
+import { pendingQuestionsRepository, type PendingQuestionsRepository } from './pending-questions-repository.js';
 
 /** coding agent 运行不使用 cmasterBot 自身的记忆系统 */
 const noopMemory: MemoryAccess = {
@@ -75,6 +77,8 @@ export interface RequirementExecutionServiceDeps {
     createEngine?: (engineKind: ExecutionEngineKind, spec: AgentSpec, logger: Logger) => IAgentEngine;
     /** 阶段 prompt 模板的 DB 覆盖层（spec #85），默认走真实 devWorkflowPromptTemplateRepository */
     promptOverrides?: DevWorkflowPromptOverrides;
+    /** 待回答问题的唯一真源（spec #85），默认走真实 pendingQuestionsRepository */
+    pendingQuestions?: PendingQuestionsRepository;
 }
 
 const consoleLogger: Logger = {
@@ -99,6 +103,7 @@ export class RequirementExecutionService {
     private logger: Logger;
     private createEngine: (engineKind: ExecutionEngineKind, spec: AgentSpec, logger: Logger) => IAgentEngine;
     private promptOverrides: DevWorkflowPromptOverrides;
+    private pendingQuestions: PendingQuestionsRepository;
     /** 运行中的 run（run.id → 中止句柄），供 cancel() 定位并中止；drive() 结束时自行清理 */
     private activeRuns = new Map<string, { controller: AbortController; cancelled: boolean }>();
 
@@ -109,6 +114,7 @@ export class RequirementExecutionService {
         this.worktree = deps.worktree ?? worktreeManager;
         this.logger = deps.logger ?? consoleLogger;
         this.promptOverrides = deps.promptOverrides ?? devWorkflowPromptTemplateRepository;
+        this.pendingQuestions = deps.pendingQuestions ?? pendingQuestionsRepository;
         this.createEngine = deps.createEngine ?? ((engineKind, spec, logger) => {
             switch (engineKind) {
                 case 'codex': return new CodexEngine(logger, {});
@@ -285,6 +291,82 @@ export class RequirementExecutionService {
     }
 
     /**
+     * 统一回答入口（spec: 两阶段自动化 #85）：标记待回答问题集为 answered 后按引擎能力双路分派——
+     * claude-code 原生中断走内存里挂起的 Promise（resolveInterrupt，executeAgentRun 的 for-await
+     * 循环仍在运行，唤醒后自动继续，不需要额外驱动）；非交互引擎（headless 进程已退出）取
+     * requirement_runs.resume_token 续接同一会话，组装「已回答问题 + 请继续」作为新一轮输入。
+     * 页面全程不感知走的是哪条分派路径。
+     */
+    async submitAnswers(requirementId: string, answers: string[]): Promise<void> {
+        const requirement = this.requirements.getById(requirementId);
+        if (!requirement) throw new Error(`Requirement not found: ${requirementId}`);
+        if (requirement.status !== 'waiting_input') {
+            throw new Error(`Requirement is not waiting for input (current: ${requirement.status})`);
+        }
+        const pending = this.pendingQuestions.getLatestByRequirement(requirementId);
+        if (!pending || pending.status !== 'pending') {
+            throw new Error(`No pending question set found for requirement: ${requirementId}`);
+        }
+        this.pendingQuestions.markAnswered(pending.id, answers);
+
+        const [latestRun] = this.runs.listByRequirement(requirementId);
+        if (!latestRun) throw new Error(`No run found for requirement: ${requirementId}`);
+
+        const joinedAnswer = answers.join('\n');
+
+        if (hasPendingInterrupt(latestRun.sessionId)) {
+            resolveInterrupt(latestRun.sessionId, true, { response: joinedAnswer });
+            return;
+        }
+
+        if (!latestRun.resumeToken) {
+            throw new Error(`Requirement ${requirementId} has no resumable session (engine may not support resume, or the process already exited without one)`);
+        }
+        const project = this.projects.getById(requirement.projectId);
+        if (!project) throw new Error(`Project not found: ${requirement.projectId}`);
+
+        const engineKind = ENGINE_KIND_FROM_LABEL[latestRun.engine] ?? 'claude-code';
+        const continuationTask = `已回答问题：\n${joinedAnswer}\n\n请基于以上回答继续。`;
+        const resumeOptions: StartRunOptions = { engine: engineKind };
+
+        if (requirement.parentId) {
+            // 卡片：先续接这张卡自己的 run，成功后直接继续驱动父需求的后续卡片
+            // （driveCardsSequentially 私有方法，不走 startImplementation 的公开状态门禁——
+            // 此时父需求处于 waiting_input，公开入口的 IMPLEMENTATION_RESUMABLE_STATUSES
+            // 不包含它，但这里是同一次实现流程的延续，不是重新发起，跳过门禁是正确的）
+            const parentId = requirement.parentId;
+            this.requirements.updateStatus(requirement.id, 'in_progress');
+            this.executeAgentRun(project, requirement, latestRun, resumeOptions, {
+                task: continuationTask, phase: 'implementation', onSuccessStatus: 'implemented', resumeToken: latestRun.resumeToken,
+            }).then(() => {
+                const finishedCard = this.requirements.getById(requirement.id)!;
+                const parent = this.requirements.getById(parentId);
+                if (!parent) return;
+                if (finishedCard.status === 'implemented') {
+                    this.requirements.updateStatus(parent.id, 'in_progress');
+                    const remainingCards = this.requirements.listCardsByParent(parent.id);
+                    this.driveCardsSequentially(project, parent, remainingCards, latestRun.worktreePath ?? '', latestRun.branch ?? '', resumeOptions).catch(err => {
+                        this.logger.error(`[requirement-execution] continue implementation for ${parentId} after card resume failed: ${(err as Error).message}`);
+                    });
+                } else {
+                    this.requirements.updateStatus(parent.id, finishedCard.status);
+                }
+            }).catch(err => {
+                this.logger.error(`[requirement-execution] resume card ${requirement.id} crashed outside its own try/catch: ${(err as Error).message}`);
+            });
+            return;
+        }
+
+        // 分析阶段续接
+        this.requirements.updateStatus(requirement.id, 'in_progress');
+        this.executeAgentRun(project, requirement, latestRun, resumeOptions, {
+            task: continuationTask, phase: 'analysis', onSuccessStatus: 'analyzed', resumeToken: latestRun.resumeToken,
+        }).catch(err => {
+            this.logger.error(`[requirement-execution] resume analysis ${requirement.id} crashed outside its own try/catch: ${(err as Error).message}`);
+        });
+    }
+
+    /**
      * 逐张驱动卡片；某卡失败/取消/等待回答则停在当卡（不推进后续卡片），把父需求状态同步为
      * 该卡的终态，供页面据此判断下一步（重试/跳过/回答问题）。全部卡片终态为 implemented 时，
      * 父需求转 implemented（走现有 merge() 流程）。
@@ -416,6 +498,10 @@ export class RequirementExecutionService {
             systemPrompt?: string;
             phase?: 'analysis' | 'implementation';
             onSuccessStatus: Requirement['status'];
+            /** 续接凭据（spec #85）：传给引擎表示续接同一会话，而非新起一轮 */
+            resumeToken?: string;
+            /** 内部用：协议违约重试是否已经用过（最多重试一轮） */
+            protocolRetryAttempted?: boolean;
         }
     ): Promise<void> {
         if (config.phase) this.requirements.updatePhase(requirement.id, config.phase);
@@ -444,6 +530,10 @@ export class RequirementExecutionService {
         emitEvent('session_start', { specId: spec.id, specName: spec.name, task, requirementId: requirement.id, engine: options.engine ?? 'claude-code' });
 
         let awaitingResume = false;
+        // 标记块协议（spec: 两阶段自动化 #85）判定材料：累积 content/answer 步骤的文本，
+        // 循环结束后据此判断 agent 最终想表达的是提问还是完成（只在 phase 已设置时启用，
+        // 旧单阶段 drive() 不传 phase，行为与改造前完全一致，不受影响）。
+        let accumulatedText = '';
         try {
             for await (const step of engine.run(task, {
                 sessionId: run.sessionId,
@@ -451,6 +541,7 @@ export class RequirementExecutionService {
                 cwd: run.worktreePath ?? undefined,
                 approvalMode: options.approvalMode ?? 'auto',
                 abortSignal: controller.signal,
+                resumeToken: config.resumeToken,
             })) {
                 emitEvent('agent_step', {
                     type: step.type,
@@ -462,8 +553,25 @@ export class RequirementExecutionService {
                     interruptReason: step.interruptReason,
                 });
 
+                if (step.resumeToken) {
+                    this.runs.setResumeToken(run.id, step.resumeToken);
+                }
+                if ((step.type === 'content' || step.type === 'answer') && step.content) {
+                    accumulatedText += step.content + '\n';
+                }
+
                 if (step.type === 'interrupt') {
                     awaitingResume = true;
+                    if (config.phase) {
+                        // claude-code 原生中断（ask_user 等）双写 pending_questions（spec #85）：
+                        // 内存态挂起 Promise 由引擎自己维护，这里只负责落表，让页面能用同一张表
+                        // 统一渲染，不必区分问题来自原生中断还是非交互引擎的标记块。
+                        this.pendingQuestions.create({
+                            requirementId: requirement.id, runId: run.id, sessionId: run.sessionId,
+                            phase: config.phase,
+                            questions: [{ id: step.interruptId ?? 'q1', question: step.interruptReason ?? step.content }],
+                        });
+                    }
                     this.requirements.updateStatus(requirement.id, 'waiting_input');
                     this.runs.updateStatus(run.id, 'waiting_input');
                     continue;
@@ -475,9 +583,71 @@ export class RequirementExecutionService {
                 }
             }
 
-            emitEvent('session_end', { status: 'succeeded' });
-            this.runs.updateStatus(run.id, 'succeeded', { finished: true });
-            this.requirements.updateStatus(requirement.id, config.onSuccessStatus);
+            if (!config.phase) {
+                // 旧单阶段路径：行为与改造前完全一致，不做标记块协议判定
+                emitEvent('session_end', { status: 'succeeded' });
+                this.runs.updateStatus(run.id, 'succeeded', { finished: true });
+                this.requirements.updateStatus(requirement.id, config.onSuccessStatus);
+                return;
+            }
+
+            const marker = extractLastMarker(accumulatedText);
+
+            if (marker?.type === 'questions') {
+                // 非交互引擎的等价"提问"路径（claude-code 走上面的原生 interrupt，二者
+                // 落到同一张 pending_questions 表，页面渲染不区分来源）
+                this.pendingQuestions.create({
+                    requirementId: requirement.id, runId: run.id, sessionId: run.sessionId,
+                    phase: config.phase, questions: marker.questions,
+                });
+                emitEvent('session_end', { status: 'waiting_input' });
+                this.runs.updateStatus(run.id, 'waiting_input');
+                this.requirements.updateStatus(requirement.id, 'waiting_input');
+                return;
+            }
+
+            if (marker?.type === 'done') {
+                if (config.phase === 'analysis') {
+                    if (marker.data.analysisSpec) {
+                        this.requirements.updateAnalysisSpec(requirement.id, marker.data.analysisSpec);
+                    }
+                    if (Array.isArray(marker.data.cards)) {
+                        marker.data.cards.forEach((c, i) => {
+                            this.requirements.createCard({
+                                parentId: requirement.id,
+                                projectId: project.id,
+                                reqKey: `${requirement.reqKey}-card-${i + 1}`,
+                                source: 'agent',
+                                sourceKey: `card-${i + 1}`,
+                                title: c.title,
+                                cardNo: i + 1,
+                            });
+                        });
+                    }
+                }
+                emitEvent('session_end', { status: 'succeeded' });
+                this.runs.updateStatus(run.id, 'succeeded', { finished: true });
+                this.requirements.updateStatus(requirement.id, config.onSuccessStatus);
+                return;
+            }
+
+            // 协议违约：既没有问题也没有完成信号。附加违约提示重试一轮；再次违约则整体标记 failed。
+            if (!config.protocolRetryAttempted) {
+                emitEvent('agent_step', {
+                    type: 'meta',
+                    content: '⚠️ 未检测到 cmaster:questions/cmaster:done 标记块，追加提示重试一轮',
+                });
+                return await this.executeAgentRun(project, requirement, run, options, {
+                    ...config,
+                    task: `${config.task}\n\n你上一次的回复没有包含所需的 cmaster:questions 或 cmaster:done 代码块。请严格按照输出协议重新给出结果。`,
+                    protocolRetryAttempted: true,
+                });
+            }
+
+            const violationMessage = '协议违约：agent 回复未包含 cmaster:questions 或 cmaster:done 标记块（已重试一次仍未修正）';
+            emitEvent('session_end', { status: 'failed', error: violationMessage });
+            this.runs.updateStatus(run.id, 'failed', { errorMessage: violationMessage, finished: true });
+            this.requirements.updateStatus(requirement.id, 'failed');
         } catch (err) {
             // cancel() 已经把状态改成 cancelled 了；这里只是让 catch 分支保持终态一致，不覆盖成 failed
             if (this.activeRuns.get(run.id)?.cancelled) {

--- a/src/gateway/routes/requirements.ts
+++ b/src/gateway/routes/requirements.ts
@@ -161,6 +161,33 @@ export async function registerRequirementRoutes(app: FastifyInstance, deps: Gate
         }
     });
 
+    // 两阶段自动化统一回答入口（spec #85）：页面提交回答后，平台按引擎能力自动分派——
+    // claude-code 原生中断走内存 Promise，非交互引擎走 resume_token 续接；页面全程不感知引擎。
+    app.post<{ Params: { id: string }; Body: { answers: string[] } }>('/api/requirements/:id/answers', async (request, reply) => {
+        try {
+            const answers = request.body?.answers;
+            if (!Array.isArray(answers) || answers.length === 0) {
+                reply.status(400);
+                return { error: 'Missing required field: answers (non-empty array)' };
+            }
+            await requirementExecutionService.submitAnswers(request.params.id, answers);
+            return { success: true };
+        } catch (error: any) {
+            deps.logger.error(`Submit answers error: ${error.message}`);
+            if (error.message?.startsWith('Requirement not found') || error.message?.startsWith('Project not found')
+                || error.message?.startsWith('No pending question set') || error.message?.startsWith('No run found')) {
+                reply.status(404);
+                return { error: error.message };
+            }
+            if (error.message?.includes('waiting for input') || error.message?.includes('no resumable session')) {
+                reply.status(409);
+                return { error: error.message };
+            }
+            reply.status(500);
+            return { error: error.message };
+        }
+    });
+
     // 人工核验通过、PR 已在 GitHub 上合并后调用：标记需求完成 + 自动清理 worktree（spec §4.3）
     app.post<{ Params: { id: string } }>('/api/requirements/:id/merge', async (request, reply) => {
         try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,12 @@ export interface ExecutionStep {
     droppedCount?: number;
     // Phase 26: Harness instance tracking（供前端关联子任务面板）
     harnessInstanceId?: string;
+    /**
+     * 研发流程两阶段自动化：引擎侧会话续接凭据（capabilities.resume=true 时，run() 结束前
+     * 在最后一个 meta step 上携带）。codex=rollout uuid，opencode/pi=首行 session id。
+     * 调用方（RequirementExecutionService）捕获后存入 requirement_runs.resume_token。
+     */
+    resumeToken?: string;
     timestamp: Date;
 }
 

--- a/tests/codex-engine.test.ts
+++ b/tests/codex-engine.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { writeFileSync, mkdtempSync, mkdirSync, chmodSync, rmSync, readFileSync } from 'fs';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, mkdirSync, chmodSync, rmSync, readFileSync, utimesSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { CodexEngine } from '../src/core/harness/codex-engine.js';
@@ -10,6 +10,8 @@ const mockMemory: MemoryAccess = { get: async () => undefined, set: async () => 
 
 let tmpDir: string;
 let fakeBinPath: string;
+/** 大部分测试无关 resume 反查，指向一个空目录，避免误扫到本机真实 ~/.codex/sessions */
+let emptySessionsRoot: string;
 
 async function drain(gen: AsyncGenerator<ExecutionStep>): Promise<ExecutionStep[]> {
     const steps: ExecutionStep[] = [];
@@ -32,6 +34,7 @@ if (stderrOut) process.stderr.write(stderrOut);
 process.exitCode = parseInt(process.env.FAKE_CODEX_EXIT_CODE || '0', 10);
 `);
     chmodSync(fakeBinPath, 0o755);
+    emptySessionsRoot = mkdtempSync(path.join(tmpdir(), 'fake-codex-sessions-empty-'));
 });
 
 afterAll(() => {
@@ -46,15 +49,15 @@ afterEach(() => {
 });
 
 describe('CodexEngine', () => {
-    it('capabilities: interactiveApproval=false, resume=false（显式降级，spec §5.5）', () => {
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
-        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
+    it('capabilities: interactiveApproval=false（显式降级，spec §5.5），resume=true（原生会话续接，spec #85）', () => {
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
+        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: true });
     });
 
     it('拼装的 CLI 参数包含 exec/--json/--sandbox/-C/--skip-git-repo-check 与 prompt（不含 -a/--ask-for-approval，实测确认 exec 不支持该参数）', async () => {
         const argsFile = path.join(tmpDir, 'args.json');
         process.env.FAKE_CODEX_ARGS_FILE = argsFile;
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sandbox: 'read-only' });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sandbox: 'read-only', sessionsRoot: emptySessionsRoot });
         await drain(engine.run('implement X', { sessionId: 's8', memory: mockMemory, cwd: tmpDir }));
         const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
         expect(args).toEqual(['exec', '--json', '--sandbox', 'read-only', '--skip-git-repo-check', '-C', tmpDir, 'implement X']);
@@ -63,7 +66,7 @@ describe('CodexEngine', () => {
     it('-C 显式传给 CLI，不依赖进程级 cwd（防御性修复，同一类 bug 在 opencode 引擎上被真实踩中过）', async () => {
         const argsFile = path.join(tmpDir, 'args.json');
         process.env.FAKE_CODEX_ARGS_FILE = argsFile;
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const otherDir = path.join(tmpDir, 'a-different-project-dir');
         mkdirSync(otherDir);
         await drain(engine.run('task', { sessionId: 's8b', memory: mockMemory, cwd: otherDir }));
@@ -79,7 +82,7 @@ describe('CodexEngine', () => {
             JSON.stringify({ id: '0', msg: { type: 'task_started', model_context_window: 272000 } }),
         ].join('\n') + '\n';
 
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('do the task', { sessionId: 's1', memory: mockMemory }));
 
         expect(steps).toHaveLength(2);
@@ -94,7 +97,7 @@ describe('CodexEngine', () => {
             JSON.stringify({ id: '0', msg: { type: 'error', message: 'unexpected status 402' } }),
         ].join('\n') + '\n';
 
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('task', { sessionId: 's2', memory: mockMemory }));
 
         expect(steps.some(s => s.type === 'meta' && s.content.includes('重试中'))).toBe(true);
@@ -115,7 +118,7 @@ describe('CodexEngine', () => {
             JSON.stringify({ id: '0', msg: { type: 'token_count', info: null } }),
         ].join('\n') + '\n';
 
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('Just reply with the single word: pong.', { sessionId: 's1b', memory: mockMemory }));
 
         // 配置回显 1 条 meta（prompt 回显不产出）+ task_started 1 条 meta + agent_message 1 条
@@ -130,7 +133,7 @@ describe('CodexEngine', () => {
 
     it('未识别的事件类型不静默丢弃，降级为 meta 透出原始 payload', async () => {
         process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'some_future_event', foo: 'bar' } }) + '\n';
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('task', { sessionId: 's3', memory: mockMemory }));
         expect(steps).toHaveLength(1);
         expect(steps[0].content).toContain('some_future_event');
@@ -142,7 +145,7 @@ describe('CodexEngine', () => {
             'not json at all',
             JSON.stringify({ id: '0', msg: { type: 'task_started', model_context_window: 1000 } }),
         ].join('\n') + '\n';
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('task', { sessionId: 's3b', memory: mockMemory }));
         expect(steps).toHaveLength(1);
         expect(steps[0].content).toContain('1000');
@@ -156,7 +159,7 @@ describe('CodexEngine', () => {
             JSON.stringify({ id: '0', msg: { type: 'task_complete', last_agent_message: '完成了' } }),
         ].join('\n') + '\n';
 
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         const steps = await drain(engine.run('task', { sessionId: 's4', memory: mockMemory }));
 
         expect(steps.find(s => s.type === 'thought')?.content).toBe('思考中...');
@@ -170,7 +173,7 @@ describe('CodexEngine', () => {
     it('非零退出码抛错，携带 stderr', async () => {
         process.env.FAKE_CODEX_EXIT_CODE = '1';
         process.env.FAKE_CODEX_STDERR = 'boom';
-        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath });
+        const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot: emptySessionsRoot });
         await expect(drain(engine.run('task', { sessionId: 's5', memory: mockMemory })))
             .rejects.toThrow(/exited with code 1/);
     });
@@ -193,5 +196,73 @@ describe('CodexEngine', () => {
         controller.abort();
         // kill 后进程以信号终止（非 0 退出码），run() 应该 reject 而不是永久挂起
         await expect(runPromise).rejects.toThrow();
+    });
+
+    // ─────────────────────────── Resume（两阶段自动化 spec #85，实测记录 #75）───────────────────────────
+
+    describe('resume', () => {
+        let sessionsRoot: string;
+
+        function writeRollout(uuid: string, cwd: string, mtimeMs: number): void {
+            const dayDir = path.join(sessionsRoot, '2026', '07', '12');
+            mkdirSync(dayDir, { recursive: true });
+            const file = path.join(dayDir, `rollout-2026-07-12T10-00-00-${uuid}.jsonl`);
+            writeFileSync(file, JSON.stringify({
+                timestamp: '2026-07-12T02:00:00.000Z',
+                type: 'session_meta',
+                payload: { id: uuid, timestamp: '2026-07-12T02:00:00.000Z', cwd, originator: 'codex_cli_rs', cli_version: '0.39.0' },
+            }) + '\n');
+            const now = new Date(mtimeMs);
+            utimesSync(file, now, now);
+        }
+
+        beforeEach(() => {
+            // 每个用例独立的 sessionsRoot，避免上一个用例写的 rollout 文件在时间窗内被下一个误认
+            sessionsRoot = mkdtempSync(path.join(tmpdir(), 'fake-codex-sessions-'));
+        });
+
+        it('成功结束后按 cwd + 时间窗反查 rollout uuid，作为最后一步 meta 的 resumeToken 携带', async () => {
+            process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'agent_message', message: 'ok' } }) + '\n';
+            const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot });
+            const runStart = Date.now();
+            writeRollout('019f553e-aaaa-bbbb-cccc-000000000001', tmpDir, runStart + 500);
+
+            const steps = await drain(engine.run('task', { sessionId: 'sr1', memory: mockMemory, cwd: tmpDir }));
+            const resumeStep = steps.find(s => s.resumeToken);
+            expect(resumeStep?.resumeToken).toBe('019f553e-aaaa-bbbb-cccc-000000000001');
+        });
+
+        it('cwd 不匹配的 rollout 文件不会被误认成本轮会话', async () => {
+            process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'agent_message', message: 'ok' } }) + '\n';
+            const otherDir = path.join(tmpDir, 'unrelated-project');
+            mkdirSync(otherDir, { recursive: true });
+            const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot });
+            const runStart = Date.now();
+            writeRollout('019f553e-aaaa-bbbb-cccc-000000000002', otherDir, runStart + 500);
+
+            const steps = await drain(engine.run('task', { sessionId: 'sr2', memory: mockMemory, cwd: tmpDir }));
+            expect(steps.some(s => s.resumeToken)).toBe(false);
+        });
+
+        it('resume 时 flags 前置于 resume 子命令，携带 --sandbox 重传（resume 轮默认回显 read-only）', async () => {
+            const argsFile = path.join(tmpDir, 'resume-args.json');
+            process.env.FAKE_CODEX_ARGS_FILE = argsFile;
+            process.env.FAKE_CODEX_OUTPUT = JSON.stringify({ id: '0', msg: { type: 'agent_message', message: 'ok' } }) + '\n';
+            const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot });
+            const uuid = '019f553e-aaaa-bbbb-cccc-000000000003';
+            writeRollout(uuid, tmpDir, Date.now() - 60000); // 早于本轮 run，只用于校验存在性，不参与本轮反查
+
+            await drain(engine.run('刚才的暗号是什么？', { sessionId: 'sr3', memory: mockMemory, cwd: tmpDir, resumeToken: uuid }));
+            const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+            expect(args).toEqual(['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', '-C', tmpDir, 'resume', uuid, '刚才的暗号是什么？']);
+        });
+
+        it('resumeToken 对应的 rollout 文件不存在时直接抛错，不静默新建（codex 已知坑：伪 id exit 0）', async () => {
+            const engine = new CodexEngine(mockLogger, { binaryPath: fakeBinPath, sessionsRoot });
+            await expect(drain(engine.run('task', {
+                sessionId: 'sr4', memory: mockMemory, cwd: tmpDir,
+                resumeToken: '00000000-0000-0000-0000-000000000000',
+            }))).rejects.toThrow(/rollout 文件不存在/);
+        });
     });
 });

--- a/tests/marker-blocks.test.ts
+++ b/tests/marker-blocks.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { extractMarkerBlock, extractQuestionsBlock, extractDoneBlock, extractLastMarker } from '../src/core/harness/marker-blocks.js';
+
+describe('marker-blocks', () => {
+    describe('extractMarkerBlock', () => {
+        it('提取单个标记块并解析 JSON', () => {
+            const text = '一些前置文字\n```cmaster:done\n{"foo":"bar"}\n```\n后续文字';
+            expect(extractMarkerBlock(text, 'cmaster:done')).toEqual({ foo: 'bar' });
+        });
+
+        it('取最后一个匹配块（agent 可能在思考过程里提过格式示例）', () => {
+            const text = [
+                '示例格式：```cmaster:done\n{"foo":"draft"}\n```',
+                '真正的结果：```cmaster:done\n{"foo":"final"}\n```',
+            ].join('\n');
+            expect(extractMarkerBlock(text, 'cmaster:done')).toEqual({ foo: 'final' });
+        });
+
+        it('未出现该标记块时返回 undefined', () => {
+            expect(extractMarkerBlock('普通回复，没有标记块', 'cmaster:done')).toBeUndefined();
+        });
+
+        it('标记块内容不是合法 JSON 时返回 undefined（不抛错）', () => {
+            const text = '```cmaster:done\n这不是 JSON\n```';
+            expect(extractMarkerBlock(text, 'cmaster:done')).toBeUndefined();
+        });
+
+        it('两种标记块互不干扰，各自独立提取', () => {
+            const text = '```cmaster:questions\n{"questions":[]}\n```\n```cmaster:done\n{"ok":true}\n```';
+            expect(extractMarkerBlock(text, 'cmaster:questions')).toEqual({ questions: [] });
+            expect(extractMarkerBlock(text, 'cmaster:done')).toEqual({ ok: true });
+        });
+    });
+
+    describe('extractQuestionsBlock', () => {
+        it('提取合法的 questions 数组', () => {
+            const text = '```cmaster:questions\n{"questions":[{"id":"q1","question":"用什么版式？"}]}\n```';
+            expect(extractQuestionsBlock(text)).toEqual({ questions: [{ id: 'q1', question: '用什么版式？' }] });
+        });
+
+        it('questions 为空数组时视为未取到（没有实际问题）', () => {
+            const text = '```cmaster:questions\n{"questions":[]}\n```';
+            expect(extractQuestionsBlock(text)).toBeUndefined();
+        });
+
+        it('缺少 questions 字段时视为未取到', () => {
+            const text = '```cmaster:questions\n{"foo":"bar"}\n```';
+            expect(extractQuestionsBlock(text)).toBeUndefined();
+        });
+    });
+
+    describe('extractDoneBlock', () => {
+        it('提取携带分析规格与卡片的 done 块', () => {
+            const text = '```cmaster:done\n{"analysisSpec":{"goal":"g","scope":"s","acceptance":"a"},"cards":[{"title":"卡1"},{"title":"卡2"}]}\n```';
+            const done = extractDoneBlock(text);
+            expect(done?.analysisSpec).toEqual({ goal: 'g', scope: 's', acceptance: 'a' });
+            expect(done?.cards).toEqual([{ title: '卡1' }, { title: '卡2' }]);
+        });
+
+        it('空对象 done 块也算取到（如单卡实现完成，没有额外产物）', () => {
+            const text = '```cmaster:done\n{}\n```';
+            expect(extractDoneBlock(text)).toEqual({});
+        });
+
+        it('done 块内容是数组而非对象时视为未取到', () => {
+            const text = '```cmaster:done\n[1,2,3]\n```';
+            expect(extractDoneBlock(text)).toBeUndefined();
+        });
+    });
+
+    describe('extractLastMarker', () => {
+        it('只有 questions 块时返回 questions 类型', () => {
+            const text = '```cmaster:questions\n{"questions":[{"id":"q1","question":"？"}]}\n```';
+            expect(extractLastMarker(text)).toEqual({ type: 'questions', questions: [{ id: 'q1', question: '？' }] });
+        });
+
+        it('只有 done 块时返回 done 类型', () => {
+            const text = '```cmaster:done\n{"ok":true}\n```';
+            expect(extractLastMarker(text)).toEqual({ type: 'done', data: { ok: true } });
+        });
+
+        it('两种都出现时，取文本中位置更靠后的那一个（不是按类型各自的最后一次）', () => {
+            const questionsThenDone = '```cmaster:questions\n{"questions":[{"id":"q1","question":"？"}]}\n```\n```cmaster:done\n{"ok":true}\n```';
+            expect(extractLastMarker(questionsThenDone)).toEqual({ type: 'done', data: { ok: true } });
+
+            const doneThenQuestions = '```cmaster:done\n{"ok":true}\n```\n```cmaster:questions\n{"questions":[{"id":"q1","question":"？"}]}\n```';
+            expect(extractLastMarker(doneThenQuestions)).toEqual({ type: 'questions', questions: [{ id: 'q1', question: '？' }] });
+        });
+
+        it('都没有出现时返回 undefined（协议违约的判定依据）', () => {
+            expect(extractLastMarker('普通回复，没有任何标记块')).toBeUndefined();
+        });
+
+        it('最后一个标记块内容非法（如 questions 数组为空）时返回 undefined', () => {
+            const text = '```cmaster:questions\n{"questions":[]}\n```';
+            expect(extractLastMarker(text)).toBeUndefined();
+        });
+    });
+});

--- a/tests/opencode-engine.test.ts
+++ b/tests/opencode-engine.test.ts
@@ -43,9 +43,9 @@ afterEach(() => {
 });
 
 describe('OpenCodeEngine', () => {
-    it('capabilities: interactiveApproval=false（v1 一次性非交互模式，opencode serve 双向通道留后续）, resume=false', () => {
+    it('capabilities: interactiveApproval=false（v1 一次性非交互模式，opencode serve 双向通道留后续）, resume=true（原生 --session 续接，spec #85）', () => {
         const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
-        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
+        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: true });
     });
 
     it('拼装的 CLI 参数包含 run/--format/json/--dir 与 prompt', async () => {
@@ -80,11 +80,13 @@ describe('OpenCodeEngine', () => {
         const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
         const steps = await drain(engine.run('reply pong', { sessionId: 's2', memory: mockMemory }));
 
-        // step-start 不产出步骤；text → content；step-finish(reason=stop) → meta
-        expect(steps).toHaveLength(2);
+        // step-start 不产出步骤；text → content；step-finish(reason=stop) → meta；
+        // 成功结束后追加一条携带 resumeToken 的 meta（sessionID 全程都是 's'）
+        expect(steps).toHaveLength(3);
         expect(steps[0]).toMatchObject({ type: 'content', content: 'pong' });
         expect(steps[1]).toMatchObject({ type: 'meta' });
         expect(steps[1].content).toContain('stop');
+        expect(steps[2].resumeToken).toBe('s');
     });
 
     it('真实成功路径（实测，含工具调用）：tool_use（glob）拆成 action+observation，step_finish(reason=tool-calls) 不产出步骤', async () => {
@@ -113,8 +115,10 @@ describe('OpenCodeEngine', () => {
         const observation = steps.find(s => s.type === 'observation');
         expect(observation?.content).toContain('a.txt');
         expect(steps.find(s => s.type === 'content')?.content).toBe('Found 2 files.');
-        // tool-calls 阶段的 step_finish 不产出 meta（只有最终 stop 阶段才产出）
-        expect(steps.filter(s => s.type === 'meta')).toHaveLength(1);
+        // tool-calls 阶段的 step_finish 不产出 meta（只有最终 stop 阶段才产出）；
+        // 排除成功结束后追加的 resumeToken meta，业务性的 meta 只有 1 条
+        expect(steps.filter(s => s.type === 'meta' && !s.resumeToken)).toHaveLength(1);
+        expect(steps.some(s => s.resumeToken === 's')).toBe(true);
     });
 
     it('error 事件（实测确认，无 part 包装）：answer + meta', async () => {
@@ -137,9 +141,11 @@ describe('OpenCodeEngine', () => {
         }) + '\n';
         const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
         const steps = await drain(engine.run('task', { sessionId: 's5', memory: mockMemory }));
-        expect(steps).toHaveLength(1);
-        expect(steps[0].content).toContain('some-future-part');
-        expect(steps[0].content).toContain('bar');
+        // 成功结束后追加一条 resumeToken meta（sessionID='s'），业务性输出只有 1 条
+        const businessSteps = steps.filter(s => !s.resumeToken);
+        expect(businessSteps).toHaveLength(1);
+        expect(businessSteps[0].content).toContain('some-future-part');
+        expect(businessSteps[0].content).toContain('bar');
     });
 
     it('工具执行失败（state.status=error）产出带 ❌ 前缀的 observation', async () => {
@@ -177,5 +183,52 @@ describe('OpenCodeEngine', () => {
         const runPromise = drain(engine.run('task', { sessionId: 's9', memory: mockMemory, abortSignal: controller.signal }));
         controller.abort();
         await expect(runPromise).rejects.toThrow();
+    });
+
+    // ─────────────────────────── Resume（两阶段自动化 spec #85，实测记录 #76）───────────────────────────
+
+    describe('resume', () => {
+        it('传入 resumeToken 时 CLI 参数包含 --session，且仍复用相同 --dir', async () => {
+            const argsFile = path.join(tmpDir, 'resume-args.json');
+            process.env.FAKE_OPENCODE_ARGS_FILE = argsFile;
+            process.env.FAKE_OPENCODE_OUTPUT = JSON.stringify({ type: 'text', timestamp: 1, sessionID: 'ses_abc', part: { type: 'text', text: '暗号' } }) + '\n';
+            const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
+            await drain(engine.run('刚才的暗号是什么？', { sessionId: 'sr1', memory: mockMemory, cwd: tmpDir, resumeToken: 'ses_abc' }));
+            const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+            expect(args).toEqual(['run', '--format', 'json', '--dir', tmpDir, '--session', 'ses_abc', '刚才的暗号是什么？']);
+        });
+
+        it('resumeToken 直接取自 JSONL 每行都带的 sessionID，无需像 codex 那样反查文件', async () => {
+            process.env.FAKE_OPENCODE_OUTPUT = JSON.stringify({ type: 'text', timestamp: 1, sessionID: 'ses_xyz', part: { type: 'text', text: 'ok' } }) + '\n';
+            const engine = new OpenCodeEngine(mockLogger, { binaryPath: fakeBinPath });
+            const steps = await drain(engine.run('task', { sessionId: 'sr2', memory: mockMemory }));
+            expect(steps.find(s => s.resumeToken)?.resumeToken).toBe('ses_xyz');
+        });
+
+        it('resume 时看门狗超时兜底：目录不一致会挂死且不报错，watchdogMs 内无任何输出则主动判定失败', async () => {
+            const hangScript = path.join(tmpDir, 'hang-opencode.cjs');
+            writeFileSync(hangScript, `#!/usr/bin/env node\n// 模拟 --dir 不一致：既不输出也不退出\n`);
+            chmodSync(hangScript, 0o755);
+
+            const engine = new OpenCodeEngine(mockLogger, { binaryPath: hangScript, resumeWatchdogMs: 100 });
+            await expect(drain(engine.run('task', {
+                sessionId: 'sr3', memory: mockMemory, cwd: tmpDir, resumeToken: 'ses_stale',
+            }))).rejects.toThrow(/挂死/);
+        });
+
+        it('首轮（无 resumeToken）不受看门狗影响：即使输出较慢也不会被误杀', async () => {
+            const delayedScript = path.join(tmpDir, 'delayed-opencode.cjs');
+            writeFileSync(delayedScript, `#!/usr/bin/env node
+setTimeout(() => {
+    process.stdout.write(${JSON.stringify(JSON.stringify({ type: 'text', timestamp: 1, sessionID: 's', part: { type: 'text', text: 'ok' } }) + '\n')});
+    process.exit(0);
+}, 50);
+`);
+            chmodSync(delayedScript, 0o755);
+            // resumeWatchdogMs 故意设得比延迟还短：首轮不应受影响（看门狗只在 resumeToken 场景生效）
+            const engine = new OpenCodeEngine(mockLogger, { binaryPath: delayedScript, resumeWatchdogMs: 10 });
+            const steps = await drain(engine.run('task', { sessionId: 'sr4', memory: mockMemory }));
+            expect(steps.some(s => s.type === 'content' && s.content === 'ok')).toBe(true);
+        });
     });
 });

--- a/tests/opencode-engine.test.ts
+++ b/tests/opencode-engine.test.ts
@@ -207,7 +207,10 @@ describe('OpenCodeEngine', () => {
 
         it('resume 时看门狗超时兜底：目录不一致会挂死且不报错，watchdogMs 内无任何输出则主动判定失败', async () => {
             const hangScript = path.join(tmpDir, 'hang-opencode.cjs');
-            writeFileSync(hangScript, `#!/usr/bin/env node\n// 模拟 --dir 不一致：既不输出也不退出\n`);
+            // 模拟 --dir 不一致：既不输出也不退出——必须真的挂起进程（而不是让脚本自然
+            // 执行完退出），否则本用例在 CI 上会和看门狗定时器赛跑，脚本自己先退出就
+            // 让断言失败（真实踩过：本地偶尔通过，CI 上稳定失败）
+            writeFileSync(hangScript, `#!/usr/bin/env node\nsetInterval(() => {}, 1000);\n`);
             chmodSync(hangScript, 0o755);
 
             const engine = new OpenCodeEngine(mockLogger, { binaryPath: hangScript, resumeWatchdogMs: 100 });

--- a/tests/pi-engine.test.ts
+++ b/tests/pi-engine.test.ts
@@ -43,9 +43,9 @@ afterEach(() => {
 });
 
 describe('PiEngine', () => {
-    it('capabilities: interactiveApproval=false（v1 一次性非交互模式，--mode rpc 双向通道留后续）, resume=false', () => {
+    it('capabilities: interactiveApproval=false（v1 一次性非交互模式，--mode rpc 双向通道留后续）, resume=true（原生 --session 续接，spec #85）', () => {
         const engine = new PiEngine(mockLogger, { binaryPath: fakeBinPath });
-        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: false });
+        expect(engine.capabilities).toEqual({ interactiveApproval: false, resume: true });
     });
 
     it('拼装的 CLI 参数包含 --mode json -p、--provider/--model/--tools 与 prompt', async () => {
@@ -59,6 +59,7 @@ describe('PiEngine', () => {
         expect(args).toEqual([
             '--mode', 'json', '-p',
             '--provider', 'mistral', '--model', 'mistral-large-latest', '--tools', 'read,grep',
+            '--session-dir', path.join(tmpDir, '.cmaster-pi-sessions'),
             'implement X',
         ]);
     });
@@ -82,10 +83,12 @@ describe('PiEngine', () => {
         const engine = new PiEngine(mockLogger, { binaryPath: fakeBinPath });
         const steps = await drain(engine.run('reply pong', { sessionId: 's2', memory: mockMemory }));
 
-        expect(steps).toHaveLength(2);
+        // session 启动 meta + pong content + 成功结束后追加的 resumeToken meta（id='x'）
+        expect(steps).toHaveLength(3);
         expect(steps[0]).toMatchObject({ type: 'meta' });
         expect(steps[0].content).toContain('/private/tmp/pi-probe');
         expect(steps[1]).toMatchObject({ type: 'content', content: 'pong' });
+        expect(steps[2].resumeToken).toBe('x');
     });
 
     it('真实成功路径（实测，含工具调用）：tool_execution_start/end → action/observation，多轮 message_end 各自产出 content', async () => {
@@ -203,5 +206,51 @@ describe('PiEngine', () => {
         const runPromise = drain(engine.run('task', { sessionId: 's10', memory: mockMemory, abortSignal: controller.signal }));
         controller.abort();
         await expect(runPromise).rejects.toThrow();
+    });
+
+    // ─────────────────────────── Resume（两阶段自动化 spec #85，实测记录 #77）───────────────────────────
+
+    describe('resume', () => {
+        it('传入 resumeToken 时 CLI 参数包含 --session-dir 与 --session', async () => {
+            const argsFile = path.join(tmpDir, 'resume-args.json');
+            process.env.FAKE_PI_ARGS_FILE = argsFile;
+            process.env.FAKE_PI_OUTPUT = JSON.stringify({
+                type: 'message_end',
+                message: { role: 'assistant', content: [{ type: 'text', text: '紫色大象88' }], stopReason: 'stop' },
+            }) + '\n';
+            const engine = new PiEngine(mockLogger, { binaryPath: fakeBinPath, provider: 'mistral', model: 'devstral-medium-latest' });
+            await drain(engine.run('刚才的暗号是什么？', { sessionId: 'sr1', memory: mockMemory, cwd: tmpDir, resumeToken: '019f5548-b50a-abcd' }));
+            const args = JSON.parse(readFileSync(argsFile, 'utf-8'));
+            expect(args).toEqual([
+                '--mode', 'json', '-p',
+                '--provider', 'mistral', '--model', 'devstral-medium-latest',
+                '--session-dir', path.join(tmpDir, '.cmaster-pi-sessions'),
+                '--session', '019f5548-b50a-abcd',
+                '刚才的暗号是什么？',
+            ]);
+        });
+
+        it('resumeToken 直接取自首行 session 事件的 id 字段，无需扫目录反查', async () => {
+            process.env.FAKE_PI_OUTPUT = [
+                JSON.stringify({ type: 'session', version: 3, id: '019f5548-real-session', timestamp: 't', cwd: tmpDir }),
+                JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }], stopReason: 'stop' } }),
+            ].join('\n') + '\n';
+            const engine = new PiEngine(mockLogger, { binaryPath: fakeBinPath });
+            const steps = await drain(engine.run('task', { sessionId: 'sr2', memory: mockMemory, cwd: tmpDir }));
+            expect(steps.find(s => s.resumeToken)?.resumeToken).toBe('019f5548-real-session');
+        });
+
+        it('--session 传伪 id 时 pi 显式 exit 1 + stderr「No session found」，透传为可判的错误', async () => {
+            const stderrScript = path.join(tmpDir, 'fake-pi-stderr.cjs');
+            writeFileSync(stderrScript, `#!/usr/bin/env node
+process.stderr.write("No session found matching '00000000-stale'");
+process.exitCode = 1;
+`);
+            chmodSync(stderrScript, 0o755);
+            const engine = new PiEngine(mockLogger, { binaryPath: stderrScript });
+            await expect(drain(engine.run('task', {
+                sessionId: 'sr3', memory: mockMemory, cwd: tmpDir, resumeToken: '00000000-stale',
+            }))).rejects.toThrow(/No session found/);
+        });
     });
 });

--- a/tests/requirement-execution-service.test.ts
+++ b/tests/requirement-execution-service.test.ts
@@ -3,7 +3,9 @@ import { DatabaseSync } from 'node:sqlite';
 import { ProjectRepository } from '../src/core/project-repository.js';
 import { RequirementRepository } from '../src/core/requirement-repository.js';
 import { RequirementRunRepository } from '../src/core/requirement-run-repository.js';
+import { PendingQuestionsRepository } from '../src/core/pending-questions-repository.js';
 import { RequirementExecutionService } from '../src/core/requirement-execution-service.js';
+import { waitForUserDecision } from '../src/core/interrupt-coordinator.js';
 import type { WorktreeManager } from '../src/core/worktree-manager.js';
 import type { IAgentEngine } from '../src/core/harness/agent-engine.js';
 import type { ExecutionStep } from '../src/types.js';
@@ -34,6 +36,11 @@ function createTestDb(): DatabaseSync {
             worktree_path TEXT, branch TEXT, session_id TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'running',
             retry_no INTEGER NOT NULL DEFAULT 0, pr_url TEXT, error_message TEXT, token_cost TEXT, resume_token TEXT,
             started_at TEXT NOT NULL, finished_at TEXT
+        );
+        CREATE TABLE IF NOT EXISTS pending_questions (
+            id TEXT PRIMARY KEY, requirement_id TEXT NOT NULL, run_id TEXT NOT NULL, session_id TEXT NOT NULL,
+            phase TEXT NOT NULL, questions TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending',
+            answers TEXT, created_at TEXT NOT NULL, answered_at TEXT
         );
     `);
     return db;
@@ -72,10 +79,29 @@ function engineThrowing(message: string): IAgentEngine {
     };
 }
 
+/** 两阶段自动化（spec #85）：phase 已设置的 startAnalysis/startImplementation 成功路径
+ * 必须携带 cmaster:done 标记块，否则会被判协议违约——这里统一生成一个带指定 payload 的步骤 */
+function doneStep(content: string, payload: Record<string, unknown> = {}): ExecutionStep {
+    return {
+        type: 'answer',
+        content: `${content}\n\`\`\`cmaster:done\n${JSON.stringify(payload)}\n\`\`\``,
+        timestamp: new Date(),
+    };
+}
+
+function questionsStep(questions: Array<{ id: string; question: string }>): ExecutionStep {
+    return {
+        type: 'content',
+        content: `\`\`\`cmaster:questions\n${JSON.stringify({ questions })}\n\`\`\``,
+        timestamp: new Date(),
+    };
+}
+
 describe('RequirementExecutionService', () => {
     let projects: ProjectRepository;
     let requirements: RequirementRepository;
     let runs: RequirementRunRepository;
+    let pendingQuestions: PendingQuestionsRepository;
     let worktree: WorktreeManager;
     let projectId: string;
 
@@ -84,13 +110,14 @@ describe('RequirementExecutionService', () => {
         projects = new ProjectRepository(db as any);
         requirements = new RequirementRepository(db as any);
         runs = new RequirementRunRepository(db as any);
+        pendingQuestions = new PendingQuestionsRepository(db as any);
         worktree = fakeWorktreeManager();
         projectId = projects.create({ name: 'cmasterBot', dir: '/repo/cmasterBot' }).id;
     });
 
     function makeService(createEngine: (engineKind: any, spec: any, logger: any) => IAgentEngine) {
         return new RequirementExecutionService({
-            projects, requirements, runs, worktree,
+            projects, requirements, runs, pendingQuestions, worktree,
             logger: { debug() {}, info() {}, warn() {}, error() {} },
             createEngine,
         });
@@ -393,7 +420,7 @@ describe('RequirementExecutionService', () => {
 
     describe('startAnalysis', () => {
         it('建 worktree、建 run，phase=analysis，成功结束后转 analyzed（不是 implemented）', async () => {
-            const service = makeService(() => engineYielding([{ type: 'answer', content: 'spec drafted', timestamp: new Date() }]));
+            const service = makeService(() => engineYielding([doneStep('spec drafted')]));
             const requirement = requirements.create({
                 projectId, reqKey: 'cmasterBot#a1', source: 'github', sourceKey: 'a1', title: 'Add feature',
             });
@@ -421,7 +448,7 @@ describe('RequirementExecutionService', () => {
         it('interrupt 步骤 → waiting_input，恢复后 → in_progress，最终 analyzed', async () => {
             const service = makeService(() => engineYielding([
                 { type: 'interrupt', interruptKind: 'question', interruptId: 'i1', content: 'q?', timestamp: new Date() },
-                { type: 'answer', content: 'spec drafted', timestamp: new Date() },
+                doneStep('spec drafted'),
             ]));
             const requirement = requirements.create({
                 projectId, reqKey: 'cmasterBot#a3', source: 'github', sourceKey: 'a3', title: 'Add feature',
@@ -441,7 +468,7 @@ describe('RequirementExecutionService', () => {
         });
 
         it('reanalyze=true 允许从 analyzed 重新发起，并把尚未 implemented 的卡片标记 cancelled（已实现卡片不受影响）', async () => {
-            const service = makeService(() => engineYielding([{ type: 'answer', content: 'redone', timestamp: new Date() }]));
+            const service = makeService(() => engineYielding([doneStep('redone')]));
             const requirement = requirements.create({
                 projectId, reqKey: 'cmasterBot#a5', source: 'github', sourceKey: 'a5', title: 'Add feature',
             });
@@ -501,7 +528,7 @@ describe('RequirementExecutionService', () => {
 
         it('按 card_no 顺序串行驱动全部卡片，全部完成后父需求转 implemented，共用同一 worktree', async () => {
             const { requirement, cards } = makeAnalyzedWithCards(2, 'i3');
-            const service = makeService(() => engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]));
+            const service = makeService(() => engineYielding([doneStep('done')]));
 
             await service.startImplementation(requirement.id);
             await new Promise(r => setTimeout(r, 0));
@@ -519,7 +546,7 @@ describe('RequirementExecutionService', () => {
             const service = makeService(() => {
                 call += 1;
                 if (call === 2) return engineThrowing('card 2 boom');
-                return engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]);
+                return engineYielding([doneStep('done')]);
             });
 
             await service.startImplementation(requirement.id);
@@ -537,7 +564,7 @@ describe('RequirementExecutionService', () => {
             const service = makeService(() => {
                 firstAttemptCall += 1;
                 if (firstAttemptCall === 2) return engineThrowing('card 2 boom');
-                return engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]);
+                return engineYielding([doneStep('done')]);
             });
             await service.startImplementation(requirement.id);
             await new Promise(r => setTimeout(r, 0));
@@ -545,7 +572,7 @@ describe('RequirementExecutionService', () => {
             expect(requirements.getById(requirement.id)!.status).toBe('failed');
 
             // 重试：第二次调用换一个总是成功的引擎
-            const retryService = makeService(() => engineYielding([{ type: 'answer', content: 'done on retry', timestamp: new Date() }]));
+            const retryService = makeService(() => engineYielding([doneStep('done on retry')]));
             await retryService.startImplementation(requirement.id);
             await new Promise(r => setTimeout(r, 0));
 
@@ -560,7 +587,7 @@ describe('RequirementExecutionService', () => {
             const service = makeService(() => {
                 call += 1;
                 if (call === 1) return engineThrowing('card 1 boom');
-                return engineYielding([{ type: 'answer', content: 'done', timestamp: new Date() }]);
+                return engineYielding([doneStep('done')]);
             });
             await service.startImplementation(requirement.id);
             await new Promise(r => setTimeout(r, 0));
@@ -606,6 +633,248 @@ describe('RequirementExecutionService', () => {
             const card = requirements.createCard({ parentId: requirement.id, projectId, reqKey: 'cmasterBot#sc3-1', source: 'manual', sourceKey: 'sc3-1', title: '卡1', cardNo: 1 });
             requirements.updateStatus(card.id, 'implemented');
             expect(() => service.skipCard(card.id)).toThrow(/already terminal/);
+        });
+    });
+
+    // ─────────────────────────── 标记块协议 + 待回答问题（spec #85, ticket #88）───────────────────────────
+
+    describe('标记块协议解析（analysis 阶段）', () => {
+        it('cmaster:done 携带 analysisSpec + cards：写入规格，按顺序建卡', async () => {
+            const service = makeService(() => engineYielding([
+                doneStep('分析完成', {
+                    analysisSpec: { goal: 'g', scope: 's', acceptance: 'a' },
+                    cards: [{ title: '卡片 A' }, { title: '卡片 B' }],
+                }),
+            ]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#m1', source: 'github', sourceKey: 'm1', title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'queued');
+
+            await service.startAnalysis(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            const updated = requirements.getById(requirement.id)!;
+            expect(updated.status).toBe('analyzed');
+            expect(updated.analysisSpec).toEqual({ goal: 'g', scope: 's', acceptance: 'a' });
+
+            const cards = requirements.listCardsByParent(requirement.id);
+            expect(cards.map(c => c.title)).toEqual(['卡片 A', '卡片 B']);
+            expect(cards.map(c => c.cardNo)).toEqual([1, 2]);
+            expect(cards.every(c => c.status === 'queued')).toBe(true);
+        });
+
+        it('cmaster:questions（非交互引擎的等价提问路径）：写入 pending_questions，需求转 waiting_input', async () => {
+            const service = makeService(() => engineYielding([questionsStep([{ id: 'q1', question: '用什么版式？' }])]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#m2', source: 'github', sourceKey: 'm2', title: 'Add feature',
+            });
+
+            await service.startAnalysis(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(requirement.id)!.status).toBe('waiting_input');
+            const pending = pendingQuestions.getLatestByRequirement(requirement.id);
+            expect(pending?.status).toBe('pending');
+            expect(pending?.questions).toEqual([{ id: 'q1', question: '用什么版式？' }]);
+        });
+
+        it('claude-code 原生 interrupt 也会双写 pending_questions（与标记块路径落同一张表）', async () => {
+            const service = makeService(() => ({
+                kind: 'claude-agent-sdk',
+                capabilities: { interactiveApproval: true, resume: false },
+                run: async function* (_input: string, context: any) {
+                    yield { type: 'interrupt', interruptKind: 'question', interruptId: 'i1', interruptReason: '用什么版式？', content: '用什么版式？', sessionId: context.sessionId, timestamp: new Date() };
+                    await waitForUserDecision(context.sessionId, {});
+                    yield doneStep('好的');
+                },
+            }));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#m3', source: 'github', sourceKey: 'm3', title: 'Add feature',
+            });
+
+            await service.startAnalysis(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(requirement.id)!.status).toBe('waiting_input');
+            const pending = pendingQuestions.getLatestByRequirement(requirement.id);
+            expect(pending?.status).toBe('pending');
+            expect(pending?.questions).toEqual([{ id: 'i1', question: '用什么版式？' }]);
+        });
+
+        it('协议违约（既无 questions 也无 done）：追加提示重试一轮，仍违约则标 failed', async () => {
+            const service = makeService(() => engineYielding([{ type: 'answer', content: '好的，我明白了', timestamp: new Date() }]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#m4', source: 'github', sourceKey: 'm4', title: 'Add feature',
+            });
+
+            await service.startAnalysis(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            const updated = requirements.getById(requirement.id)!;
+            expect(updated.status).toBe('failed');
+            const [latestRun] = runs.listByRequirement(requirement.id);
+            expect(latestRun.errorMessage).toContain('协议违约');
+        });
+
+        it('第一次违约、第二次带 done 标记块：重试后成功', async () => {
+            const attempts: string[] = [];
+            const retryingService = makeService(() => ({
+                kind: 'claude-agent-sdk',
+                capabilities: { interactiveApproval: true, resume: false },
+                run: async function* () {
+                    attempts.push('call');
+                    if (attempts.length === 1) {
+                        yield { type: 'answer', content: '第一次忘了标记块', timestamp: new Date() } as ExecutionStep;
+                    } else {
+                        yield doneStep('这次带上了');
+                    }
+                },
+            }));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#m5', source: 'github', sourceKey: 'm5', title: 'Add feature',
+            });
+
+            await retryingService.startAnalysis(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(attempts).toHaveLength(2);
+            expect(requirements.getById(requirement.id)!.status).toBe('analyzed');
+        });
+    });
+
+    describe('submitAnswers（统一回答分派，spec #85）', () => {
+        it('拒绝非 waiting_input 状态', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#sa1', source: 'github', sourceKey: 'sa1', title: 'Add feature',
+            });
+            await expect(service.submitAnswers(requirement.id, ['x'])).rejects.toThrow(/waiting for input/);
+        });
+
+        it('waiting_input 但没有 pending 问题集时拒绝', async () => {
+            const service = makeService(() => engineYielding([]));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#sa2', source: 'github', sourceKey: 'sa2', title: 'Add feature',
+            });
+            requirements.updateStatus(requirement.id, 'waiting_input');
+            await expect(service.submitAnswers(requirement.id, ['x'])).rejects.toThrow(/No pending question set/);
+        });
+
+        it('分派路径 A：claude-code 原生中断走 resolveInterrupt，run 在原地继续并完成', async () => {
+            const service = makeService(() => ({
+                kind: 'claude-agent-sdk',
+                capabilities: { interactiveApproval: true, resume: false },
+                run: async function* (_input: string, context: any) {
+                    yield { type: 'interrupt', interruptKind: 'question', interruptId: 'i1', interruptReason: '用什么版式？', content: '用什么版式？', sessionId: context.sessionId, timestamp: new Date() };
+                    const decision = await waitForUserDecision(context.sessionId, {});
+                    yield doneStep(`已收到：${decision.response}`);
+                },
+            }));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#sa3', source: 'github', sourceKey: 'sa3', title: 'Add feature',
+            });
+            await service.startAnalysis(requirement.id);
+            await new Promise(r => setTimeout(r, 0));
+            expect(requirements.getById(requirement.id)!.status).toBe('waiting_input');
+
+            await service.submitAnswers(requirement.id, ['A4 纵向']);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(requirement.id)!.status).toBe('analyzed');
+            const pending = pendingQuestions.getLatestByRequirement(requirement.id);
+            expect(pending?.status).toBe('answered');
+            expect(pending?.answers).toEqual(['A4 纵向']);
+        });
+
+        it('分派路径 B：非交互引擎走 resumeToken 续接（进程已退出，重新驱动一轮）', async () => {
+            let resumeCallArgs: any[] = [];
+            const service = makeService(() => ({
+                kind: 'codex',
+                capabilities: { interactiveApproval: false, resume: true },
+                run: async function* (_input: string, context: any) {
+                    resumeCallArgs.push({ input: _input, resumeToken: context.resumeToken });
+                    if (!context.resumeToken) {
+                        yield { type: 'meta', content: 'session recorded', resumeToken: 'codex-session-abc', timestamp: new Date() } as ExecutionStep;
+                        yield questionsStep([{ id: 'q1', question: '用什么版式？' }]);
+                    } else {
+                        yield doneStep('续接后完成');
+                    }
+                },
+            }));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#sa4', source: 'github', sourceKey: 'sa4', title: 'Add feature',
+            });
+            await service.startAnalysis(requirement.id, { engine: 'codex' });
+            await new Promise(r => setTimeout(r, 0));
+            expect(requirements.getById(requirement.id)!.status).toBe('waiting_input');
+            const [runBeforeResume] = runs.listByRequirement(requirement.id);
+            expect(runBeforeResume.resumeToken).toBe('codex-session-abc');
+
+            await service.submitAnswers(requirement.id, ['A4 纵向']);
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(resumeCallArgs[1].resumeToken).toBe('codex-session-abc');
+            expect(resumeCallArgs[1].input).toContain('A4 纵向');
+            expect(requirements.getById(requirement.id)!.status).toBe('analyzed');
+        });
+
+        it('无 resumeToken 时拒绝（引擎不支持续接或凭据缺失）', async () => {
+            const service = makeService(() => ({
+                kind: 'codex',
+                capabilities: { interactiveApproval: false, resume: true },
+                run: async function* () {
+                    yield questionsStep([{ id: 'q1', question: '？' }]);
+                },
+            }));
+            const requirement = requirements.create({
+                projectId, reqKey: 'cmasterBot#sa5', source: 'github', sourceKey: 'sa5', title: 'Add feature',
+            });
+            await service.startAnalysis(requirement.id, { engine: 'codex' });
+            await new Promise(r => setTimeout(r, 0));
+
+            await expect(service.submitAnswers(requirement.id, ['x'])).rejects.toThrow(/no resumable session/);
+        });
+
+        it('卡片续接：本卡完成后自动继续驱动父需求的下一张卡片', async () => {
+            const { requirement, cards } = (function makeAnalyzedWithCards() {
+                const req = requirements.create({
+                    projectId, reqKey: 'cmasterBot#sa6', source: 'github', sourceKey: 'sa6', title: 'Add feature',
+                });
+                requirements.updateStatus(req.id, 'analyzed');
+                const c1 = requirements.createCard({ parentId: req.id, projectId, reqKey: 'cmasterBot#sa6-1', source: 'manual', sourceKey: 'sa6-1', title: '卡1', cardNo: 1 });
+                const c2 = requirements.createCard({ parentId: req.id, projectId, reqKey: 'cmasterBot#sa6-2', source: 'manual', sourceKey: 'sa6-2', title: '卡2', cardNo: 2 });
+                return { requirement: req, cards: [c1, c2] };
+            })();
+
+            const service = makeService(() => ({
+                kind: 'codex',
+                capabilities: { interactiveApproval: false, resume: true },
+                run: async function* (input: string, context: any) {
+                    if (input.includes('卡1') && !context.resumeToken) {
+                        yield { type: 'meta', content: 'x', resumeToken: 'card1-session', timestamp: new Date() } as ExecutionStep;
+                        yield questionsStep([{ id: 'q1', question: '？' }]);
+                    } else {
+                        yield doneStep('完成');
+                    }
+                },
+            }));
+
+            await service.startImplementation(requirement.id, { engine: 'codex' });
+            await new Promise(r => setTimeout(r, 0));
+            expect(requirements.getById(cards[0].id)!.status).toBe('waiting_input');
+            expect(requirements.getById(requirement.id)!.status).toBe('waiting_input');
+
+            await service.submitAnswers(cards[0].id, ['答案']);
+            // 卡1续接 → 卡1完成 → 自动触发 startImplementation 继续驱动卡2，链路比单卡多几个
+            // microtask/macrotask，多让几拍
+            await new Promise(r => setTimeout(r, 0));
+            await new Promise(r => setTimeout(r, 0));
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(requirements.getById(cards[0].id)!.status).toBe('implemented');
+            expect(requirements.getById(cards[1].id)!.status).toBe('implemented'); // 自动继续驱动下一张
+            expect(requirements.getById(requirement.id)!.status).toBe('implemented');
         });
     });
 });


### PR DESCRIPTION
## Summary

⚠️ **Stacked PR**：base 是 [#95](https://github.com/yiyisf/masterBot/pull/95)（含 91+86+89 的改动），并额外 merge 了 [#93 三引擎 resume](https://github.com/yiyisf/masterBot/pull/93) 进来（本切片依赖 resumeToken 机制，但 #95 那条线未包含它）。合并顺序建议：92 → 94 → 93 → 95 → 本 PR，或等前几个都合并进 master 后 rebase。

- 新增 `marker-blocks.ts`：`cmaster:questions`/`cmaster:done` 标记块解析器，取回复中**最后一个标记块**（不区分类型，按文本位置判定谁更晚——agent 可能先问后又改口直接完成，反之亦然）。
- `executeAgentRun` 接入标记块协议（**仅 phase 已设置的两阶段运行生效，旧单阶段 `drive()` 完全不受影响**）：
  - `cmaster:done` 携带 `analysisSpec`/`cards` → 落库规格 + 按顺序建卡。
  - `cmaster:questions`（非交互引擎的等价"提问"路径）→ 落 `pending_questions`，转 `waiting_input`。
  - claude-code 原生 `interrupt` 步骤同样双写 `pending_questions`（与标记块路径落同一张表，页面渲染不区分来源）。
  - 协议违约（两者皆无）→ 附加提示重试一轮，仍违约则整体 `failed`。
- 新增 `submitAnswers()`：统一回答入口，双路分派——claude-code 走 `resolveInterrupt`；非交互引擎取 `resume_token` 续接（卡片续接完成后自动继续驱动父需求后续卡片，绕开 `startImplementation` 的公开状态门禁，因为这是同一次实现流程的延续而非重新发起）。
- 新增路由 `POST /api/requirements/:id/answers`。

为 spec [#85](https://github.com/yiyisf/masterBot/issues/85) 纵向切片 4/6，对应实施 ticket [#88](https://github.com/yiyisf/masterBot/issues/88)。解锁「/projects 双栏详情面板与看板」（[#90](https://github.com/yiyisf/masterBot/issues/90)）。

## Test plan
- [x] `npx vitest run` — 483 tests passed（新增：标记块解析器 16 例、标记块协议集成 5 例、submitAnswers 双路分派 6 例）
- [x] `npx tsc --noEmit`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)